### PR TITLE
Partially return back to 1.1.62 API

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonElement
 
-typealias GBTrackingCallback = (GBExperiment, GBExperimentResult?) -> Unit
+typealias GBTrackingCallback = (GBExperiment, GBExperimentResult) -> Unit
 typealias GBFeatureUsageCallback = (featureKey: String, gbFeatureResult: GBFeatureResult) -> Unit
 
 /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
@@ -232,7 +232,9 @@ internal class GBFeatureEvaluator {
                                         result = track.result.experimentResult
                                     )
                                 ) {
-                                    context.trackingCallback(track.experiment, track.result.experimentResult)
+                                    track.result.experimentResult?.let {
+                                        context.trackingCallback(track.experiment, it)
+                                    }
                                 }
                             }
                         }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
@@ -88,22 +88,12 @@ class GBError(error: Throwable?) {
     /**
      * Error Message for the caught error / exception
      */
-    private lateinit var errorMessage: String
+    val errorMessage: String = error?.message ?: ""
 
     /**
      * Error Stacktrace for the caught error / exception
      */
-    private lateinit var stackTrace: String
-
-    /**
-     * Constructor for initializing
-     */
-    init {
-        if (error != null) {
-            errorMessage = error.message ?: ""
-            stackTrace = error.stackTraceToString()
-        }
-    }
+    val stackTrace: String? = error?.stackTraceToString()
 }
 
 /**
@@ -319,7 +309,7 @@ object RangeSerializer {
  * Wrapper for deserialized model with optional field
  */
 sealed class OptionalProperty<out T> {
-    object NotPresent : OptionalProperty<Nothing>()
+    data object NotPresent : OptionalProperty<Nothing>()
     data class Present<T>(val value: T) : OptionalProperty<T>()
 }
 


### PR DESCRIPTION
Fields of GBError were set private again. Nullability of second parameter of GBTrackingCallback was taken away