### PR TITLE
Fixed NetworkDispatcher for IOS build

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Network/NetworkClient.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Network/NetworkClient.kt
@@ -17,8 +17,6 @@ import kotlinx.serialization.json.Json
  * Implement this intterface to define specific implementation for Network Calls - to be made by SDK
  */
 interface NetworkDispatcher {
-    val JSONParser : Json
-        get() = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }
     @DelicateCoroutinesApi
     fun consumeGETRequest(request: String, onSuccess: (String) -> Unit, onError: (Throwable) -> Unit)
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -5,11 +5,15 @@ import com.sdk.growthbook.Network.CoreNetworkClient
 import com.sdk.growthbook.Network.NetworkDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 /**
  * DataSource for Feature API
  */
 internal class FeaturesDataSource(val dispatcher: NetworkDispatcher = CoreNetworkClient()) {
+
+    private val JSONParser: Json
+        get() = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }
 
   private val apiUrl =
 	FeatureURLBuilder().buildUrl(GrowthBookSDK.gbContext.hostURL, GrowthBookSDK.gbContext.apiKey)
@@ -23,7 +27,7 @@ internal class FeaturesDataSource(val dispatcher: NetworkDispatcher = CoreNetwor
   ) {
 	dispatcher.consumeGETRequest(apiUrl,
 	  onSuccess = { rawContent ->
-		val result: FeaturesDataModel = dispatcher.JSONParser.decodeFromString(rawContent)
+		val result: FeaturesDataModel = JSONParser.decodeFromString(rawContent)
 		result.also(success)
 	  },
 	  onError = { apiTimeError ->


### PR DESCRIPTION
The NetworkDispatcher protocol contained a `JSONParser` field that cannot be initialized on iOS because the JsonConfiguration() class is translated to Swift as the Kotlinx_serialization_jsonJsonConfiguration class in which the constructors are explicitly removed.

Fixs
- Move `JSONParser` to FeaturesDataSource as a private field.