### PR TITLE
Bump NetworkDispatcherKtor library version

### DIFF
--- a/NetworkDispatcherKtor/build.gradle.kts
+++ b/NetworkDispatcherKtor/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.4"
+version = "1.0.5"
 
 kotlin {
     androidTarget {


### PR DESCRIPTION
A new version of the library needs to be released to incorporate the recent dependency updates + Kotlin/Wasm support.