### PR TITLE
feat: add case-insensitive operators to condition evaluator

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
@@ -270,7 +270,11 @@ internal class GBConditionEvaluator {
     /**
      * Evaluates Condition Value against given condition & attributes
      */
-    fun evalConditionValue(conditionValue: GBValue, attributeValue: GBValue?, savedGroups: Map<String, GBValue>?): Boolean {
+    fun evalConditionValue(
+        conditionValue: GBValue,
+        attributeValue: GBValue?,
+        savedGroups: Map<String, GBValue>?
+    ): Boolean {
 
         // If conditionValue is a string, number, boolean, return true
         // if it's "equal" to attributeValue and false if not.
@@ -301,7 +305,13 @@ internal class GBConditionEvaluator {
             if (isOperatorObject(conditionValue)) {
                 for (key in conditionValue.keys) {
                     // If evalOperatorCondition(key, attributeValue, value) is false, return false
-                    if (!evalOperatorCondition(key, attributeValue, conditionValue[key]!!, savedGroups)) {
+                    if (!evalOperatorCondition(
+                            key,
+                            attributeValue,
+                            conditionValue[key]!!,
+                            savedGroups
+                        )
+                    ) {
                         return false
                     }
                 }
@@ -544,6 +554,36 @@ internal class GBConditionEvaluator {
 
                         val regex = Regex(targetPrimitiveValue?.value.orEmpty())
                         regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
+                    } catch (error: Throwable) {
+                        false
+                    }
+                }
+
+                "\$regexi" -> {
+                    return try {
+                        val regex =
+                            Regex(targetPrimitiveValue?.value.orEmpty(), RegexOption.IGNORE_CASE)
+                        regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
+                    } catch (error: Throwable) {
+                        false
+                    }
+                }
+
+                "\$notRegex" -> {
+                    return try {
+                        val regex =
+                            Regex(targetPrimitiveValue?.value.orEmpty())
+                        !regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
+                    } catch (error: Throwable) {
+                        false
+                    }
+                }
+
+                "\$notRegexi" -> {
+                    return try {
+                        val regex =
+                            Regex(targetPrimitiveValue?.value.orEmpty(), RegexOption.IGNORE_CASE)
+                        !regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
                     } catch (error: Throwable) {
                         false
                     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
@@ -549,44 +549,35 @@ internal class GBConditionEvaluator {
                 }
                 // Evaluate REGEX operator - whether attribute contains condition regex
                 "\$regex" -> {
-
-                    return try {
-
-                        val regex = Regex(targetPrimitiveValue?.value.orEmpty())
-                        regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
-                    } catch (error: Throwable) {
-                        false
-                    }
+                    return evalRegex(conditionValue = targetPrimitiveValue,
+                        attributeValue = sourcePrimitiveValue,
+                        ignoreCase = false,
+                        negate = false
+                    )
                 }
 
                 "\$regexi" -> {
-                    return try {
-                        val regex =
-                            Regex(targetPrimitiveValue?.value.orEmpty(), RegexOption.IGNORE_CASE)
-                        regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
-                    } catch (error: Throwable) {
-                        false
-                    }
+                    return evalRegex(conditionValue = targetPrimitiveValue,
+                        attributeValue = sourcePrimitiveValue,
+                        ignoreCase = true,
+                        negate = false
+                    )
                 }
 
                 "\$notRegex" -> {
-                    return try {
-                        val regex =
-                            Regex(targetPrimitiveValue?.value.orEmpty())
-                        !regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
-                    } catch (error: Throwable) {
-                        false
-                    }
+                    return evalRegex(conditionValue = targetPrimitiveValue,
+                        attributeValue = sourcePrimitiveValue,
+                        ignoreCase = false,
+                        negate = true
+                    )
                 }
 
                 "\$notRegexi" -> {
-                    return try {
-                        val regex =
-                            Regex(targetPrimitiveValue?.value.orEmpty(), RegexOption.IGNORE_CASE)
-                        !regex.containsMatchIn(sourcePrimitiveValue?.value ?: "0")
-                    } catch (error: Throwable) {
-                        false
-                    }
+                    return evalRegex(conditionValue = targetPrimitiveValue,
+                        attributeValue = sourcePrimitiveValue,
+                        ignoreCase = true,
+                        negate = true
+                    )
                 }
                 // Evaluate VEQ operator - whether versions are equals
                 "\$veq" -> return paddedVersionSource == paddedVersionTarget
@@ -673,4 +664,17 @@ internal class GBConditionEvaluator {
             is GBString -> this.value.toDoubleOrNull() ?: 0.0
             else -> 0.0
         }
+
+    private fun evalRegex(conditionValue: GBString?, attributeValue: GBString?, ignoreCase: Boolean, negate: Boolean): Boolean {
+        if (conditionValue == null || attributeValue == null) return false
+
+        return try {
+            val options = if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet()
+            val regex = Regex(conditionValue.value, options)
+            val matches = regex.containsMatchIn(attributeValue.value)
+            if (negate) !matches else matches
+        } catch (t: Throwable) {
+            false
+        }
+    }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBConditionEvaluator.kt
@@ -270,11 +270,12 @@ internal class GBConditionEvaluator {
     /**
      * Evaluates Condition Value against given condition & attributes
      */
-    fun evalConditionValue(
-        conditionValue: GBValue,
-        attributeValue: GBValue?,
-        savedGroups: Map<String, GBValue>?
-    ): Boolean {
+    fun evalConditionValue(conditionValue: GBValue, attributeValue: GBValue?, savedGroups: Map<String, GBValue>?, inSensitive: Boolean = false): Boolean {
+
+        // Simple equality comparison with optional case-insensitivity
+        if (inSensitive && conditionValue is GBString && attributeValue is GBString) {
+            return conditionValue.value.equals(attributeValue.value, ignoreCase = true)
+        }
 
         // If conditionValue is a string, number, boolean, return true
         // if it's "equal" to attributeValue and false if not.
@@ -429,6 +430,14 @@ internal class GBConditionEvaluator {
                         isIn(attributeValue, conditionValue)
                     } else conditionValue.contains(attributeValue)
                 }
+                // Evaluate INI operator - attributeValue in the conditionValue array
+                "\$ini" -> {
+                    return isIn(attributeValue, conditionValue, true)
+                }
+                // Evaluate NINI operator - attributeValue in the conditionValue array
+                "\$nini" -> {
+                    return !isIn(attributeValue, conditionValue, true)
+                }
                 // Evaluate NIN operator - attributeValue not in the conditionValue array
                 "\$nin" -> {
                     return if (attributeValue is GBArray) {
@@ -437,27 +446,13 @@ internal class GBConditionEvaluator {
                 }
                 // Evaluate ALL operator - whether condition contains all attribute
                 "\$all" -> {
-
-                    if (attributeValue is GBArray) {
-                        // Loop through conditionValue array
-                        // If none of the elements in the attributeValue array pass
-                        // evalConditionValue(conditionValue[i], attributeValue[j]), return false
-                        for (con in conditionValue) {
-                            var result = false
-                            for (attr in attributeValue) {
-                                if (evalConditionValue(con, attr, savedGroups)) {
-                                    result = true
-                                }
-                            }
-                            if (!result) {
-                                return false
-                            }
-                        }
-                        return true
-                    } else {
-                        // If attributeValue is not an array, return false
-                        return false
-                    }
+                    if (attributeValue !is GBArray) return false
+                    return isInAll(attributeValue, conditionValue, savedGroups, false)
+                }
+                // Evaluate ALLI operator - whether condition contains all attribute
+                "\$alli" -> {
+                    if (attributeValue !is GBArray) return false
+                    return isInAll(attributeValue, conditionValue, savedGroups, true)
                 }
             }
         } else if (attributeValue is GBArray) {
@@ -600,7 +595,6 @@ internal class GBConditionEvaluator {
                         savedGroups?.get(conditionValue.asKey()) as? GBArray ?: GBArray(emptyList())
                     return isIn(attributeValue, gbArray)
                 }
-
                 "\$notInGroup" -> {
                     val gbArray =
                         savedGroups?.get(conditionValue.asKey()) as? GBArray ?: GBArray(emptyList())
@@ -618,23 +612,55 @@ internal class GBConditionEvaluator {
             else -> this.toString()
         }
 
-    private fun isIn(actualValue: GBValue, conditionValue: GBArray): Boolean {
+    private fun isIn(actualValue: GBValue?, conditionValue: GBArray, inSensitive: Boolean = false): Boolean {
+        fun caseFold(value: GBValue?): GBValue? {
+            return if (inSensitive && value is GBString) {
+                GBString(value.value.lowercase())
+            } else {
+                value
+            }
+        }
 
-        if (actualValue !is GBArray) return conditionValue.contains(actualValue)
+        if (actualValue is GBArray) {
+            if (actualValue.isEmpty()) return false
 
-        if (actualValue.size == 0) return false
-
-        actualValue.forEach {
-            if (getType(it) == GBAttributeType.GbString ||
-                getType(it) == GBAttributeType.GbBoolean ||
-                getType(it) == GBAttributeType.GbNumber
-            ) {
-                if (conditionValue.contains(it)) {
-                    return true
+            return actualValue.any { attr ->
+                conditionValue.any { cond ->
+                    caseFold(attr) == caseFold(cond)
                 }
             }
         }
-        return false
+
+        return conditionValue.any {
+            caseFold(actualValue) ==  caseFold(it)
+        }
+    }
+
+    private fun isInAll(
+        actual: GBValue,
+        expected: GBArray,
+        savedGroups: Map<String, GBValue>?,
+        inSensitive: Boolean = false
+    ): Boolean {
+        if (actual !is GBArray) return false
+
+        for (expectedItem in expected) {
+            var passed = false
+
+            for (actualItem in actual) {
+                if (evalConditionValue(
+                        expectedItem,
+                        actualItem,
+                        savedGroups,
+                        inSensitive)) {
+                    passed = true
+                    break
+                }
+            }
+            if (!passed) return false
+
+        }
+        return true
     }
 
     private fun comparisonTemplate(

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
@@ -758,6 +758,90 @@
       false
     ],
     [
+      "$regexi - pass (case insensitive match)",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      true
+    ],
+    [
+      "$regexi - pass (uppercase pattern, lowercase value)",
+      {
+        "userAgent": {
+          "$regexi": "(MOBILE|TABLET)"
+        }
+      },
+      {
+        "userAgent": "android mobile browser"
+      },
+      true
+    ],
+    [
+      "$regexi - fail",
+      {
+        "userAgent": {
+          "$regexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      false
+    ],
+    [
+      "$notRegex - pass",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegex - fail",
+      {
+        "userAgent": {
+          "$notRegex": "(Mobile|Tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
+      "$notRegexi - pass",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Chrome Desktop Browser"
+      },
+      true
+    ],
+    [
+      "$notRegexi - fail",
+      {
+        "userAgent": {
+          "$notRegexi": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
       "$gt/$lt numbers - pass",
       {
         "age": {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
@@ -842,6 +842,90 @@
       false
     ],
     [
+      "$ini - pass",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "a"
+      },
+      true
+    ],
+    [
+      "$ini - fail",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": "c"
+      },
+      false
+    ],
+    [
+      "$ini - array pass",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "a"]
+      },
+      true
+    ],
+    [
+      "$nini - pass",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "c"
+      },
+      true
+    ],
+    [
+      "$nini - fail",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": "a"
+      },
+      false
+    ],
+    [
+      "$alli - pass",
+      {
+        "tags": {
+          "$alli": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["a", "b", "c"]
+      },
+      true
+    ],
+    [
+      "$alli - fail",
+      {
+        "tags": {
+          "$alli": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["a", "c"]
+      },
+      false
+    ],
+    [
       "$gt/$lt numbers - pass",
       {
         "age": {


### PR DESCRIPTION
This PR adds support for case-insensitive operators in the condition evaluator.

1) Adds support for case-insensitive regex operators:

- `$regexi`

- `$notRegexi`

- `$notRegex`

2) Adds case-insensitive versions of membership operators:

- `$ini` — case-insensitive version of `$in`

- `$nini` — case-insensitive version of `$nin`

- `$alli` — case-insensitive version of `$all`