### PR TITLE
Remove catch-all proguard keep rule

### DIFF
--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.1.28"
+version = "1.1.29"
 
 kotlin {
 

--- a/GrowthBook/consumer-rules.pro
+++ b/GrowthBook/consumer-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class com.sdk.growthbook.**, ** { *; }
+-keep class com.sdk.growthbook.**

--- a/GrowthBook/consumer-rules.pro
+++ b/GrowthBook/consumer-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class com.sdk.growthbook.**
+-keep class com.sdk.growthbook.** { *; }

--- a/GrowthBook/proguard-rules.pro
+++ b/GrowthBook/proguard-rules.pro
@@ -1,6 +1,6 @@
 
 # Core SDK
--keep class com.sdk.growthbook.**, ** { *; }
+-keep class com.sdk.growthbook.**
 
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.SerializationKt

--- a/GrowthBook/proguard-rules.pro
+++ b/GrowthBook/proguard-rules.pro
@@ -1,6 +1,6 @@
 
 # Core SDK
--keep class com.sdk.growthbook.**
+-keep class com.sdk.growthbook.** { *; }
 
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.SerializationKt


### PR DESCRIPTION
Minimal change to fix the issue of an overly broad consumer proguard rule, which was effectively disabling obfuscation and code shrinking for consumer apps. At present this still keeps everything within the SDK, so it may be worth taking a further look at these rules to allow R8 to shrink things even further.

I've also bumped the library version in this PR, as that seems to be the workflow in this repo - feel free to remove that if not needed!

Fixes #47 