### PR TITLE
"is in the list" condition always evaluates to "false" for numerical attributes

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Extensions.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Utils/Extensions.kt
@@ -61,10 +61,12 @@ internal fun Map<*, *>.toJsonElement(): JsonElement {
     this.forEach {
         val key = it.key as? String ?: return@forEach
         val value = it.value ?: return@forEach
-        when (value) {
-            is Map<*, *> -> map[key] = (value).toJsonElement()
-            is List<*> -> map[key] = value.toJsonElement()
-            else -> map[key] = JsonPrimitive(value.toString())
+        map[key] = when (value) {
+            is Map<*, *> -> (value).toJsonElement()
+            is List<*> -> value.toJsonElement()
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
         }
     }
     return JsonObject(map)

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
@@ -1,0 +1,19 @@
+package com.sdk.growthbook.integration
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.GrowthBookSDK
+import com.sdk.growthbook.tests.MockNetworkClient
+
+internal fun buildSDK(json: String, attributes: Map<String, Any> = mapOf()): GrowthBookSDK {
+    return GBSDKBuilder(
+        "some_key",
+        "http://host.com",
+        attributes = attributes,
+        encryptionKey = "",
+        trackingCallback = { _, _ -> }).setNetworkDispatcher(
+        MockNetworkClient(
+            json,
+            null
+        )
+    ).initialize()
+}

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTests.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTests.kt
@@ -1,0 +1,44 @@
+package com.sdk.growthbook.integration
+
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class IntegrationTests {
+
+    @Test
+    fun verifyIsInTheListRule() {
+        // User attributes for targeting and assigning users to experiment variations
+        val attrs = HashMap<String, Any>()
+        attrs["appBuildNumber"] = 3432
+
+        @Language("json")
+        val json = """
+{
+  "status": 200,
+  "features": {
+    "user576-feature": {
+      "defaultValue": false,
+      "rules": [
+        {
+          "condition": {
+            "appBuildNumber": {
+              "${'$'}in": [
+                3432,
+                3431
+              ]
+            }
+          },
+          "force": true
+        }
+      ]
+    }
+  }
+}
+        """.trimMargin()
+
+        val sdkInstance = buildSDK(json, attrs)
+
+        assertEquals(true, sdkInstance.feature("user576-feature").value)
+    }
+}

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -1,8 +1,5 @@
 package com.sdk.growthbook.integration
 
-import com.sdk.growthbook.GBSDKBuilder
-import com.sdk.growthbook.GrowthBookSDK
-import com.sdk.growthbook.tests.MockNetworkClient
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -80,20 +77,6 @@ internal class VerifySDKReturnFeatureValues {
         val sdkInstance = buildSDK(json, attributes)
 
         assertEquals("Default value for brand:KZ", sdkInstance.feature("string_feature").value)
-    }
-
-    private fun buildSDK(json: String, attributes: Map<String, Any> = mapOf()): GrowthBookSDK {
-        return GBSDKBuilder(
-            "some_key",
-            "http://host.com",
-            attributes = attributes,
-            encryptionKey = "",
-            trackingCallback = { _, _ -> }).setNetworkDispatcher(
-            MockNetworkClient(
-                json,
-                null
-            )
-        ).initialize()
     }
 
     @Test


### PR DESCRIPTION
This is the fix for a bug mentioned [here](https://github.com/growthbook/growthbook-kotlin/issues/65)