### PR TITLE
fix minExperimentBucketVersion comparison

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -488,7 +488,8 @@ internal class GBUtils {
             )
 
             if (minExperimentBucketVersion > 0) {
-                for (version in 0..minExperimentBucketVersion) {
+                // users with any blocked bucket version (0 to minExperimentBucketVersion - 1) are excluded from the test
+                for (version in 0..minExperimentBucketVersion - 1) {
                     val blockedKey = getStickyBucketExperimentKey(experimentKey, version)
                     if (blockedKey in assignments) {
                         return Pair(-1, true)


### PR DESCRIPTION
minBucketVersion doesn't allow bucketVersion of the same number through. This causes rebucketing when not in the base case.