### PR TITLE
GrowthBookSDK: Move `gbContext` out of companion object

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -1,6 +1,6 @@
 package com.sdk.growthbook.features
 
-import com.sdk.growthbook.GrowthBookSDK
+import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.network.NetworkDispatcher
 import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.Json
  */
 internal class FeaturesDataSource(
     private val dispatcher: NetworkDispatcher,
-    private val enableLogging: Boolean = true,
+    private val gbContext: GBContext,
 ) {
 
     private val jsonParser: Json
@@ -30,8 +30,8 @@ internal class FeaturesDataSource(
         featureRefreshStrategy: FeatureRefreshStrategy =
             FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
     ) = FeatureURLBuilder().buildUrl(
-        GrowthBookSDK.gbContext.hostURL,
-        GrowthBookSDK.gbContext.apiKey,
+        gbContext.hostURL,
+        gbContext.apiKey,
         featureRefreshStrategy
     )
 
@@ -96,7 +96,7 @@ internal class FeaturesDataSource(
             payload["forcedVariations"] = params.forcedVariations
         }
 
-        if (enableLogging) {
+        if (gbContext.enableLogging) {
             println(payload)
         }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -1,6 +1,5 @@
 package com.sdk.growthbook.tests
 
-import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBRemoteEvalParams
@@ -11,7 +10,6 @@ import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import kotlinx.serialization.json.JsonObject
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -21,18 +19,15 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     private var isError: Boolean = false
     private var hasFeatures: Boolean = false
 
-    @BeforeTest
-    fun setUp() {
-        GrowthBookSDK.gbContext = GBContext(
-            "Key", hostURL = "https://example.com",
-            enabled = true, attributes = HashMap(), forcedVariations = HashMap(),
-            qaMode = false, trackingCallback = { _, _ ->
+    private val gbContext = GBContext(
+        "Key", hostURL = "https://example.com",
+        enabled = true, attributes = HashMap(), forcedVariations = HashMap(),
+        qaMode = false, trackingCallback = { _, _ ->
 
-            },
-            encryptionKey = null,
-            remoteEval = false,
-        )
-    }
+        },
+        encryptionKey = null,
+        remoteEval = false,
+    )
 
     @Test
     fun testSuccess() {
@@ -40,7 +35,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         isError = true
         val viewModel = FeaturesViewModel(
             this,
-            FeaturesDataSource(MockNetworkClient(MockResponse.successResponse, null)),
+            FeaturesDataSource(MockNetworkClient(MockResponse.successResponse, null), gbContext),
             "3tfeoyW0wlo47bDnbWDkxg==", false,
         )
 
@@ -60,7 +55,8 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             FeaturesDataSource(
                 MockNetworkClient(
                     MockResponse.successResponseEncryptedFeatures, null
-                )
+                ),
+                gbContext
             ), "3tfeoyW0wlo47bDnbWDkxg==", false,
         )
 
@@ -81,7 +77,8 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             dataSource = FeaturesDataSource(
                 MockNetworkClient(
                     null, Throwable("UNKNOWN", null)
-                )
+                ),
+                gbContext
             ),
             cachingEnabled = false,
         )
@@ -103,7 +100,8 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             dataSource = FeaturesDataSource(
                 MockNetworkClient(
                     MockResponse.ERROR_RESPONSE, null
-                )
+                ),
+                gbContext
             ),
             encryptionKey = "",
             cachingEnabled = false,
@@ -127,7 +125,8 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 dispatcher = MockNetworkClient(
                     successResponse = MockResponse.successResponse,
                     error = null
-                )
+                ),
+                gbContext
             ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
@@ -159,7 +158,8 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 dispatcher = MockNetworkClient(
                     successResponse = null,
                     error = Error()
-                )
+                ),
+                gbContext
             ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,


### PR DESCRIPTION
This should allow for multiple, isolated instances of `GrowthBookSDK` by moving `gbContext` out of the companion object and into the class as a private field.  The `gbContext` is then passed directly to FeaturesDataSource instead of it accessing the global instance of `gbContext` via the companion object.