### PR TITLE
Remove the reflective lookup of json serializers.

### DIFF
--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -1,8 +1,6 @@
 package com.sdk.growthbook.sandbox
 
 import android.content.Context
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import java.io.File
@@ -12,7 +10,7 @@ import java.io.FileInputStream
  * Actual Implementation for Caching in Android - As expected in KMM
  */
 actual internal object CachingImpl {
-    actual fun getLayer() : CachingLayer {
+    actual fun getLayer(): CachingLayer {
         return CachingAndroid()
     }
 }
@@ -22,8 +20,8 @@ actual internal object CachingImpl {
  */
 internal class CachingAndroid : CachingLayer {
 
-    companion object{
-        var context : Context? = null
+    companion object {
+        var context: Context? = null
     }
 
     /**
@@ -34,7 +32,7 @@ internal class CachingAndroid : CachingLayer {
     /**
      * Save Content in Android App Specific Internal Memory
      */
-    override fun saveContent(fileName: String, content: JsonElement){
+    override fun saveContent(fileName: String, content: JsonElement) {
         val file = getTargetFile(fileName)
 
         if (file != null) {
@@ -46,19 +44,17 @@ internal class CachingAndroid : CachingLayer {
             // Create New File
             file.createNewFile()
 
-            val jsonContents = json.encodeToString(content)
+            val jsonContents = json.encodeToString(JsonElement.serializer(), content)
 
             // Save contents in file
             file.appendText(jsonContents)
         }
-
-
     }
 
     /**
      * Retrieve Content from Android App Specific Internal Memory
      */
-    override fun getContent(fileName: String) : JsonElement?{
+    override fun getContent(fileName: String): JsonElement? {
 
         val file = getTargetFile(fileName)
 
@@ -66,18 +62,17 @@ internal class CachingAndroid : CachingLayer {
             // Read File Contents
             val inputAsString = FileInputStream(file).bufferedReader().use { it.readText() }
             // return File Contents
-            return json.decodeFromString(inputAsString)
+            return json.decodeFromString(JsonElement.serializer(), inputAsString)
         }
 
         // Return null if file doesn't exist
         return null
-
     }
 
     /**
      * Get Target File - with complete path in internal memory
      */
-    fun getTargetFile(fileName: String) : File? {
+    fun getTargetFile(fileName: String): File? {
         if (context != null) {
             val path = context!!.getFilesDir()
             // Create Directory in Internal Memory
@@ -88,7 +83,6 @@ internal class CachingAndroid : CachingLayer {
                 targetFileName = fileName.removeSuffix(".txt")
             }
             return File(letDirectory, targetFileName + ".txt")
-        }
-        else return null
+        } else return null
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Constants.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Constants.kt
@@ -25,7 +25,7 @@ internal class Constants {
 /**
  * Type Alias for Feature in GrowthBook
  */
-internal typealias GBFeatures = HashMap<String, GBFeature>
+internal typealias GBFeatures = Map<String, GBFeature>
 
 /**
  * Type Alias for Condition Element in GrowthBook Rules

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Crypto.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Crypto.kt
@@ -1,9 +1,11 @@
 package com.sdk.growthbook.Utils
 
+import com.sdk.growthbook.model.GBFeature
 import com.soywiz.krypto.AES
 import com.soywiz.krypto.Padding
 import com.soywiz.krypto.encoding.Base64
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 
 interface Crypto {
@@ -42,8 +44,10 @@ fun encryptToFeaturesDataModel(string: String): GBFeatures? {
     val JSONParser = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }
 
     return try {
-
-        val result: GBFeatures = JSONParser.decodeFromString(string)
+        val result: GBFeatures = JSONParser.decodeFromString(
+            deserializer = MapSerializer(String.serializer(), GBFeature.serializer()),
+            string = string
+        )
         result
     } catch (e: Exception) {
         null

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
@@ -2,13 +2,13 @@ package com.sdk.growthbook.evaluators
 
 import com.sdk.growthbook.Utils.GBCondition
 import com.sdk.growthbook.Utils.GBUtils
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -267,12 +267,16 @@ internal class GBConditionEvaluator {
         if (conditionValue is JsonArray) {
             return if (attributeValue is JsonArray) {
                 if (conditionValue.size == attributeValue.size) {
-                    val conditionArray =
-                        Json.decodeFromJsonElement<Array<JsonElement>>(conditionValue)
-                    val attributeArray =
-                        Json.decodeFromJsonElement<Array<JsonElement>>(attributeValue)
+                    val conditionArray = Json.decodeFromJsonElement(
+                        ListSerializer(JsonElement.serializer()),
+                        conditionValue
+                    )
+                    val attributeArray = Json.decodeFromJsonElement(
+                        ListSerializer(JsonElement.serializer()),
+                        attributeValue
+                    )
 
-                    conditionArray.contentDeepEquals(attributeArray)
+                    conditionArray == attributeArray
                 } else {
                     false
                 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -4,7 +4,6 @@ import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.Network.CoreNetworkClient
 import com.sdk.growthbook.Network.NetworkDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
@@ -30,7 +29,10 @@ internal class FeaturesDataSource(private val dispatcher: NetworkDispatcher = Co
     ) {
         dispatcher.consumeGETRequest(apiUrl,
             onSuccess = { rawContent ->
-                val result: FeaturesDataModel = JSONParser.decodeFromString(rawContent)
+                val result = JSONParser.decodeFromString(
+                    deserializer = FeaturesDataModel.serializer(),
+                    string = rawContent
+                )
                 result.also(success)
             },
             onError = { apiTimeError ->

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -1,17 +1,14 @@
 package com.sdk.growthbook.features
 
 import com.sdk.growthbook.Utils.Constants
-import com.sdk.growthbook.Utils.Crypto
 import com.sdk.growthbook.Utils.DefaultCrypto
 import com.sdk.growthbook.Utils.GBError
 import com.sdk.growthbook.Utils.GBFeatures
 import com.sdk.growthbook.Utils.getFeaturesFromEncryptedFeatures
-import com.sdk.growthbook.model.GBFeature
 import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.sandbox.getData
 import com.sdk.growthbook.sandbox.putData
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.serialization.json.Json
 
 /**
  * Interface for Feature API Completion Events
@@ -70,13 +67,17 @@ internal class FeaturesViewModel(
      * Cache API Response and push success event
      */
     private fun prepareFeaturesData(dataModel: FeaturesDataModel) {
-        manager.getLayer().putData(Constants.featureCache, dataModel)
+        manager.getLayer().putData(
+            fileName = Constants.featureCache,
+            content = dataModel,
+            serializer = FeaturesDataModel.serializer()
+        )
         // Call Success Delegate with mention of data available with remote
         var features = dataModel.features
         val encryptedFeatures = dataModel.encryptedFeatures
         val crypto = DefaultCrypto()
         try {
-            if (features != null && features.isNotEmpty()) {
+            if (!features.isNullOrEmpty()) {
                 this.delegate.featuresFetchedSuccessfully(features = features, isRemote = true)
             } else if (encryptionKey != null && encryptedFeatures != null) {
                 features =

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -40,7 +40,10 @@ internal class FeaturesViewModel(
 
         try {
             // Check for cache data
-            val dataModel = manager.getLayer().getData<FeaturesDataModel>(Constants.featureCache)
+            val dataModel = manager.getLayer().getData(
+                Constants.featureCache,
+                FeaturesDataModel.serializer()
+            )
 
             if (dataModel != null) {
                 // Call Success Delegate with mention of data available but its not remote

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -1,10 +1,10 @@
 package com.sdk.growthbook.sandbox
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
 
 /**
  * Interface for Caching Layer
@@ -29,8 +29,12 @@ internal inline fun <reified T> CachingLayer.getData(fileName: String): @Seriali
 /**
  * Default Implementation for Caching Layer Interface methods
  */
-internal inline fun <reified T> CachingLayer.putData(fileName: String, content: @Serializable T) {
-    val jsonContent = Json.encodeToJsonElement(content)
+internal fun <T> CachingLayer.putData(
+    fileName: String,
+    content: T,
+    serializer: KSerializer<T>
+) {
+    val jsonContent = Json.encodeToJsonElement(serializer, content)
     saveContent(fileName, jsonContent)
 }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -1,10 +1,8 @@
 package com.sdk.growthbook.sandbox
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
 
 /**
  * Interface for Caching Layer
@@ -21,9 +19,10 @@ internal interface CachingLayer {
 /**
  * Default Implementation for Caching Layer Interface methods
  */
-internal inline fun <reified T> CachingLayer.getData(fileName: String): @Serializable T? {
+internal fun <T> CachingLayer.getData(fileName: String, serializer: KSerializer<T>): T? {
     val content = getContent(fileName)
-    return content?.let { Json.decodeFromJsonElement<T>(it) }
+        ?: return null
+    return Json.decodeFromJsonElement(serializer, content)
 }
 
 /**

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBConditionTests.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBConditionTests.kt
@@ -1,10 +1,11 @@
 package com.sdk.growthbook.tests
 
+import com.sdk.growthbook.Utils.GBCondition
 import com.sdk.growthbook.evaluators.GBAttributeType
 import com.sdk.growthbook.evaluators.GBConditionEvaluator
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.intellij.lang.annotations.Language
@@ -21,8 +22,8 @@ class GBConditionTests {
 
     @Test
     fun testConditions() {
-        var failedScenarios: ArrayList<String> = ArrayList()
-        var passedScenarios: ArrayList<String> = ArrayList()
+        val failedScenarios: ArrayList<String> = ArrayList()
+        val passedScenarios: ArrayList<String> = ArrayList()
         for (item in evalConditions) {
             if (item is JsonArray) {
                 val evaluator = GBConditionEvaluator()
@@ -92,8 +93,8 @@ class GBConditionTests {
 
         assertEquals(
             false, GBConditionEvaluator().evalCondition(
-                Json.decodeFromString(attributes),
-                Json.decodeFromString(condition),
+                Json.decodeFromString(JsonElement.serializer(), attributes),
+                Json.decodeFromString(GBCondition.serializer(), condition),
             )
         )
     }
@@ -116,8 +117,8 @@ class GBConditionTests {
 
         assertEquals(
             false, GBConditionEvaluator().evalCondition(
-                Json.decodeFromString(attributes),
-                Json.decodeFromString(condition),
+                Json.decodeFromString(JsonElement.serializer(), attributes),
+                Json.decodeFromString(GBCondition.serializer(), condition),
             )
         )
     }
@@ -140,8 +141,8 @@ class GBConditionTests {
 
         assertEquals(
             true, GBConditionEvaluator().evalCondition(
-                Json.decodeFromString(attributes),
-                Json.decodeFromString(condition),
+                Json.decodeFromString(JsonElement.serializer(), attributes),
+                Json.decodeFromString(GBCondition.serializer(), condition),
             )
         )
     }
@@ -164,8 +165,8 @@ class GBConditionTests {
 
         assertEquals(
             false, GBConditionEvaluator().evalCondition(
-                Json.decodeFromString(attributes),
-                Json.decodeFromString(condition),
+                Json.decodeFromString(JsonElement.serializer(), attributes),
+                Json.decodeFromString(GBCondition.serializer(), condition),
             )
         )
     }

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
@@ -5,7 +5,6 @@ import com.sdk.growthbook.evaluators.GBExperimentEvaluator
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBExperiment
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -22,19 +21,26 @@ class GBExperimentRunTests {
 
     @Test
     fun testExperiments() {
-        var failedScenarios: ArrayList<String> = ArrayList()
-        var passedScenarios: ArrayList<String> = ArrayList()
+        val failedScenarios: ArrayList<String> = ArrayList()
+        val passedScenarios: ArrayList<String> = ArrayList()
         for (item in evalConditions) {
             if (item is JsonArray) {
 
                 val testContext =
-                    GBTestHelper.jsonParser.decodeFromJsonElement<GBContextTest>(item[1])
+                    GBTestHelper.jsonParser.decodeFromJsonElement(
+                        GBContextTest.serializer(),
+                        item[1]
+                    )
                 val experiment =
-                    GBTestHelper.jsonParser.decodeFromJsonElement<GBExperiment>(item[2])
+                    GBTestHelper.jsonParser.decodeFromJsonElement(
+                        GBExperiment.serializer(),
+                        item[2]
+                    )
 
                 val attributes = testContext.attributes.jsonObject.toHashMap()
 
-                val gbContext = GBContext("",
+                val gbContext = GBContext(
+                    apiKey = "",
                     hostURL = "",
                     enabled = testContext.enabled,
                     attributes = attributes,
@@ -42,7 +48,8 @@ class GBExperimentRunTests {
                     qaMode = testContext.qaMode,
                     trackingCallback = { _, _ ->
 
-                    }, encryptionKey = "")
+                    }, encryptionKey = ""
+                )
 
                 val evaluator = GBExperimentEvaluator()
                 val result = evaluator.evaluateExperiment(gbContext, experiment)

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBFeatureValueTests.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBFeatureValueTests.kt
@@ -4,7 +4,6 @@ import com.sdk.growthbook.Utils.toHashMap
 import com.sdk.growthbook.evaluators.GBFeatureEvaluator
 import com.sdk.growthbook.model.GBContext
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.BeforeTest
@@ -22,21 +21,26 @@ class GBFeatureValueTests {
 
     @Test
     fun testFeatures() {
-        var failedScenarios: ArrayList<String> = ArrayList()
-        var passedScenarios: ArrayList<String> = ArrayList()
+        val failedScenarios: ArrayList<String> = ArrayList()
+        val passedScenarios: ArrayList<String> = ArrayList()
         for (item in evalConditions) {
             if (item is JsonArray) {
 
                 val testData =
-                    GBTestHelper.jsonParser.decodeFromJsonElement<GBFeaturesTest>(item[1])
+                    GBTestHelper.jsonParser.decodeFromJsonElement(
+                        GBFeaturesTest.serializer(),
+                        item[1]
+                    )
 
                 val attributes = testData.attributes.jsonObject.toHashMap()
 
-                val gbContext = GBContext("", hostURL = "",
+                val gbContext = GBContext(
+                    apiKey = "", hostURL = "",
                     enabled = true, attributes = attributes, forcedVariations = HashMap(),
                     qaMode = false, trackingCallback = { _, _ ->
 
-                    }, encryptionKey = "")
+                    }, encryptionKey = ""
+                )
                 if (testData.features != null) {
                     gbContext.features = testData.features
                 }
@@ -45,7 +49,10 @@ class GBFeatureValueTests {
                 val result = evaluator.evaluateFeature(gbContext, item[2].jsonPrimitive.content)
 
                 val expectedResult =
-                    GBTestHelper.jsonParser.decodeFromJsonElement<GBFeatureResultTest>(item[3])
+                    GBTestHelper.jsonParser.decodeFromJsonElement(
+                        GBFeatureResultTest.serializer(),
+                        item[3]
+                    )
 
                 val status = item[0].toString() +
                     "\nExpected Result - " +

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBTestHelper.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBTestHelper.kt
@@ -3,7 +3,6 @@ package com.sdk.growthbook.tests
 import com.sdk.growthbook.Utils.GBFeatures
 import com.sdk.growthbook.model.GBExperiment
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -16,7 +15,7 @@ class GBTestHelper {
     companion object {
 
         val jsonParser = Json { ignoreUnknownKeys = true }
-        val testData = jsonParser.decodeFromString<JsonElement>(gbTestCases)
+        val testData = jsonParser.decodeFromString(JsonElement.serializer(), gbTestCases)
 
         fun getEvalConditionData(): JsonArray {
             val array = testData.jsonObject.get("evalCondition") as JsonArray


### PR DESCRIPTION
- Libraries should enforce minimal proguard rules
- This PR transitions the reflection lookup of serializers to explicit serializers
- Added bonus: Increased performance due to no need for reflective class lookups