### PR TITLE
feat: Add error reporting for fetch features failure

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -219,14 +219,13 @@ class GrowthBookSDK() : FeaturesFlowDelegate {
     override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
         gbContext.features = features
         if (isRemote) {
-            this.refreshHandler?.let { it(true) }
+            this.refreshHandler?.invoke(true, null)
         }
     }
 
     override fun featuresFetchFailed(error: GBError, isRemote: Boolean) {
-
         if (isRemote) {
-            this.refreshHandler?.let { it(false) }
+            this.refreshHandler?.invoke(false, error)
         }
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Constants.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Constants.kt
@@ -36,7 +36,7 @@ typealias GBCondition = JsonElement
  * Handler for Refresh Cache Request
  * It updates back whether cache was refreshed or not
  */
-typealias GBCacheRefreshHandler = (Boolean) -> Unit
+typealias GBCacheRefreshHandler = (Boolean, GBError?) -> Unit
 
 /**
  * Triple Tuple for GrowthBook Namespaces


### PR DESCRIPTION
Refer https://github.com/growthbook/growthbook-kotlin/issues/29

When we were using this SDK, it failed to parse JSON in release build type, even while using the proguard rules described in the readme file, this made debugging this on prod a nightmare we couldn't even send any logs, we essentially had to debug the SDK with minifyEnabled and go through Kotlin Serializer reflection code to figure out that proguard was removing the `serializer` function generated by `@Serializable` annotation from kotlin serializer