### PR TITLE
rm compulsory ktor usage, enable shrinking of ktor in case not used

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Network/NetworkClient.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/Network/NetworkClient.kt
@@ -36,12 +36,6 @@ interface NetworkDispatcher {
     fun consumeSSEConnection(
         url: String
     ): Flow<Resource<String>>
-
-    suspend fun prepareGetRequest(
-        url: String,
-        headers: Map<String, String> = emptyMap(),
-        queryParams: Map<String, String> = emptyMap()
-    ): HttpStatement
 }
 
 /**
@@ -78,10 +72,10 @@ internal class CoreNetworkClient : NetworkDispatcher {
         }
     }
 
-    override suspend fun prepareGetRequest(
+    private suspend fun prepareGetRequest(
         url: String,
-        headers: Map<String, String>,
-        queryParams: Map<String, String>
+        headers: Map<String, String> = emptyMap(),
+        queryParams: Map<String, String> = emptyMap(),
     ): HttpStatement =
         client.prepareGet(url) {
             headers {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -1,7 +1,6 @@
 package com.sdk.growthbook.features
 
 import com.sdk.growthbook.GrowthBookSDK
-import com.sdk.growthbook.Network.CoreNetworkClient
 import com.sdk.growthbook.Network.NetworkDispatcher
 import com.sdk.growthbook.Utils.FeatureRefreshStrategy
 import com.sdk.growthbook.Utils.GBFeatures
@@ -15,7 +14,7 @@ import kotlinx.serialization.json.Json
 /**
  * DataSource for Feature API
  */
-internal class FeaturesDataSource(private val dispatcher: NetworkDispatcher = CoreNetworkClient()) {
+internal class FeaturesDataSource(private val dispatcher: NetworkDispatcher) {
 
     private val JSONParser: Json
         get() = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -25,7 +25,7 @@ internal interface FeaturesFlowDelegate {
  */
 internal class FeaturesViewModel(
     private val delegate: FeaturesFlowDelegate,
-    private val dataSource: FeaturesDataSource = FeaturesDataSource(),
+    private val dataSource: FeaturesDataSource,
     var encryptionKey: String?
 ) {
 

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
@@ -10,8 +10,8 @@ internal fun buildSDK(json: String, attributes: Map<String, Any> = mapOf()): Gro
         "http://host.com",
         attributes = attributes,
         encryptionKey = "",
-        trackingCallback = { _, _ -> }).setNetworkDispatcher(
-        MockNetworkClient(
+        trackingCallback = { _, _ -> },
+        networkDispatcher = MockNetworkClient(
             json,
             null
         )

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBEncryptedFeatures.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GBEncryptedFeatures.kt
@@ -60,7 +60,9 @@ class GBEncryptedFeatures {
             encryptionKey = "",
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).initialize()
+            },
+            networkDispatcher = MockNetworkClient(null, null),
+            ).initialize()
 
         val keyString = "Ns04T5n9+59rl2x3SlNHtQ=="
         val encryptedFeatures =

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -1,7 +1,6 @@
 package com.sdk.growthbook.tests
 
 import com.sdk.growthbook.GBSDKBuilder
-import com.sdk.growthbook.GBSDKBuilderJAVA
 import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.Utils.GBCacheRefreshHandler
 import com.sdk.growthbook.Utils.GBError
@@ -32,11 +31,13 @@ class GrowthBookSDKBuilderTests {
         val sdkInstance = GBSDKBuilder(
             testApiKey,
             testHostURL,
-            attributes = testAttributes,
+            testAttributes,
             encryptionKey = null,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).initialize()
+            },
+            networkDispatcher = MockNetworkClient(null, null),
+        ).initialize()
 
         assertEquals(sdkInstance.getGBContext().apiKey, testApiKey)
         assertTrue(sdkInstance.getGBContext().enabled)
@@ -57,7 +58,9 @@ class GrowthBookSDKBuilderTests {
             encryptionKey = null,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).setRefreshHandler { isRefreshed, gbError ->
+            },
+            networkDispatcher = MockNetworkClient(null, null),
+            ).setRefreshHandler { isRefreshed, gbError ->
         }.setEnabled(false).setForcedVariations(variations).setQAMode(true).initialize()
 
         assertTrue(sdkInstance.getGBContext().apiKey == testApiKey)
@@ -80,10 +83,11 @@ class GrowthBookSDKBuilderTests {
             encryptionKey = null,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).setRefreshHandler { isRefreshed, gbError ->
+            },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+            ).setRefreshHandler { isRefreshed, gbError ->
 
         }
-            .setNetworkDispatcher(MockNetworkClient(MockResponse.successResponse, null))
             .setEnabled(false).setForcedVariations(variations).setQAMode(true).initialize()
 
         assertTrue(sdkInstance.getGBContext().apiKey == testApiKey)
@@ -105,9 +109,11 @@ class GrowthBookSDKBuilderTests {
             encryptionKey = null,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).setRefreshHandler { _, gbError ->
+            },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+            ).setRefreshHandler { _, gbError ->
             isRefreshed = true
-        }.setNetworkDispatcher(MockNetworkClient(MockResponse.successResponse, null)).initialize()
+        }.initialize()
 
         assertTrue(isRefreshed)
 
@@ -132,9 +138,11 @@ class GrowthBookSDKBuilderTests {
             attributes = testAttributes,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).setRefreshHandler { _, gbError ->
+            },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+            ).setRefreshHandler { _, gbError ->
             isRefreshed = true
-        }.setNetworkDispatcher(MockNetworkClient(MockResponse.successResponse, null)).initialize()
+        }.initialize()
 
         assertTrue(isRefreshed)
 
@@ -152,8 +160,10 @@ class GrowthBookSDKBuilderTests {
             encryptionKey = null,
             trackingCallback = { gbExperiment: GBExperiment, gbExperimentResult: GBExperimentResult ->
 
-            }).setRefreshHandler { isRefreshed, gbError ->
-        }.setNetworkDispatcher(MockNetworkClient(MockResponse.successResponse, null)).initialize()
+            },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+            ).setRefreshHandler { isRefreshed, gbError ->
+        }.initialize()
 
         val featureValue = sdkInstance.feature("fwrfewrfe")
         assertEquals(featureValue.source, GBFeatureSource.unknownFeature)
@@ -172,11 +182,8 @@ class GrowthBookSDKBuilderTests {
             "http://host.com",
             attributes = attributes,
             encryptionKey = encryptionKey,
-            trackingCallback = { _, _ -> }).setNetworkDispatcher(
-            MockNetworkClient(
-                json,
-                null
-            )
+            trackingCallback = { _, _ -> },
+            networkDispatcher = MockNetworkClient(json, null),
         ).initialize()
     }
 

--- a/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
+++ b/GrowthBook/src/commonTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
@@ -2,7 +2,6 @@ package com.sdk.growthbook.tests
 
 import com.sdk.growthbook.Network.NetworkDispatcher
 import com.sdk.growthbook.Utils.Resource
-import io.ktor.client.statement.HttpStatement
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 
@@ -27,14 +26,6 @@ class MockNetworkClient(val succesResponse: String?, val error: Throwable?) : Ne
     }
 
     override fun consumeSSEConnection(url: String): Flow<Resource<String>> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun prepareGetRequest(
-        url: String,
-        headers: Map<String, String>,
-        queryParams: Map<String, String>
-    ): HttpStatement {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
Current code keeps the dependency on Ktor, even when it's not used in the rest of the project and when custom `NetworkDispatcher` is in place, which prevents shrinking.
This PR is created to remove such dependency.