### PR TITLE
feat: add featureValue method, hide reified feature function from Objective-C

### DIFF
--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.12] - 2026-04-*
+## [1.0.12] - 2026-04-07
 
 ### Added
 - iOS targets support: `iosX64`, `iosArm64`, `iosSimulatorArm64`

--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -1,0 +1,91 @@
+# Changelog — NetworkDispatcherKtor
+
+All notable changes to the `NetworkDispatcherKtor` artifact will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [1.0.12] - 2026-04-*
+
+### Added
+- iOS targets support: `iosX64`, `iosArm64`, `iosSimulatorArm64`
+- Shared `iosMain` source set with `ktor-client-darwin`
+
+---
+
+## [1.0.11] - 2026-03-27
+
+### Fixed
+- ETag cache: log HTTP 304 Not Modified response instead of treating it as error
+- fix duplicate class for LRUEtagCache class
+
+---
+
+## [1.0.10] - 2026-02-25
+
+### Removed
+- Accept-Encoding from GET request
+
+---
+
+## [1.0.9] - 2025-12-25
+### Added
+- Accept-Encoding to GET request
+- LRU caching for NotModified response
+
+---
+
+## [1.0.8] - 2025-12-04
+
+### Changed
+- fix publishing
+
+---
+
+## [1.0.7] - 2025-11-18
+
+### Changed
+- fix publishing
+
+---
+
+## [1.0.6] - 2025-05-13
+
+### Changed
+- deprecated method was removed
+
+---
+
+## [1.0.5] - 2025-04-18
+### Added
+- Kotlin/Wasm initial support
+### Changed
+- Ktor upgraded to 3.0.3
+- Rebase on top of upstream update-dependencies branch
+
+---
+
+## [1.0.4] - 2024-11-22
+
+### Fixed
+- AbstractMethodError fix
+- Issue #142 fix
+### Changed
+- Signing signatory unified across artifacts
+- Enable compilation targeting JRE 1.8
+- Revert AGP to 7.4.2 and JDK to 11
+- Dokka plugin version update
+### Added
+- Kotlin/JS targets support
+- iOS support for NetworkDispatcherKtor module
+
+---
+
+## [1.0.1] - 2024-11-26
+
+### Changed
+- Initial release
+
+---

--- a/CHANGELOG-NetworkDispatcherOkhttp.md
+++ b/CHANGELOG-NetworkDispatcherOkhttp.md
@@ -1,0 +1,69 @@
+# Changelog — NetworkDispatcherKtor
+
+All notable changes to the `NetworkDispatcherOkhttp` artifact will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [1.0.7] - 2026-03-27
+
+### Fixed
+- ETag cache: log HTTP 304 Not Modified response instead of treating it as error
+- fix duplicate class for LRUEtagCache class
+
+---
+
+## [1.0.6] - 2026-02-25
+
+### Removed
+- Accept-Encoding from GET request
+
+---
+
+## [1.0.4] - 2025-12-04
+
+### Changed
+- fix publishing
+
+---
+
+## [1.0.3] - 2025-11-22
+
+### Changed
+- fix publishing
+
+---
+
+## [1.0.2] - 2024-11-18
+
+### Fixed
+- AbstractMethodError fix
+- Issue #142 fix
+### Changed
+- Signing signatory unified across artifacts
+- Enable compilation targeting JRE 1.8
+- Revert AGP to 7.4.2 and JDK to 11
+- Dokka plugin version update
+### Added
+- Kotlin/JS targets support
+- iOS support for NetworkDispatcherKtor module
+
+---
+
+## [1.0.1] - 2024-08-06
+
+### Changed
+- Bump OkHttp version to 4.9.2
+- Dokka plugin version was updated
+- flow{} was replaced with callbackFlow{}
+
+---
+
+## [1.0.0] - 2024-06-14
+
+### Added
+- initial release
+
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [7.1.0] - 2026-04-02
+## [7.1.0] - 2026-04-07
 
 ### Added
 - New `featureValue` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,132 @@
