### PR TITLE
Fix sticky bucket identifier attributes not updating

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -369,9 +369,7 @@ internal class GBUtils {
             attributeOverrides: Map<String, GBValue>
         ): Map<String, String> {
             val attributes = mutableMapOf<String, String>()
-            context.stickyBucketIdentifierAttributes = context.stickyBucketIdentifierAttributes
-                ?.takeIf { true }
-                ?: deriveStickyBucketIdentifierAttributes(context, data)
+            context.stickyBucketIdentifierAttributes = deriveStickyBucketIdentifierAttributes(context, data)
 
             context.stickyBucketIdentifierAttributes?.forEach { attr ->
                 val hashValue =


### PR DESCRIPTION
When user attributes change via `setAttributes()`, the `stickyBucketIdentifierAttributes` were not recalculated. This caused sticky bucket assignments to be retrieved for the wrong user.