+# Changelog
+
+All notable changes to the GrowthBook Kotlin SDK will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [7.1.0] - 2026-04-02
+
+### Added
+- New `featureValue` function
+- Hide reified function from Objective-C
+
+---
+
+## [7.0.0] - 2026-03-27
+
+### Added
+- Scoped the feature cache key by clientKey (or API host) so each SDK instance uses its own isolated cache entry
+
+### Fixed
+- Correctly handle empty string attributes
+
+---
+
+## [6.1.5] - 2025-03-03
+
+### Fixed
+- Wrap `onFeatureUsage` and tracking callbacks in try-catch block to prevent crash in the SDK
+- Fix prerequisite circular dependency
+
+---
+
+## [6.1.4] - 2025-02-13
+
+### Fixed
+- Fix `JsonDecodingException` by removing Accept Encoding header in NetworkDispatchers
+- Synchronize `saveContent` and `getContent` in CachingAndroid
+- Add Mutex to GBUtils to synchronize all sticky bucket read/write operations
+
+---
+
+## [6.1.3] - 2026-01-01
+
+### Added
+- `setAttributesSync()` — waits for sticky buckets to load before returning
+- `setAttributeOverridesSync()` — synchronous version of attribute overrides
+- `refreshStickyBucketsSync()` utility function
+- ETag caching to NetworkDispatchers
+
+### Removed
+- `StickyBucketServiceHelper` internal class (no longer needed)
+
+### Migration
+Use sync methods for login/logout/user switching to prevent race conditions where experiments were evaluated before sticky buckets loaded.
+
+---
+
+## [6.1.2] - 2025-12-05
+
+### Added
+- `startAutoRefreshFeatures()` and `stopAutoRefreshFeatures()` for better handling SSE connection
+
+---
+
+## [6.1.1] - 2025-10-20
+
+### Fixed
+- Bug fix
+
+---
+
+## [6.1.0] - 2025-08-15
+
+### Changed
+- `GBStickyBucketService` methods changed to suspend
+- `coroutineScope` added to `GBStickyBucketService`
+
+---
+
+## [6.0.0] - 2025-05-22
+
+### Changed
+- `hostURL` property renamed to `apiHost` to align with the TypeScript SDK
+- `streamingHost` property added to differentiate streaming host URL from API host
+
+---
+
+## [5.0.0] - 2025-05-22
+
+### Changed
+- GB values moved to `:Core` module (used in `:GrowthBookKotlinxSerialization`)
+- `forcedFeature` field of `GBFeatureEvaluator` is now a map of GB values
+
+---
+
+## [4.0.0] - 2025-03-03
+
+### Changed
+- `initialize()` changed from non-suspend to suspend method to eliminate null on first access
+
+### Added
+- `initializeWithoutWaitForCall()` for users not using coroutines
+
+---
+
+## [3.0.0] - 2025-01-27
+
+### Changed
+- User attributes type changed to map of GB values
+- `attributesOverride` is now a map of GB values
+- Forced features is now a map of GB values
+
+---
+
+## [2.0.0] - 2025-01-10
+
+### Changed
+- `value` field renamed to `gbValue`
+- Type of `gbValue` changed to `GBValue`
+
+### Added
+- `inline fun <reified V>feature(id: String): V?`
+
+---
+
+## [1.1.63] - 2024-11-26
+
+### Changed
+- Type of `value` field of `GBFeatureResult` changed to `kotlinx.serialization.json.JsonElement`

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.0.0"
+version = "7.1.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -38,6 +38,8 @@ import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBucketsSync
 import kotlinx.coroutines.launch
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 
 typealias GBTrackingCallback = (GBExperiment, GBExperimentResult) -> Unit
 typealias GBFeatureUsageCallback = (featureKey: String, gbFeatureResult: GBFeatureResult) -> Unit
@@ -249,7 +251,43 @@ class GrowthBookSDK(
      *
      * @returns a feature value typed with specified type
      */
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
+    @Deprecated("Use featureValue() instead", ReplaceWith("featureValue<V>(id)"))
     inline fun <reified V>feature(id: String): V? {
+        val listOfSupportedTypes = listOf(
+            Boolean::class, String::class,
+            Number::class, Short::class, Int::class,
+            Long::class, Float::class, Double::class,
+            GBJson::class,
+        )
+        if (V::class !in listOfSupportedTypes) {
+            return null
+        }
+
+        val gbFeatureResult = feature(id)
+        return when(val gbResultValue = gbFeatureResult.gbValue) {
+            is GBNull -> null
+            is GBBoolean -> gbResultValue.value as? V
+            is GBString -> gbResultValue.value as? V
+            is GBNumber -> gbResultValue.value as? V
+            is GBJson -> gbResultValue as? V
+            is GBValue.Unknown -> null
+            is GBArray -> null
+            null -> null
+        }
+    }
+
+    /**
+     * The feature method takes a string argument,
+     * which is the unique identifier, and the type of the accessed feature.
+     * The supported types of accessed features are:
+     * [Boolean], [String], [Number], [Short],
+     * [Int], [Long], [Float], [Double], [GBJson]
+     *
+     * @returns a feature value typed with specified type
+     */
+    inline fun <reified V>featureValue(id: String): V? {
         val listOfSupportedTypes = listOf(
             Boolean::class, String::class,
             Number::class, Short::class, Int::class,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -255,31 +255,11 @@ class GrowthBookSDK(
     @HiddenFromObjC
     @Deprecated("Use featureValue() instead", ReplaceWith("featureValue<V>(id)"))
     inline fun <reified V>feature(id: String): V? {
-        val listOfSupportedTypes = listOf(
-            Boolean::class, String::class,
-            Number::class, Short::class, Int::class,
-            Long::class, Float::class, Double::class,
-            GBJson::class,
-        )
-        if (V::class !in listOfSupportedTypes) {
-            return null
-        }
-
-        val gbFeatureResult = feature(id)
-        return when(val gbResultValue = gbFeatureResult.gbValue) {
-            is GBNull -> null
-            is GBBoolean -> gbResultValue.value as? V
-            is GBString -> gbResultValue.value as? V
-            is GBNumber -> gbResultValue.value as? V
-            is GBJson -> gbResultValue as? V
-            is GBValue.Unknown -> null
-            is GBArray -> null
-            null -> null
-        }
+        return extractFeatureValue(id)
     }
 
     /**
-     * The feature method takes a string argument,
+     * The featureValue method takes a string argument,
      * which is the unique identifier, and the type of the accessed feature.
      * The supported types of accessed features are:
      * [Boolean], [String], [Number], [Short],
@@ -288,27 +268,7 @@ class GrowthBookSDK(
      * @returns a feature value typed with specified type
      */
     inline fun <reified V>featureValue(id: String): V? {
-        val listOfSupportedTypes = listOf(
-            Boolean::class, String::class,
-            Number::class, Short::class, Int::class,
-            Long::class, Float::class, Double::class,
-            GBJson::class,
-        )
-        if (V::class !in listOfSupportedTypes) {
-            return null
-        }
-
-        val gbFeatureResult = feature(id)
-        return when(val gbResultValue = gbFeatureResult.gbValue) {
-            is GBNull -> null
-            is GBBoolean -> gbResultValue.value as? V
-            is GBString -> gbResultValue.value as? V
-            is GBNumber -> gbResultValue.value as? V
-            is GBJson -> gbResultValue as? V
-            is GBValue.Unknown -> null
-            is GBArray -> null
-            null -> null
-        }
+        return extractFeatureValue(id)
     }
 
     /**
@@ -441,6 +401,34 @@ class GrowthBookSDK(
                 data = dataModel,
                 attributeOverrides = attributeOverrides
             )
+        }
+    }
+
+    /**
+     * Helper method for reified feature and featureValue
+     */
+    @PublishedApi
+    internal inline fun <reified V>extractFeatureValue(id: String): V? {
+        val listOfSupportedTypes = listOf(
+            Boolean::class, String::class,
+            Number::class, Short::class, Int::class,
+            Long::class, Float::class, Double::class,
+            GBJson::class,
+        )
+        if (V::class !in listOfSupportedTypes) {
+            return null
+        }
+
+        val gbFeatureResult : GBFeatureResult = this.feature(id)
+        return when(val gbResultValue = gbFeatureResult.gbValue) {
+            is GBNull -> null
+            is GBBoolean -> gbResultValue.value as? V
+            is GBString -> gbResultValue.value as? V
+            is GBNumber -> gbResultValue.value as? V
+            is GBJson -> gbResultValue as? V
+            is GBValue.Unknown -> null
+            is GBArray -> null
+            null -> null
         }
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBFeatureValueTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBFeatureValueTests.kt
@@ -18,6 +18,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.kotlinx.serialization.gbSerialize
+import com.sdk.growthbook.model.GBBoolean
+import com.sdk.growthbook.model.GBFeature
+import com.sdk.growthbook.model.GBString
 
 class GBFeatureValueTests {
 
@@ -129,6 +132,74 @@ class GBFeatureValueTests {
         print(failedScenarios)
 
         assertTrue(failedScenarios.size == 0)
+    }
+
+    @Test
+    fun `featureValue returns typed value for Boolean feature`() {
+        val sdk = GBSDKBuilder(
+            apiKey = "",
+            apiHost = "",
+            networkDispatcher = MockNetworkClient(successResponse = null, error = null),
+            attributes = emptyMap(),
+            trackingCallback = { _, _ -> },
+        ).initialize()
+
+        sdk.getGBContext().features = mapOf(
+            "bool-feature" to GBFeature(
+                GBBoolean(true)
+            )
+        )
+
+        val result = sdk.featureValue<Boolean>("bool-feature")
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `featureValue returns typed value for String feature`() {
+        val sdk = GBSDKBuilder(
+            apiKey = "",
+            apiHost = "",
+            networkDispatcher = MockNetworkClient(successResponse = null, error = null),
+            attributes = emptyMap(),
+            trackingCallback = { _, _ -> },
+        ).initialize()
+
+        sdk.getGBContext().features = mapOf(
+            "str-feature" to GBFeature(
+                GBString("hello")
+            )
+        )
+
+        val result = sdk.featureValue<String>("str-feature")
+        assertEquals("hello", result)
+    }
+
+    @Test
+    fun `featureValue returns null for unsupported type`() {
+        val sdk = GBSDKBuilder(
+            apiKey = "",
+            apiHost = "",
+            networkDispatcher = MockNetworkClient(successResponse = null, error = null),
+            attributes = emptyMap(),
+            trackingCallback = { _, _ -> },
+        ).initialize()
+
+        val result = sdk.featureValue<List<String>>("any-feature")
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `featureValue returns null for unknown feature`() {
+        val sdk = GBSDKBuilder(
+            apiKey = "",
+            apiHost = "",
+            networkDispatcher = MockNetworkClient(successResponse = null, error = null),
+            attributes = emptyMap(),
+            trackingCallback = { _, _ -> },
+        ).initialize()
+
+        val result = sdk.featureValue<Boolean>("nonexistent")
+        assertEquals(null, result)
     }
 
     @Test

--- a/NetworkDispatcherKtor/build.gradle.kts
+++ b/NetworkDispatcherKtor/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.11"
+version = "1.0.12"
 
 kotlin {
     androidTarget {
@@ -55,6 +55,16 @@ kotlin {
                 implementation("io.ktor:ktor-client-android:$ktorVersion")
             }
         }
+        val iosMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+                implementation("io.ktor:ktor-client-darwin:$ktorVersion")
+            }
+        }
+        val iosX64Main by getting { dependsOn(iosMain) }
+        val iosArm64Main by getting { dependsOn(iosMain) }
+        val iosSimulatorArm64Main by getting { dependsOn(iosMain) }
+
         val androidUnitTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@
 # GrowthBook - Kotlin SDK
 
 - **Lightweight and fast**
-- **Android apps & JVM projects**
+- **Kotlin Multiplatform (Android, iOS, JVM, JS, Wasm)**
     - **Android version 21 & above**
     - **JDK 17 & Above**
+    - **iOS (iosX64, iosArm64, iosSimulatorArm64)**
 
 - **Use your existing event tracking (GA, Segment, Mixpanel, custom)**
 - **Adjust variation weights and targeting without deploying new code**
+
+See [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## Setup
 
@@ -25,15 +28,16 @@ repositories {
 
 dependencies {
     // Add GrowthBook module:
-    implementation 'io.growthbook.sdk:GrowthBook:<version>' // 6.1.2 latest version when this file was edited
+    implementation 'io.growthbook.sdk:GrowthBook:7.1.0'
 
     // Add Network Dispatcher you prefer:
-    // 1) NetworkDispatcherKtor artifact contains the Network Dispatcher based on Ktor artifact
-    implementation 'io.growthbook.sdk:NetworkDispatcherKtor:1.0.8'
-    // 2) NetworkDispatcherOkHttp artifact contains the Network Dispatcher based on OkHttp artifact
-    implementation 'io.growthbook.sdk:NetworkDispatcherOkHttp:1.0.4'
+    // 1) NetworkDispatcherKtor — supports Android, iOS, JVM, JS, Wasm
+    implementation 'io.growthbook.sdk:NetworkDispatcherKtor:1.0.12'
+    // 2) NetworkDispatcherOkHttp — supports Android and JVM only
+    implementation 'io.growthbook.sdk:NetworkDispatcherOkHttp:1.0.7'
 }
 ```
+
 If you are not sure which dispatcher to choose we recommend to use network dispatcher based on Ktor.
 
 The main class of `NetworkDispatcherKtor` artifact is `GBNetworkDispatcherKtor` while the main class of `NetworkDispatcherOkHttp` artifact is `GBNetworkDispatcherOkHttp`.
@@ -56,7 +60,7 @@ Integration is super easy:
 Now you can start/stop tests, adjust coverage and variation weights, and apply a winning variation to 100% of traffic,
 all within the Growth Book App without deploying code changes to your site.
 
- `initialize()` method should be called in order to obtain SDK instance:
+`initialize()` method should be called in order to obtain SDK instance:
 
 ```kotlin
 var sdkInstance: GrowthBookSDK = GBSDKBuilder(
@@ -90,6 +94,13 @@ If you are accessing features the first time there will be no features right aft
 
     ```kotlin
   fun feature(id: String) : GBFeatureResult
+    ```
+- The featureValue method takes a string argument, which is the unique identifier, and the type of the accessed feature. 
+The supported types of accessed features are: Boolean, String, Number, Short, Int, Long, Float, Double], GBJson - 
+and returns a feature value typed with specified type.
+
+    ```kotlin
+  inline fun <reified V>featureValue(id: String): V?
     ```
 
 - If you changed, added or removed any features, you can call the refreshCache method to clear the cache and download
@@ -220,7 +231,7 @@ If you are accessing features the first time there will be no features right aft
 
 ## Models
 
-This SDK operates with such models as `GBContext`, `GBFeature`, `GBFeatureRule`, `GBFeatureSource`, `GBFeatureResult`, `GBExperiment`, `GBExperimentResult`, etc. 
+This SDK operates with such models as `GBContext`, `GBFeature`, `GBFeatureRule`, `GBFeatureSource`, `GBFeatureResult`, `GBExperiment`, `GBExperimentResult`, etc.
 
 These models can be found in `model` package. Some entities were put in utils/Constants.kt file. In JS SDK there is only one entity "Result" while in this SDK `GBFeatureResult`, `GBExperimentResult` are present.
 
@@ -346,57 +357,7 @@ class GBStickyBucketServiceImp(
 }
 ```
 
-## Changelog
-- **v1.1.63** 2024-11-26
-    - The type of `value` field of `GBFeatureResult` class was changed to `kotlinx.serialization.json.JsonElement`
-- **v2.0.0** 2025-01-10
-    - the `value` field was renamed to `gbValue`, the type of this field was changed to `GBValue`;
-    - `inline fun <reified V>feature(id: String): V?` was added (useful when you need only feature value and you know the type of this feature)
-- **v3.0.0** 2025-01-27
-    - user attributes type was changed (map of GB values);
-    - attributesOverride is map of GB values;
-    - forced features is map of GB values
-- **v4.0.0** 2025-03-03
-    - `initialize()` method was changed from non-suspend to suspend method
-in order to get rid of null on the first access. It is expected that user of
-the SDK calls `initialize()` from coroutine. For those who doesn't use coroutines,
-they can use `initializeWithoutWaitForCall()` method
-- **v5.0.0** 2025-05-22
-    - GB values were moved to :Core module because they are used in :GrowthBookKotlinxSerialization
-module;
-    - forcedFeature field of GBFeatureEvaluator is a map of GB values.
-- **v6.0.0** 2025-05-22
-    - hostURL property was renamed to apiHost in order to follow the same way as Typescript SDK follows,
-streamingHost property was added to  to differentiate streaming host url from API host.
-- **v6.1.0** 2025-08-15
-    - `GBStickyBucketService` methods were changed to suspend, `coroutineScope` was added.
-- **v6.1.1** 2025-10-20
-    - bug fix
-- **v6.1.2** 2025-12-05
-    - Add `startAutoRefreshFeatures()` and `stopAutoRefreshFeatures()` for better handling SSE connection
-- **v6.1.3** 2026-01-01
-    - **IMPORTANT:** Add synchronous methods to prevent sticky bucket race conditions
-    - Add `setAttributesSync()` - waits for sticky buckets to load before returning
-    - Add `setAttributeOverridesSync()` - synchronous version of attribute overrides
-    - Add `refreshStickyBucketsSync()` utility function
-    - Remove `StickyBucketServiceHelper` internal class (no longer needed)
-    - Update lib up to 0.7.1 changelog
-    - Add ETag caching to NetworkDispatchers
-    - **Migration:** Use sync methods for login/logout/user switching to prevent race conditions where experiments were evaluated before sticky buckets loaded
-- **v6.1.4** 2025-02-13
-    - fix JsonDecodingException by removing Accept Encoding header in NetworkDispatchers
-    - synchronize saveContent and getContent in CachingAndroid
-    - Add Mutex to GBUtils file to synchronize all sticky bucket read/write operations refreshStickyBucketsSync and saveStickyBucketAssignment
-- **v6.1.5** 2025-03-03
-    - wrap onFeatureUsage and tracking callbacks in try-catch block to prevent crash in the SDK JsonDecodingException by removing Accept Encoding header in NetworkDispatchers
-    - fix prerequisite circular dependency
-- **v7.0.0** 2026-03-27
-    - feat!: Scoped the feature cache key by clientKey (or API host) so each SDK instance uses its own isolated cache entry.
-    - fix: correctly handle empty string attributes
-- **v7.1.0** 2026-04-02
-    - feat: create new featureValue function, hide reified function from Objective-C
 ## License
 
 This project uses the MIT license. The core GrowthBook app will always remain open and free, although we may add some
 commercial enterprise add-ons in the future.
- 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ streamingHost property was added to  to differentiate streaming host url from AP
 - **v7.0.0** 2026-03-27
     - feat!: Scoped the feature cache key by clientKey (or API host) so each SDK instance uses its own isolated cache entry.
     - fix: correctly handle empty string attributes
+- **v7.1.0** 2026-04-02
+    - feat: create new featureValue function, hide reified function from Objective-C
 ## License
 
 This project uses the MIT license. The core GrowthBook app will always remain open and free, although we may add some


### PR DESCRIPTION
## Problem
When users add the lib to a KMP project, the reified `feature<V>()` and non-reified `feature()` functions conflict due to the same Objective-C selector.

--- 

## Changes
- Hide reified `feature<V>()` from Objective-C via `@HiddenFromObjC` and deprecate it
- Add new `featureValue<V>()` function as a replacement (visible to Objective-C)
- Extract shared logic into `extractFeatureValue()` to avoid duplication
- Add unit tests for `featureValue()`
- Add iOS targets support (iosX64, iosArm64, iosSimulatorArm64) for NetworkDispatcherKtor
- Create CHANGELOG for GrowthBook, NetworkDispatcherKtor, NetworkDispatcherOkHttp
- Update README

---

## Migration

```kotlin
// Before
val value = gb.feature<Boolean>("my-feature")

// After
val value = gb.featureValue<Boolean>("my-feature")
```

