### PR TITLE
fix: correct sticky bucket propagation, attribute lookup, and race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `GBSDKBuilder.setCacheMaxAge()` — configurable cache freshness window; while the
   cache is younger than the given age, the next fetch is served from cache and the
-  network call is skipped. `refreshCache()` always bypasses this window.
+  network call is skipped, provided the cached payload actually decodes to usable
+  features/savedGroups — a fresh but empty/undecodable cache falls through to the
+  network instead. `refreshCache()` always bypasses this window.
 - `GrowthBookSDK.close()` — releases the instance's resources (stops any active SSE connection and cancels the background coroutine scope that processes fetched payloads). Call it when the SDK instance is no longer needed (e.g. on logout or before replacing it) to avoid leaking coroutines across repeated initializations
 
 ### Fixed
 - Sticky-bucket race condition: evaluation could observe a torn mix of state (e.g. freshly fetched features together with stale sticky-bucket assignment docs) when a background refresh ran concurrently with `feature()`/`run()`. All cross-thread evaluation inputs (`features`, `attributes`, `forcedVariations`, `stickyBucketAssignmentDocs`, `stickyBucketIdentifierAttributes`, `savedGroups`) are now published together as a single immutable snapshot behind an atomic reference, so every evaluation reads one consistent view
 - Sticky-bucket assignments generated during evaluation are now merged back into the context one key at a time (atomically) instead of writing the whole docs map back after `feature()`/`run()`. The previous whole-map write-back could overwrite assignments produced by a concurrent background refresh
 - `savedGroups` passed to the `GrowthBookSDK` constructor were written to an unused private field and never reached evaluation; they are now stored on the context
+- Encrypted feature payloads now decode before the sticky-bucket refresh, so sticky-bucket identifier attributes derive from the real features instead of an empty set on the first fetch (which could re-bucket users)
 
 ### Changed
 - `suspendFeature()` now retries failed fetches with exponential backoff (capped)
   instead of an unbounded recursive loop, preventing DNS request flooding when the
-  network is unavailable (#236).
+  network is unavailable (#236). A hung network round (a dispatcher that connects but
+  never responds) now times out after 30s and is treated as a failed attempt, so
+  `suspendFeature()` can no longer hang indefinitely.
 - Concurrent feature refreshes are now coalesced into a single shared in-flight
   request, so N parallel `suspendFeature()` callers no longer trigger N network
   fetches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [7.3.0] - 2026-06-23
+
+### Fixed
+- Sticky-bucket race condition: evaluation could observe a torn mix of state (e.g. freshly fetched features together with stale sticky-bucket assignment docs) when a background refresh ran concurrently with `feature()`/`run()`. All cross-thread evaluation inputs (`features`, `attributes`, `forcedVariations`, `stickyBucketAssignmentDocs`, `stickyBucketIdentifierAttributes`, `savedGroups`) are now published together as a single immutable snapshot behind an atomic reference, so every evaluation reads one consistent view
+- `savedGroups` passed to the `GrowthBookSDK` constructor were written to an unused private field and never reached evaluation; they are now stored on the context
+
+### Changed
+- The fetched payload (sticky-bucket refresh + feature application + `refreshHandler` invocation) is now processed on a defined background dispatcher (platform IO) instead of an arbitrary continuation thread. The `refreshHandler` callback is therefore invoked on a background thread — marshal back to your UI thread yourself if it touches UI state
+
+### Breaking
+- `GBContext` is no longer a `data class`. The compiler-generated `copy()`, `equals()`, `hashCode()` and `componentN()` (destructuring) members are no longer available. The primary constructor signature and all property accessors are unchanged, so normal construction and field access are unaffected
+
+---
+
 ## [7.2.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.3.0] - 2026-06-23
 
+### Added
+- `GrowthBookSDK.close()` — releases the instance's resources (stops any active SSE connection and cancels the background coroutine scope that processes fetched payloads). Call it when the SDK instance is no longer needed (e.g. on logout or before replacing it) to avoid leaking coroutines across repeated initializations
+
 ### Fixed
 - Sticky-bucket race condition: evaluation could observe a torn mix of state (e.g. freshly fetched features together with stale sticky-bucket assignment docs) when a background refresh ran concurrently with `feature()`/`run()`. All cross-thread evaluation inputs (`features`, `attributes`, `forcedVariations`, `stickyBucketAssignmentDocs`, `stickyBucketIdentifierAttributes`, `savedGroups`) are now published together as a single immutable snapshot behind an atomic reference, so every evaluation reads one consistent view
 - Sticky-bucket assignments generated during evaluation are now merged back into the context one key at a time (atomically) instead of writing the whole docs map back after `feature()`/`run()`. The previous whole-map write-back could overwrite assignments produced by a concurrent background refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Sticky-bucket race condition: evaluation could observe a torn mix of state (e.g. freshly fetched features together with stale sticky-bucket assignment docs) when a background refresh ran concurrently with `feature()`/`run()`. All cross-thread evaluation inputs (`features`, `attributes`, `forcedVariations`, `stickyBucketAssignmentDocs`, `stickyBucketIdentifierAttributes`, `savedGroups`) are now published together as a single immutable snapshot behind an atomic reference, so every evaluation reads one consistent view
+- Sticky-bucket assignments generated during evaluation are now merged back into the context one key at a time (atomically) instead of writing the whole docs map back after `feature()`/`run()`. The previous whole-map write-back could overwrite assignments produced by a concurrent background refresh
 - `savedGroups` passed to the `GrowthBookSDK` constructor were written to an unused private field and never reached evaluation; they are now stored on the context
 
 ### Changed

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.2.0"
+version = "7.3.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -1,5 +1,6 @@
 package com.sdk.growthbook
 
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.GBValue
@@ -106,8 +107,26 @@ class GBSDKBuilder(
     private var featureUsageCallback: GBFeatureUsageCallback? = null
     private var initialFeatures: GBFeatures? = null
 
+    // Dispatcher used to process fetched payloads. Defaults to the platform IO dispatcher in
+    // production; tests inject a deterministic dispatcher (e.g. Dispatchers.Unconfined or a
+    // StandardTestDispatcher) to drive the async pipeline synchronously.
+    private var coroutineContext: CoroutineContext = PlatformDependentIODispatcher
+
     /**
-     * Set Refresh Handler - Will be called when cache is refreshed
+     * Override the dispatcher used to process fetched payloads. Intended for tests that need
+     * deterministic, synchronous application of mocked network responses.
+     */
+    internal fun setCoroutineContext(context: CoroutineContext): GBSDKBuilder {
+        this.coroutineContext = context
+        return this
+    }
+
+    /**
+     * Set Refresh Handler - Will be called when cache is refreshed.
+     *
+     * Note: the handler is invoked from the SDK's payload-processing dispatcher (the platform IO
+     * dispatcher by default), i.e. on a background thread — not necessarily the main thread.
+     * Marshal back to your UI thread yourself if the callback touches UI state.
      */
     fun setRefreshHandler(refreshHandler: GBCacheRefreshHandler): GBSDKBuilder {
         this.refreshHandler = refreshHandler
@@ -209,6 +228,7 @@ class GBSDKBuilder(
             refreshHandler,
             networkDispatcher,
             cachingEnabled = cachingEnabled,
+            coroutineContext = coroutineContext,
         )
     }
 
@@ -261,6 +281,7 @@ class GBSDKBuilder(
                 internalRefreshHandler,
                 networkDispatcher,
                 cachingEnabled = cachingEnabled,
+                coroutineContext = coroutineContext,
             )
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -304,7 +304,7 @@ class GBSDKBuilder(
                 internalRefreshHandler,
                 networkDispatcher,
                 cachingEnabled = cachingEnabled,
-                cacheMaxAge = cacheMaxAge
+                cacheMaxAge = cacheMaxAge,
                 coroutineContext = coroutineContext,
             )
         }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -267,13 +267,11 @@ class GrowthBookSDK(
      * @returns a [GBFeatureResult] object
      */
     fun feature(id: String): GBFeatureResult {
-        val evaluator = GBFeatureEvaluator(
-            createEvaluationContext(), this.forcedFeatures,
-        )
-        return evaluator.evaluateFeature(
-            featureKey = id,
-            attributeOverrides = attributeOverrides,
-        )
+        val evalContext = createEvaluationContext()
+        val evaluator = GBFeatureEvaluator(evalContext, this.forcedFeatures)
+        val result = evaluator.evaluateFeature(featureKey = id, attributeOverrides = attributeOverrides)
+        gbContext.stickyBucketAssignmentDocs = evalContext.userContext.stickyBucketAssignmentDocs
+        return result
     }
 
     /**
@@ -317,13 +315,16 @@ class GrowthBookSDK(
      * The run method takes an Experiment object and returns an ExperimentResult
      */
     fun run(experiment: GBExperiment): GBExperimentResult {
+        val evalContext = createEvaluationContext()
         val evaluator = GBExperimentEvaluator(
-            createEvaluationContext()
+            evalContext
         )
         val result = evaluator.evaluateExperiment(
             experiment = experiment,
             attributeOverrides = attributeOverrides
         )
+
+        gbContext.stickyBucketAssignmentDocs = evalContext.userContext.stickyBucketAssignmentDocs
 
         fireSubscriptions(experiment, result)
         return result

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -37,6 +37,8 @@ import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBuckets
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.HiddenFromObjC
@@ -83,6 +85,9 @@ class GrowthBookSDK(
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,
         cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
+        coroutineScope = gbContext.stickyBucketService?.coroutineScope ?: CoroutineScope(
+            PlatformDependentIODispatcher + SupervisorJob()
+        )
     )
 
     init {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -84,10 +84,7 @@ class GrowthBookSDK(
         ),
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,
-        cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
-        coroutineScope = gbContext.stickyBucketService?.coroutineScope ?: CoroutineScope(
-            PlatformDependentIODispatcher + SupervisorJob()
-        )
+        cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}"
     )
 
     init {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -36,7 +36,7 @@ import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.StackContext
-import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBucketsSync
+import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBuckets
 import kotlinx.coroutines.launch
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.HiddenFromObjC
@@ -330,8 +330,11 @@ class GrowthBookSDK(
     }
 
     /**
-     * The setAttributes method replaces the Map of user attributes
-     * that are used to assign variations
+     * Replaces the Map of user attributes used to assign variations.
+     *
+     * Sticky bucket refresh runs in the background (fire-and-forget).
+     * If you use Sticky Bucketing and need to evaluate experiments immediately
+     * after setting attributes, use [setAttributesSync] instead.
      */
     fun setAttributes(attributes: Map<String, GBValue>) {
         gbContext.attributes = attributes
@@ -339,28 +342,25 @@ class GrowthBookSDK(
     }
 
     /**
-     * Synchronous version of setAttributes that waits for sticky buckets to load.
+     * Coroutine version of [setAttributes] that awaits sticky bucket refresh before returning.
      *
-     * Use this method when switching users, during login/logout, or any scenario
-     * where you need to ensure sticky bucket assignments are loaded before
-     * evaluating experiments.
+     * Note: despite the "Sync" suffix this is a suspend function — it does not block the thread.
+     * Use this when you use Sticky Bucketing and need to guarantee that assignments are loaded
+     * before evaluating experiments (e.g. after login or user switch).
      *
      * Example:
      * ```kotlin
      * lifecycleScope.launch {
      *     sdk.setAttributesSync(loginAttributes)
-     *     // Sticky buckets guaranteed to be loaded here
-     *     val result = sdk.feature("my-experiment")
+     *     val result = sdk.feature("my-experiment") // sticky buckets guaranteed
      * }
      * ```
-     *
-     * @param attributes The user attributes map
      */
     suspend fun setAttributesSync(attributes: Map<String, GBValue>) {
         gbContext.attributes = attributes
 
         if (gbContext.stickyBucketService != null) {
-            refreshStickyBucketsSync(
+            refreshStickyBuckets(
                 context = gbContext,
                 data = null,
                 attributeOverrides = attributeOverrides
@@ -369,8 +369,11 @@ class GrowthBookSDK(
     }
 
     /**
-     * The setAttributeOverrides method replaces the Map of user overrides attribute
-     * that are used for Sticky Bucketing
+     * Replaces the Map of attribute overrides used for Sticky Bucketing.
+     *
+     * Sticky bucket refresh runs in the background (fire-and-forget).
+     * If you need to guarantee assignments are loaded before evaluating experiments,
+     * use [setAttributeOverridesSync] instead.
      */
     fun setAttributeOverrides(overrides: Map<String, GBValue>) {
         attributeOverrides = overrides
@@ -381,15 +384,15 @@ class GrowthBookSDK(
     }
 
     /**
-     * Synchronous version of setAttributeOverrides that waits for sticky buckets to load.
+     * Coroutine version of [setAttributeOverrides] that awaits sticky bucket refresh before returning.
      *
-     * @param overrides The attribute overrides map
+     * Note: despite the "Sync" suffix this is a suspend function — it does not block the thread.
      */
     suspend fun setAttributeOverridesSync(overrides: Map<String, GBValue>) {
         attributeOverrides = overrides
 
         if (gbContext.stickyBucketService != null) {
-            refreshStickyBucketsSync(
+            refreshStickyBuckets(
                 context = gbContext,
                 data = null,
                 attributeOverrides = attributeOverrides
@@ -418,23 +421,36 @@ class GrowthBookSDK(
     }
 
     /**
-     * Delegate that call refresh Sticky Bucket Service
-     * after success fetched features
+     * Called after the full API payload is received, before features are applied to context.
+     * Awaits sticky bucket refresh so that context is consistent when featuresFetchedSuccessfully fires.
      */
-    override fun featuresAPIModelSuccessfully(model: FeaturesDataModel) {
-        refreshStickyBucketService(dataModel = model)
-    }
-
-    /**
-     * Method for update latest attributes
-     */
-    private fun refreshStickyBucketService(dataModel: FeaturesDataModel? = null) {
-        gbContext.stickyBucketService?.coroutineScope?.launch {
-            refreshStickyBucketsSync(
+    override suspend fun onPayloadReady(model: FeaturesDataModel) {
+        try {
+            refreshStickyBuckets(
                 context = gbContext,
-                data = dataModel,
+                data = model,
                 attributeOverrides = attributeOverrides
             )
+        } catch (e: Exception) {
+            if (gbContext.enableLogging) {
+                GB.error("GrowthBook: Failed to refresh sticky buckets on payload ready: ${e.message}", e)
+            }
+        }
+    }
+
+    private fun refreshStickyBucketService(dataModel: FeaturesDataModel? = null) {
+        gbContext.stickyBucketService?.coroutineScope?.launch {
+            try {
+                refreshStickyBuckets(
+                    context = gbContext,
+                    data = dataModel,
+                    attributeOverrides = attributeOverrides
+                )
+            } catch (e: Exception) {
+                if (gbContext.enableLogging) {
+                    GB.error("GrowthBook: Failed to refresh sticky bucket assignments: ${e.message}", e)
+                }
+            }
         }
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -289,7 +289,8 @@ class GrowthBookSDK(
         val evalContext = createEvaluationContext()
         val evaluator = GBFeatureEvaluator(evalContext, this.forcedFeatures)
         val result = evaluator.evaluateFeature(featureKey = id, attributeOverrides = attributeOverrides)
-        gbContext.stickyBucketAssignmentDocs = evalContext.userContext.stickyBucketAssignmentDocs
+        // Newly-generated sticky assignments are merged into the context per-key during evaluation
+        // (see EvaluationContext.onStickyAssignmentChanged) — no whole-map write-back needed here.
         return result
     }
 
@@ -343,7 +344,8 @@ class GrowthBookSDK(
             attributeOverrides = attributeOverrides
         )
 
-        gbContext.stickyBucketAssignmentDocs = evalContext.userContext.stickyBucketAssignmentDocs
+        // Newly-generated sticky assignments are merged into the context per-key during evaluation
+        // (see EvaluationContext.onStickyAssignmentChanged) — no whole-map write-back needed here.
 
         fireSubscriptions(experiment, result)
         return result
@@ -575,6 +577,12 @@ class GrowthBookSDK(
                     attributes = snapshot.attributes,
                     stickyBucketAssignmentDocs = snapshot.stickyBucketAssignmentDocs,
                 ),
+                // Merge each newly-generated sticky assignment back into the shared context by its
+                // single key, atomically — instead of writing the whole docs map back after
+                // evaluation (which could clobber a concurrent background refresh).
+                onStickyAssignmentChanged = { key, doc ->
+                    gbContext.mergeStickyAssignmentDoc(key, doc)
+                },
                 stackContext = StackContext(null, mutableSetOf())
             )
         }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -300,6 +300,13 @@ class GrowthBookSDK internal constructor(
      * If a call is in progress, it waits for the result. If network
      * call failed, it tries to call again.
      *
+     * Known limitation (remote-eval): the internal retry uses the coalesced GET refresh
+     * ([FeaturesViewModel.awaitRefresh]), not the remote-eval POST. In remote-eval mode, if this is
+     * called while the initial remote-eval POST is still in flight or has failed, the retry issues a
+     * plain GET, so a GET that lands first can momentarily surface non-personalized (unevaluated)
+     * feature definitions until the POST completes and overwrites them. Routing the retry through the
+     * remote-eval path is deferred to a later release.
+     *
      * @returns a [GBFeatureResult] object
      */
     suspend fun suspendFeature(id: String): GBFeatureResult {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -44,6 +44,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.HiddenFromObjC
+import kotlin.time.Duration.Companion.milliseconds
 
 typealias GBTrackingCallback = (GBExperiment, GBExperimentResult) -> Unit
 typealias GBFeatureUsageCallback = (featureKey: String, gbFeatureResult: GBFeatureResult) -> Unit
@@ -110,7 +111,7 @@ class GrowthBookSDK(
                 featuresViewModel.fetchFeatures()
             }
         }
-        gbContext.savedGroups = savedGroups
+        savedGroups?.let { gbContext.savedGroups = it }
         refreshStickyBucketService()
     }
 
@@ -284,15 +285,20 @@ class GrowthBookSDK(
             when (remoteSourceFeaturesFetchResult) {
                 FeaturesFetchResult.Success -> return feature(id)
 
-                FeaturesFetchResult.NoResultYet -> delay(TIME_FOR_CALL_WAIT_MILLIS)
+                FeaturesFetchResult.NoResultYet -> {
+                    delay(TIME_FOR_CALL_WAIT_MILLIS.milliseconds)
+                    featuresViewModel.awaitRefresh()
+                }
 
                 FeaturesFetchResult.Failed -> {
                     if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
                     featuresViewModel.awaitRefresh()
+
+                    if (remoteSourceFeaturesFetchResult != FeaturesFetchResult.Failed) continue
                     if (gbContext.enableLogging) {
                         GB.log("GrowthBookSDK: suspendFeature: retry attempt ${attempt + 1}/$MAX_RETRY_ATTEMPTS, waiting ${delaysMs}ms")
                     }
-                    delay(delaysMs)
+                    delay(delaysMs.milliseconds)
                     delaysMs = minOf(delaysMs * 2, MAX_RETRY_DELAY_MILLIS)
                     attempt++
                 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -359,8 +359,9 @@ class GrowthBookSDK(
      * after setting attributes, use [setAttributesSync] instead.
      */
     fun setAttributes(attributes: Map<String, GBValue>) {
-        gbContext.attributes = attributes
-        gbContext.stickyBucketAssignmentDocs = null
+        // Single atomic update so a concurrent feature()/run() never sees the new attributes paired
+        // with the previous user's stale sticky docs (the docs are repopulated by the refresh below).
+        gbContext.setAttributesClearingStickyDocs(attributes)
         refreshStickyBucketService()
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -40,6 +40,8 @@ import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBuckets
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.HiddenFromObjC
 
@@ -60,9 +62,12 @@ class GrowthBookSDK(
     features: GBFeatures? = null,
     savedGroups: Map<String, GBValue>? = null,
     cachingEnabled: Boolean,
+    // Dispatcher on which the fetched payload is processed (sticky-bucket refresh + feature
+    // application + refreshHandler invocation). Defaults to the platform IO dispatcher so that work
+    // runs on a defined background context rather than an arbitrary thread. Overridable (e.g. with a
+    // test dispatcher) so tests can drive the async pipeline deterministically.
+    coroutineContext: CoroutineContext = PlatformDependentIODispatcher,
 ) : FeaturesFlowDelegate {
-
-    private var savedGroups: Map<String, GBValue>? = emptyMap()
     private var forcedFeatures: Map<String, GBValue> = emptyMap()
     private var attributeOverrides: Map<String, GBValue> = emptyMap()
     private var remoteSourceFeaturesFetchResult: FeaturesFetchResult =
@@ -88,7 +93,8 @@ class GrowthBookSDK(
         ),
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,
-        cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}"
+        cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
+        coroutineContext = coroutineContext,
     )
 
     init {
@@ -98,7 +104,7 @@ class GrowthBookSDK(
         } else {
             refreshCache()
         }
-        this.savedGroups = savedGroups
+        gbContext.savedGroups = savedGroups
         refreshStickyBucketService()
     }
 
@@ -272,6 +278,12 @@ class GrowthBookSDK(
      * The feature method takes a single string argument,
      * which is the unique identifier for the feature and
      * @returns a [GBFeatureResult] object
+     *
+     * Best-effort, synchronous read of the currently loaded state: it evaluates against whatever
+     * features are in the context at call time. A remote payload is applied asynchronously (on the
+     * SDK's coroutineContext, IO by default), so a call made immediately after construction — before
+     * the first fetch completes — returns default/unknown values. To guarantee the fetched payload
+     * (and sticky-bucket assignments) are loaded before evaluating, use [suspendFeature] instead.
      */
     fun feature(id: String): GBFeatureResult {
         val evalContext = createEvaluationContext()
@@ -543,23 +555,28 @@ class GrowthBookSDK(
         private fun createEvaluationContext(
             gbContext: GBContext,
             gbExperimentHelper: GBExperimentHelper,
-        ) =
-            EvaluationContext(
+        ): EvaluationContext {
+            // One atomic read of the whole shared state: features, savedGroups, attributes and the
+            // sticky-bucket docs come from the SAME snapshot, so the evaluation can never observe a
+            // torn mix (e.g. new features with stale sticky docs).
+            val snapshot = gbContext.evalSnapshot()
+            return EvaluationContext(
                 enabled = gbContext.enabled,
-                features = gbContext.features,
-                savedGroups = gbContext.savedGroups,
+                features = snapshot.features,
+                savedGroups = snapshot.savedGroups,
                 gbExperimentHelper = gbExperimentHelper,
                 loggingEnabled = gbContext.enableLogging,
                 onFeatureUsage = gbContext.onFeatureUsage,
-                forcedVariations = gbContext.forcedVariations,
+                forcedVariations = snapshot.forcedVariations,
                 trackingCallback = gbContext.trackingCallback,
                 stickyBucketService = gbContext.stickyBucketService,
                 userContext = UserContext(
                     qaMode = gbContext.qaMode,
-                    attributes = gbContext.attributes,
-                    stickyBucketAssignmentDocs = gbContext.stickyBucketAssignmentDocs,
+                    attributes = snapshot.attributes,
+                    stickyBucketAssignmentDocs = snapshot.stickyBucketAssignmentDocs,
                 ),
                 stackContext = StackContext(null, mutableSetOf())
             )
+        }
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -155,6 +155,16 @@ class GrowthBookSDK(
     }
 
     /**
+     * Releases resources held by this SDK instance: stops any active SSE auto-refresh connection and
+     * cancels the background coroutine scope used to process fetched payloads. Call this when the
+     * instance is no longer needed (e.g. on logout, or before creating a replacement instance) to
+     * avoid leaking coroutines and threads. The instance must not be used after [close].
+     */
+    fun close() {
+        featuresViewModel.close()
+    }
+
+    /**
      * Get Cached Features
      */
     fun getFeatures(): GBFeatures {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -341,6 +341,7 @@ class GrowthBookSDK(
      */
     fun setAttributes(attributes: Map<String, GBValue>) {
         gbContext.attributes = attributes
+        gbContext.stickyBucketAssignmentDocs = null
         refreshStickyBucketService()
     }
 
@@ -381,6 +382,7 @@ class GrowthBookSDK(
     fun setAttributeOverrides(overrides: Map<String, GBValue>) {
         attributeOverrides = overrides
         if (gbContext.stickyBucketService != null) {
+            gbContext.stickyBucketAssignmentDocs = null
             refreshStickyBucketService()
         }
         refreshForRemoteEval()

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -37,11 +37,8 @@ import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBuckets
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.HiddenFromObjC
 import kotlin.time.Duration.Companion.milliseconds
@@ -55,7 +52,7 @@ typealias GBExperimentRunCallback = (GBExperiment, GBExperimentResult) -> Unit
  * that takes a Context object in the constructor.
  * It exposes two main methods: feature and run.
  */
-class GrowthBookSDK(
+class GrowthBookSDK internal constructor(
     private val gbContext: GBContext,
     gbOptions: GBOptions,
     private val refreshHandler: GBCacheRefreshHandler?,
@@ -63,13 +60,41 @@ class GrowthBookSDK(
     features: GBFeatures? = null,
     savedGroups: Map<String, GBValue>? = null,
     cachingEnabled: Boolean,
-    private val cacheMaxAge: Long? = null,
+    // Internal seam only: the public way to set a cache freshness window is
+    // GBSDKBuilder.setCacheMaxAge(). Adding these to the public constructor would break binary
+    // compatibility, so the public constructor below preserves the pre-7.3.0 signature and
+    // delegates here.
+    private val cacheMaxAge: Long?,
     // Dispatcher on which the fetched payload is processed (sticky-bucket refresh + feature
     // application + refreshHandler invocation). Defaults to the platform IO dispatcher so that work
     // runs on a defined background context rather than an arbitrary thread. Overridable (e.g. with a
     // test dispatcher) so tests can drive the async pipeline deterministically.
-    coroutineContext: CoroutineContext = PlatformDependentIODispatcher,
+    coroutineContext: CoroutineContext,
 ) : FeaturesFlowDelegate {
+
+    /**
+     * Public constructor, kept binary-compatible with pre-7.3.0 releases. To set a cache
+     * freshness window, use [com.sdk.growthbook.GBSDKBuilder.setCacheMaxAge] instead.
+     */
+    constructor(
+        gbContext: GBContext,
+        gbOptions: GBOptions,
+        refreshHandler: GBCacheRefreshHandler?,
+        networkDispatcher: NetworkDispatcher,
+        features: GBFeatures? = null,
+        savedGroups: Map<String, GBValue>? = null,
+        cachingEnabled: Boolean,
+    ) : this(
+        gbContext = gbContext,
+        gbOptions = gbOptions,
+        refreshHandler = refreshHandler,
+        networkDispatcher = networkDispatcher,
+        features = features,
+        savedGroups = savedGroups,
+        cachingEnabled = cachingEnabled,
+        cacheMaxAge = null,
+        coroutineContext = PlatformDependentIODispatcher,
+    )
     private var forcedFeatures: Map<String, GBValue> = emptyMap()
     private var attributeOverrides: Map<String, GBValue> = emptyMap()
     private var remoteSourceFeaturesFetchResult: FeaturesFetchResult =

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/EvaluationContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/EvaluationContext.kt
@@ -7,6 +7,8 @@ import com.sdk.growthbook.GBTrackingCallback
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.model.StickyBucketAssignmentDocsType
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
+import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
+import com.sdk.growthbook.utils.GBStickyAttributeKey
 
 internal data class EvaluationContext(
     val enabled: Boolean,
@@ -19,6 +21,11 @@ internal data class EvaluationContext(
     val gbExperimentHelper: GBExperimentHelper,
     val stickyBucketService: GBStickyBucketService?,
     val onFeatureUsage: ((String, GBFeatureResult) -> Unit)?,
+    // Invoked at the point a new sticky-bucket assignment doc is generated during evaluation, so the
+    // single changed key can be merged back into the shared context atomically (see
+    // GBContext.mergeStickyAssignmentDoc). Replaces the previous wholesale write-back of the whole
+    // docs map after evaluation, which could clobber a concurrent background refresh.
+    val onStickyAssignmentChanged: ((GBStickyAttributeKey, GBStickyAssignmentsDocument) -> Unit)? = null,
     val stackContext: StackContext
 )
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
@@ -9,6 +9,7 @@ import com.sdk.growthbook.model.GBFeatureSource
 import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.utils.GBUtils
 import com.sdk.growthbook.kotlinx.serialization.from
+import com.sdk.growthbook.utils.GBUtils.Companion.getAttributes
 import kotlinx.coroutines.launch
 
 /**
@@ -134,7 +135,7 @@ internal class GBExperimentEvaluator(
             if (experiment.filters != null) {
                 if (GBUtils.isFilteredOut(
                         filters = experiment.filters,
-                        attributeOverrides = evaluationContext.userContext.attributes,
+                        attributeOverrides = attributeOverrides,
                         evaluationContext = evaluationContext,
                     )
                 ) {
@@ -177,7 +178,10 @@ internal class GBExperimentEvaluator(
              * return immediately (not in experiment, variationId 0)
              */
             if (experiment.condition != null) {
-                val attr = evaluationContext.userContext.attributes
+                val attr = getAttributes(
+                    attributeOverrides = attributeOverrides,
+                    attributes = evaluationContext.userContext.attributes,
+                )
                 val conditionObj: GBJson = experiment.condition!!.let(GBValue::from) as? GBJson
                     ?: GBJson(emptyMap())
                 val evaluationResult = GBConditionEvaluator().evalCondition(
@@ -209,8 +213,7 @@ internal class GBExperimentEvaluator(
                     val parentResult = GBFeatureEvaluator(evaluationContext)
                         .evaluateFeature(
                             featureKey = parentCondition.id,
-                            attributeOverrides = parentCondition.condition
-                                .jsonObject.mapValues { GBValue.from(it.value) }
+                            attributeOverrides = attributeOverrides
                         )
                     if (parentResult.source == GBFeatureSource.cyclicPrerequisite) {
                         return getExperimentResult(

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
@@ -388,13 +388,19 @@ internal class GBExperimentEvaluator(
 
             if (changed) {
                 /**
-                 * update local docs
+                 * update local docs — keeps this evaluation pass consistent (e.g. nested /
+                 * prerequisite evaluations) before the shared context is updated
                  */
                 evaluationContext.userContext.stickyBucketAssignmentDocs =
                     (stickyBucketAssignmentDocs ?: emptyMap()).toMutableMap().apply {
                         this[key] = doc
                     }
-                
+
+                // Merge the single changed assignment back into the shared context atomically,
+                // so the next feature()/run() sees it without a whole-map write-back that could
+                // clobber a concurrent background refresh.
+                evaluationContext.onStickyAssignmentChanged?.invoke(key, doc)
+
                 // Save async to storage (fire and forget)
                 evaluationContext.stickyBucketService.coroutineScope.launch {
                     GBUtils.saveStickyBucketAssignment(

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
@@ -14,6 +14,7 @@ import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.utils.Constants
 import com.sdk.growthbook.utils.GBTrackData
 import com.sdk.growthbook.utils.GBUtils
+import com.sdk.growthbook.utils.GBUtils.Companion.getAttributes
 import com.sdk.growthbook.utils.GBUtils.Companion.toHashValue
 
 /**
@@ -149,7 +150,7 @@ internal class GBFeatureEvaluator(
                         if (GBUtils.isFilteredOut(
                                 filters = rule.filters,
                                 evaluationContext = evaluationContext,
-                                attributeOverrides = evaluationContext.userContext.attributes,
+                                attributeOverrides = attributeOverrides,
                             )
                         ) {
                             /**
@@ -240,7 +241,11 @@ internal class GBFeatureEvaluator(
                             if (rule.coverage != null) {
                                 val key = rule.hashAttribute ?: Constants.ID_ATTRIBUTE_KEY
                                 val attributeValue =
-                                    evaluationContext.userContext.attributes[key].toHashValue()
+                                    getAttributes(
+                                        attributeOverrides = attributeOverrides,
+                                        attributes = evaluationContext.userContext.attributes
+                                    )[key]
+                                        .toHashValue()
 
                                 if (attributeValue.isNullOrEmpty()) {
                                     continue@ruleLoop
@@ -377,15 +382,5 @@ internal class GBFeatureEvaluator(
         }
 
         return gbFeatureResult
-    }
-
-    /**
-     * The method that merge together attributes of Context and override attribute
-     */
-    private fun getAttributes(
-        attributes: Map<String, GBValue>, attributeOverrides: Map<String, GBValue>,
-    ): Map<String, GBValue> {
-        attributes.toMutableMap().putAll(attributeOverrides)
-        return attributes
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -1,5 +1,6 @@
 package com.sdk.growthbook.features
 
+import com.sdk.growthbook.PlatformDependentIODispatcher
 import com.sdk.growthbook.utils.Constants
 import com.sdk.growthbook.utils.DefaultCrypto
 import com.sdk.growthbook.utils.GBError
@@ -16,7 +17,7 @@ import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
@@ -43,7 +44,9 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
-    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
+    private val coroutineScope: CoroutineScope = CoroutineScope(
+        PlatformDependentIODispatcher + SupervisorJob()
+    )
 ) {
 
     /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -1,7 +1,7 @@
 package com.sdk.growthbook.features
 
-import com.sdk.growthbook.PlatformDependentIODispatcher
 import com.sdk.growthbook.utils.Constants
+import kotlin.coroutines.CoroutineContext
 import com.sdk.growthbook.utils.DefaultCrypto
 import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
@@ -17,9 +17,11 @@ import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -44,9 +46,7 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
-    private val coroutineScope: CoroutineScope = CoroutineScope(
-        PlatformDependentIODispatcher + SupervisorJob()
-    )
+    coroutineContext: CoroutineContext = Dispatchers.Unconfined,
 ) {
 
     /**
@@ -54,6 +54,8 @@ internal class FeaturesViewModel(
      */
     val sseController: SSEConnectionController
         get() = dataSource.sseController
+
+    private val coroutineScope: CoroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
 
     /**
      * Fetch Features

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -15,7 +15,10 @@ import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -23,7 +26,7 @@ import kotlinx.serialization.json.JsonObject
  */
 internal interface FeaturesFlowDelegate {
     fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean)
-    fun featuresAPIModelSuccessfully(model: FeaturesDataModel)
+    suspend fun onPayloadReady(model: FeaturesDataModel)
     fun featuresFetchFailed(error: GBError, isRemote: Boolean)
     fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean)
     fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean)
@@ -40,6 +43,7 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
 ) {
 
     /**
@@ -74,7 +78,9 @@ internal class FeaturesViewModel(
             dataSource.fetchRemoteEval(
                 params = payload,
                 success = { responseFeaturesDataModel ->
-                    prepareFeaturesDataForRemoteEval(responseFeaturesDataModel.data)
+                    coroutineScope.launch {
+                        prepareFeaturesDataForRemoteEval(responseFeaturesDataModel.data)
+                    }
                 },
                 failure = { error ->
                     this.delegate.featuresFetchFailed(GBError(error.exception), true)
@@ -83,7 +89,9 @@ internal class FeaturesViewModel(
         } else {
             dataSource.fetchFeatures(
                 success = { dataModel ->
-                    prepareFeaturesDataForRemoteEval(dataModel)
+                    coroutineScope.launch {
+                        prepareFeaturesDataForRemoteEval(dataModel)
+                    }
                 },
                 failure = { error ->
                     // Call Error Delegate with mention of data not available but its not remote
@@ -133,7 +141,9 @@ internal class FeaturesViewModel(
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
         sseController.start()
         return dataSource.autoRefresh(success = { dataModel ->
-            prepareFeaturesDataForRemoteEval(dataModel = dataModel)
+            coroutineScope.launch {
+                prepareFeaturesDataForRemoteEval(dataModel = dataModel)
+            }
         }, failure = { error ->
             // Call Error Delegate with mention of data not available but its not remote
             this.delegate.featuresFetchFailed(GBError(error), true)
@@ -141,9 +151,11 @@ internal class FeaturesViewModel(
     }
 
     /**
-     * Cache API Response and push success event
+     * Cache API Response and push success event.
+     * Awaits sticky bucket refresh before notifying delegate of ready features,
+     * mirroring TypeScript's setPayload: await refreshStickyBuckets → set features.
      */
-    private fun prepareFeaturesDataForRemoteEval(dataModel: FeaturesDataModel?) {
+    private suspend fun prepareFeaturesDataForRemoteEval(dataModel: FeaturesDataModel?) {
         var features = dataModel?.features
         var savedGroups = dataModel?.savedGroups
         val encryptedFeatures = dataModel?.encryptedFeatures
@@ -155,7 +167,10 @@ internal class FeaturesViewModel(
                     putDataToCache(dataModel)
                 }
 
-                delegate.featuresAPIModelSuccessfully(dataModel)
+                // Await sticky bucket refresh before setting features in context —
+                // same ordering as TypeScript setPayload.
+                delegate.onPayloadReady(dataModel)
+
                 if (!features.isNullOrEmpty()) {
                     this.delegate.featuresFetchedSuccessfully(
                         features = features,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.SupervisorJob
 import com.sdk.growthbook.logger.GB
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 
 /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -17,7 +17,6 @@ import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import com.sdk.growthbook.logger.GB
 import kotlinx.coroutines.flow.Flow
@@ -46,7 +45,7 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
-    coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    coroutineContext: CoroutineContext
 ) {
 
     /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -23,10 +23,18 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonObject
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+
+// Upper bound on a single network round in [FeaturesViewModel.runNetworkGet]. Both recommended
+// dispatchers (Ktor/OkHttp) default to an INFINITE read timeout so a server that accepts the
+// connection then never responds would otherwise leave awaitRefresh()/suspendFeature() hanging
+// forever. Kept dispatcher-agnostic here so custom NetworkDispatcher impls are bounded too.
+private const val NETWORK_ROUND_TIMEOUT_MILLIS = 30_000L
 
 /**
  * Interface for Feature API Completion Events
@@ -201,26 +209,34 @@ internal class FeaturesViewModel(
 
     /** Bridges the callback-based GET into a suspend result for [awaitRefresh]. */
     private suspend fun runNetworkGet(): FetchResult =
-        suspendCancellableCoroutine { cont ->
-            dataSource.fetchFeatures(
-                success = {
-                    // Resume only after the payload is fully applied (incl. the
-                    // suspend sticky-bucket refresh in onPayloadReady), so awaitRefresh()
-                    // callers observe a completed refresh, not just a completed HTTP round.
-                    coroutineScope.launch {
-                        handleNetworkModel(it)
-                        cont.resume(FetchResult.Success)
+        withTimeoutOrNull(NETWORK_ROUND_TIMEOUT_MILLIS.milliseconds) {
+            suspendCancellableCoroutine { cont ->
+                dataSource.fetchFeatures(
+                    success = {
+                        // Resume only after the payload is fully applied (incl. the
+                        // suspend sticky-bucket refresh in onPayloadReady), so awaitRefresh()
+                        // callers observe a completed refresh, not just a completed HTTP round.
+                        coroutineScope.launch {
+                            handleNetworkModel(it)
+                            cont.resume(FetchResult.Success)
+                        }
+                    },
+                    failure = {
+                        dispatch(FetchOutcome.Failed(GBError(it), source = Source.NETWORK))
+                        cont.resume(FetchResult.Failed)
+                    },
+                    onNotModified = {
+                        dispatch(FetchOutcome.NotModified)
+                        cont.resume(FetchResult.NotModified)
                     }
-                },
-                failure = {
-                    dispatch(FetchOutcome.Failed(GBError(it), source = Source.NETWORK))
-                    cont.resume(FetchResult.Failed)
-                },
-                onNotModified = {
-                    dispatch(FetchOutcome.NotModified)
-                    cont.resume(FetchResult.NotModified)
-                }
-            )
+                )
+            }
+        } ?: run {
+            // Timed out: the dispatcher accepted the request but never invoked any callback.
+            // Surface it as a network failure so remoteSourceFeaturesFetchResult leaves NoResultYet
+            // and suspendFeature()'s bounded-retry path can escape instead of hanging forever.
+            dispatch(FetchOutcome.Failed(GBError(Exception("Feature fetch timed out")), source = Source.NETWORK))
+            FetchResult.Failed
         }
 
     private fun serveCache(remoteEval: Boolean, policy: FetchPolicy): Boolean {
@@ -265,7 +281,20 @@ internal class FeaturesViewModel(
 
     private suspend fun handleNetworkModel(model: FeaturesDataModel) {
         try {
-            delegate.onPayloadReady(model)
+            // Decode/decrypt the payload BEFORE the sticky-bucket refresh, mirroring the reference
+            // TS SDK (decryptPayload -> refreshStickyBuckets). For an encrypted payload the raw
+            // model has features == null, so deriveStickyBucketIdentifierAttributes would fall back
+            // to the context features — empty on a cold start — and derive sticky identifiers from
+            // nothing, re-bucketing the user. Handing onPayloadReady the decoded payload fixes that.
+            val decoded = decoder.decode(model)
+            delegate.onPayloadReady(
+                model.copy(
+                    features = decoded.features,
+                    encryptedFeatures = null,
+                    savedGroups = decoded.savedGroups,
+                    encryptedSavedGroups = null,
+                )
+            )
             if (cachingEnabled) {
                 runCatching { writeCache(model) }
                     .onFailure {
@@ -278,7 +307,7 @@ internal class FeaturesViewModel(
 
             dispatch(
                 outcome = outcomeOf(
-                    payload = decoder.decode(model),
+                    payload = decoded,
                     source = Source.NETWORK
                 )
             )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -15,15 +15,16 @@ import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonObject
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.time.Clock
 
@@ -32,7 +33,7 @@ import kotlin.time.Clock
  */
 internal interface FeaturesFlowDelegate {
     fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean)
-    fun featuresAPIModelSuccessfully(model: FeaturesDataModel)
+    suspend fun onPayloadReady(model: FeaturesDataModel)
     fun featuresFetchFailed(error: GBError, isRemote: Boolean)
     fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean)
     fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean)
@@ -91,15 +92,15 @@ internal class FeaturesViewModel(
      */
     private val decoder: FeaturePayloadDecoder = FeaturePayloadDecoder(encryptionKey),
     /**
-     * Scope that owns the coalesced refresh started by [awaitRefresh] (used by
-     * suspendFeature() retries and [revalidate]). It must outlive any single
-     * caller, so cancelling one caller never tears down a refresh shared with
-     * others ([SupervisorJob] isolates failures too). Only lightweight coordination
-     * runs here (mutex bookkeeping, continuation resumption); the actual HTTP runs
-     * on the network dispatcher's own IO scope. Injectable so tests can supply a
+     * Context on which fetched payloads are processed (decode + sticky-bucket
+     * refresh + feature application) and on which the coalesced refresh started by
+     * [awaitRefresh] (used by suspendFeature() retries and [revalidate]) runs. It
+     * must outlive any single caller, so cancelling one caller never tears down a
+     * refresh shared with others; it is wrapped in a [SupervisorJob] so one failed
+     * refresh never tears down the shared scope. Injectable so tests can supply a
      * deterministic dispatcher.
      */
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    coroutineContext: CoroutineContext
 ) {
 
     /**
@@ -107,6 +108,8 @@ internal class FeaturesViewModel(
      */
     val sseController: SSEConnectionController
         get() = dataSource.sseController
+
+    private val coroutineScope: CoroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
 
     /**
      * Guards reads and writes of [inFlight] so the check-or-start decision in
@@ -127,7 +130,7 @@ internal class FeaturesViewModel(
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
         sseController.start()
         return dataSource.autoRefresh(
-            success = { handleNetworkModel(it) },
+            success = { coroutineScope.launch { handleNetworkModel(it) } },
             failure = { delegate.featuresFetchFailed(GBError(it), isRemote = true) }
         )
     }
@@ -160,7 +163,7 @@ internal class FeaturesViewModel(
      */
     suspend fun awaitRefresh(): FetchResult {
         val deferred = refreshMutex.withLock {
-            inFlight ?: scope.async {
+            inFlight ?: coroutineScope.async {
                 try {
                     runNetworkGet()
                 } finally {
@@ -178,12 +181,22 @@ internal class FeaturesViewModel(
      * of starting a duplicate request. Always bypasses cache freshness (see
      * [FetchPolicy.ForceNetwork]).
      *
-     * Fire-and-forget: the network round runs on [scope]; observe completion via
-     * the refresh handler rather than expecting features to be ready on return.
+     * Fire-and-forget: the network round runs on [coroutineScope]; observe completion
+     * via the refresh handler rather than expecting features to be ready on return.
      */
     fun revalidate() {
         serveCache(remoteEval = false, policy = FetchPolicy.ForceNetwork)
-        scope.launch { awaitRefresh() }
+        coroutineScope.launch { awaitRefresh() }
+    }
+
+    /**
+     * Releases resources held by this view model: stops any active SSE connection and cancels the
+     * coroutine scope used to process fetched payloads, so in-flight background work does not outlive
+     * the owning SDK instance. Safe to call more than once.
+     */
+    fun close() {
+        sseController.stop()
+        coroutineScope.cancel()
     }
 
     /** Bridges the callback-based GET into a suspend result for [awaitRefresh]. */
@@ -191,8 +204,13 @@ internal class FeaturesViewModel(
         suspendCancellableCoroutine { cont ->
             dataSource.fetchFeatures(
                 success = {
-                    handleNetworkModel(it)
-                    cont.resume(FetchResult.Success)
+                    // Resume only after the payload is fully applied (incl. the
+                    // suspend sticky-bucket refresh in onPayloadReady), so awaitRefresh()
+                    // callers observe a completed refresh, not just a completed HTTP round.
+                    coroutineScope.launch {
+                        handleNetworkModel(it)
+                        cont.resume(FetchResult.Success)
+                    }
                 },
                 failure = {
                     dispatch(FetchOutcome.Failed(GBError(it), source = Source.NETWORK))
@@ -230,7 +248,7 @@ internal class FeaturesViewModel(
     private fun fetchFromNetwork(remoteEval: Boolean, payload: GBRemoteEvalParams?) {
         if (remoteEval) dataSource.fetchRemoteEval(
             params = payload,
-            success = { handleNetworkModel(it.data) },
+            success = { coroutineScope.launch { handleNetworkModel(it.data) }},
             failure = {
                 delegate.featuresFetchFailed(
                     error = GBError(it.exception),
@@ -238,15 +256,15 @@ internal class FeaturesViewModel(
                 )
             }
         ) else dataSource.fetchFeatures(
-            success = { handleNetworkModel(it) },
+            success = { coroutineScope.launch { handleNetworkModel(it) } },
             failure = { delegate.featuresFetchFailed(error = GBError(it), isRemote = true) },
             onNotModified = { dispatch(outcome = FetchOutcome.NotModified) }
         )
     }
 
-    private fun handleNetworkModel(model: FeaturesDataModel) {
+    private suspend fun handleNetworkModel(model: FeaturesDataModel) {
         try {
-            delegate.featuresAPIModelSuccessfully(model)
+            delegate.onPayloadReady(model)
             if (cachingEnabled) {
                 runCatching { writeCache(model) }
                     .onFailure {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -235,14 +235,15 @@ internal class FeaturesViewModel(
             && cachedAt != null
             && Clock.System.now().toEpochMilliseconds() - cachedAt < cacheMaxAge
 
-        dispatch(
-            outcome = FetchOutcome.Ready(
-                payload = decoder.decode(m = model),
-                source = Source.CACHE,
-                authoritative = fresh
-            )
-        )
-        return fresh
+        val outcome = outcomeOf(payload = decoder.decode(m = model), source = Source.CACHE, authoritative = fresh)
+        dispatch(outcome = outcome)
+
+        // Only treat the cache as authoritative (and skip the network) when it actually
+        // yielded a usable payload. A fresh-but-undecodable/empty cache degrades to
+        // FetchOutcome.Failed above (both features and savedGroups null) — returning false
+        // then lets fetchFeatures() fall through to the network instead of silently serving
+        // nothing for the whole freshness window.
+        return fresh && outcome is FetchOutcome.Ready
     }
 
     private fun fetchFromNetwork(remoteEval: Boolean, payload: GBRemoteEvalParams?) {
@@ -291,10 +292,10 @@ internal class FeaturesViewModel(
         }
     }
 
-    private fun outcomeOf(payload: DecodedPayload, source: Source): FetchOutcome =
+    private fun outcomeOf(payload: DecodedPayload, source: Source, authoritative: Boolean = true): FetchOutcome =
         if (payload.features == null && payload.savedGroups == null)
             FetchOutcome.Failed(GBError(Exception()), source)
-        else FetchOutcome.Ready(payload, source, authoritative = true)
+        else FetchOutcome.Ready(payload, source, authoritative = authoritative)
 
     private fun dispatch(outcome: FetchOutcome) = when (outcome) {
         is FetchOutcome.Ready -> {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -18,6 +18,7 @@ import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import com.sdk.growthbook.logger.GB
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -137,6 +138,16 @@ internal class FeaturesViewModel(
             SerializableFeaturesDataModel.serializer()
         )
         return dataModel?.gbDeserialize()
+    }
+
+    /**
+     * Releases resources held by this view model: stops any active SSE connection and cancels the
+     * coroutine scope used to process fetched payloads, so in-flight background work does not outlive
+     * the owning SDK instance. Safe to call more than once.
+     */
+    fun close() {
+        sseController.stop()
+        coroutineScope.cancel()
     }
 
     /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -155,6 +155,23 @@ class GBContext(
         set(value) = mutate { it.copy(stickyBucketAssignmentDocs = value) }
 
     /**
+     * Atomically merge a single freshly-generated sticky-bucket assignment doc into the current
+     * docs, keyed by its attribute. Unlike assigning [stickyBucketAssignmentDocs] wholesale, this
+     * only adds/replaces the one [key], so it composes with a concurrent background refresh that
+     * replaces the whole map: the CAS loop re-reads the latest state, so neither write clobbers the
+     * other's unrelated keys. Mirrors the TypeScript SDK, which mutates the live docs object by a
+     * single key at the point of generation.
+     */
+    internal fun mergeStickyAssignmentDoc(
+        key: GBStickyAttributeKey,
+        doc: GBStickyAssignmentsDocument,
+    ) = mutate {
+        it.copy(
+            stickyBucketAssignmentDocs = (it.stickyBucketAssignmentDocs ?: emptyMap()) + (key to doc)
+        )
+    }
+
+    /**
      * List of user's attributes keys
      */
     var stickyBucketIdentifierAttributes: List<String>?

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package com.sdk.growthbook.model
 
 import com.sdk.growthbook.GBTrackingCallback
@@ -5,14 +7,39 @@ import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
 import com.sdk.growthbook.utils.GBStickyAttributeKey
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 internal typealias FeatureUsageFuncCallback = (String, GBFeatureResult) -> Unit
 internal typealias StickyBucketAssignmentDocsType = Map<GBStickyAttributeKey, GBStickyAssignmentsDocument>
 
 /**
- * Defines the GrowthBook context.
+ * Immutable snapshot of the evaluation-input state shared across threads.
+ *
+ * These fields are written by the background payload pipeline (network fetch + sticky-bucket refresh)
+ * and read synchronously by feature()/run(). They are published together as a single immutable value
+ * behind an AtomicReference, so any reader observes a fully consistent set — there is no window where,
+ * e.g., new [features] are visible while [stickyBucketAssignmentDocs] are still stale.
  */
-data class GBContext(
+internal data class EvalSnapshot(
+    val features: GBFeatures = HashMap(),
+    val attributes: Map<String, GBValue> = emptyMap(),
+    val forcedVariations: Map<String, Number> = emptyMap(),
+    val stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
+    val stickyBucketIdentifierAttributes: List<String>? = null,
+    val savedGroups: Map<String, GBValue>? = null,
+)
+
+/**
+ * Defines the GrowthBook context.
+ *
+ * The cross-thread-shared evaluation inputs (features, attributes, forced variations, sticky-bucket
+ * state, saved groups) are kept in a single [EvalSnapshot] behind an [AtomicReference]. Reads return
+ * the current snapshot; writes atomically swap in a copy with the changed field (CAS loop, so
+ * concurrent writers never lose each other's updates). For a consistent multi-field read during
+ * evaluation, use [evalSnapshot] rather than reading the individual properties one by one.
+ */
+class GBContext(
 
     /**
      * Registered API Key for GrowthBook SDK
@@ -32,22 +59,22 @@ data class GBContext(
     /**
      * Map of user attributes that are used to assign variations
      */
-    internal var attributes: Map<String, GBValue>,
+    attributes: Map<String, GBValue>,
 
     /**
      * Force specific experiments to always assign a specific variation (used for QA)
      */
-    var forcedVariations: Map<String, Number>,
+    forcedVariations: Map<String, Number>,
 
     /**
      * Map of Sticky Bucket documents
      */
-    var stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
+    stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
 
     /**
      * List of user's attributes keys
      */
-    var stickyBucketIdentifierAttributes: List<String>? = null,
+    stickyBucketIdentifierAttributes: List<String>? = null,
 
     /**
      * Service that provide functionality of Sticky Bucketing
@@ -79,12 +106,73 @@ data class GBContext(
      */
     val enableLogging: Boolean = false,
 
-    var savedGroups: Map<String, GBValue>? = null
+    savedGroups: Map<String, GBValue>? = null,
 ) {
 
+    // Single source of truth for all cross-thread-shared evaluation inputs.
+    private val state = AtomicReference(
+        EvalSnapshot(
+            attributes = attributes,
+            forcedVariations = forcedVariations,
+            stickyBucketAssignmentDocs = stickyBucketAssignmentDocs,
+            stickyBucketIdentifierAttributes = stickyBucketIdentifierAttributes,
+            savedGroups = savedGroups,
+        )
+    )
+
+    /**
+     * Atomically read the full evaluation-input snapshot. Evaluation must use this (one read) instead
+     * of reading the individual properties separately, so it operates on a single consistent state.
+     */
+    internal fun evalSnapshot(): EvalSnapshot = state.load()
+
+    private fun mutate(transform: (EvalSnapshot) -> EvalSnapshot) {
+        while (true) {
+            val current = state.load()
+            if (state.compareAndSet(current, transform(current))) return
+        }
+    }
+
+    /**
+     * Map of user attributes that are used to assign variations
+     */
+    internal var attributes: Map<String, GBValue>
+        get() = state.load().attributes
+        set(value) = mutate { it.copy(attributes = value) }
+
+    /**
+     * Force specific experiments to always assign a specific variation (used for QA)
+     */
+    var forcedVariations: Map<String, Number>
+        get() = state.load().forcedVariations
+        set(value) = mutate { it.copy(forcedVariations = value) }
+
+    /**
+     * Map of Sticky Bucket documents
+     */
+    var stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType?
+        get() = state.load().stickyBucketAssignmentDocs
+        set(value) = mutate { it.copy(stickyBucketAssignmentDocs = value) }
+
+    /**
+     * List of user's attributes keys
+     */
+    var stickyBucketIdentifierAttributes: List<String>?
+        get() = state.load().stickyBucketIdentifierAttributes
+        set(value) = mutate { it.copy(stickyBucketIdentifierAttributes = value) }
+
+    /**
+     * Saved groups used by feature/experiment conditions
+     */
+    var savedGroups: Map<String, GBValue>?
+        get() = state.load().savedGroups
+        set(value) = mutate { it.copy(savedGroups = value) }
+
     // Keys are unique identifiers for the features and the values are Feature objects.
-    // Feature definitions - To be pulled from API / Cache
-    internal var features: GBFeatures = HashMap()
+    // Feature definitions - To be pulled from API / Cache.
+    internal var features: GBFeatures
+        get() = state.load().features
+        set(value) = mutate { it.copy(features = value) }
 }
 
 /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -172,6 +172,15 @@ class GBContext(
     }
 
     /**
+     * Atomically replace the user [attributes] and clear the sticky-bucket docs in a single update.
+     * Done as one swap (not two separate writes) so a concurrent reader never observes the new
+     * attributes paired with the previous user's stale sticky docs.
+     */
+    internal fun setAttributesClearingStickyDocs(attributes: Map<String, GBValue>) = mutate {
+        it.copy(attributes = attributes, stickyBucketAssignmentDocs = null)
+    }
+
+    /**
      * List of user's attributes keys
      */
     var stickyBucketIdentifierAttributes: List<String>?

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/stickybucket/GBStickyBucketServiceImp.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/stickybucket/GBStickyBucketServiceImp.kt
@@ -1,8 +1,10 @@
 package com.sdk.growthbook.stickybucket
 
+import com.sdk.growthbook.PlatformDependentIODispatcher
 import kotlinx.coroutines.CoroutineScope
 import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
 import com.sdk.growthbook.sandbox.CachingLayer
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -23,17 +25,17 @@ internal class GBStickyBucketServiceImp(
     ): GBStickyAssignmentsDocument? {
         val key = "$attributeName||$attributeValue"
 
-        localStorage?.let { localStorage ->
-            localStorage.getContent("$prefix$key")?.let { data ->
-                return try {
-                    Json.decodeFromJsonElement<GBStickyAssignmentsDocument>(data)
-                } catch (e: Exception) {
-                    null
+        return withContext(PlatformDependentIODispatcher) {
+            localStorage?.let { localStorage ->
+                localStorage.getContent("$prefix$key")?.let { data ->
+                    try {
+                        Json.decodeFromJsonElement<GBStickyAssignmentsDocument>(data)
+                    } catch (e: Exception) {
+                        null
+                    }
                 }
             }
         }
-
-        return null
     }
 
     /**
@@ -42,13 +44,15 @@ internal class GBStickyBucketServiceImp(
     override suspend fun saveAssignments(doc: GBStickyAssignmentsDocument) {
         val key = "${doc.attributeName}||${doc.attributeValue}"
 
-        localStorage?.let { localStorage ->
-            try {
-                val docDataString = Json.encodeToString(doc)
-                val jsonElement: JsonElement = Json.parseToJsonElement(docDataString)
-                localStorage.saveContent("$prefix$key", jsonElement)
-            } catch (e: Exception) {
-                // Handle JSON serialization error
+        withContext(PlatformDependentIODispatcher) {
+            localStorage?.let { localStorage ->
+                try {
+                    val docDataString = Json.encodeToString(doc)
+                    val jsonElement: JsonElement = Json.parseToJsonElement(docDataString)
+                    localStorage.saveContent("$prefix$key", jsonElement)
+                } catch (e: Exception) {
+                    // Handle JSON serialization error
+                }
             }
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -338,29 +338,6 @@ internal class GBUtils {
             }
         }
 
-        /**
-         * Method that get cached assignments
-         * and set it to Context's Sticky Bucket Assignments documents
-         */
-        fun refreshStickyBuckets(
-            context: GBContext,
-            data: FeaturesDataModel?,
-            attributeOverrides: Map<String, GBValue>
-        ) {
-            val stickyBucketService = context.stickyBucketService ?: return
-
-            stickyBucketService.coroutineScope.launch {
-                try {
-                    refreshStickyBucketsSync(context, data, attributeOverrides)
-                } catch (e: Exception) {
-                    if (context.enableLogging) {
-                        GB.error("GrowthBook: Failed to refresh sticky bucket assignments: ${e.message}", e)
-                    }
-                }
-
-            }
-        }
-
         suspend fun saveStickyBucketAssignment(
             stickyBucketService: GBStickyBucketService,
             doc: GBStickyAssignmentsDocument
@@ -371,11 +348,10 @@ internal class GBUtils {
         }
 
         /**
-         * Synchronous method that get cached assignments
-         * and set it to Context's Sticky Bucket Assignments documents that waits for completion.
-         * Use this when you need guarantees that sticky buckets are loaded.
+         * Fetches all sticky bucket assignments for the current user and stores them in context.
+         * Awaits completion — callers in a suspend context get the guarantee that docs are ready.
          */
-        suspend fun refreshStickyBucketsSync(
+        suspend fun refreshStickyBuckets(
             context: GBContext,
             data: FeaturesDataModel?,
             attributeOverrides: Map<String, GBValue>
@@ -388,7 +364,6 @@ internal class GBUtils {
                 attributeOverrides = attributeOverrides
             )
 
-            // Directly call and wait for completion
             stickyBucketMutex.withLock {
                 context.stickyBucketAssignmentDocs =
                     stickyBucketService.getAllAssignments(attributes)
@@ -469,37 +444,14 @@ internal class GBUtils {
             val hashKey = "$hashAttribute||$hashValue"
 
             val (fallbackAttribute, fallbackValue) = getHashAttribute(
-                attr = null,
-                fallback = expFallBackAttribute,
+                attr = expFallBackAttribute,
+                fallback = null,
                 attributes = attributes,
                 attributeOverrides = attributeOverrides
             )
 
             val fallbackKey = if (fallbackValue.isEmpty()) null
             else "$fallbackAttribute||$fallbackValue"
-
-            val userFallbackAttribute = userContext.attributes[expFallBackAttribute]
-            if (userFallbackAttribute != null) {
-                val leftOperand =
-                    if (stickyBucketAssignmentDocs[expFallBackAttribute + "||" + userFallbackAttribute.toHashValue()] == null
-                    ) {
-                        null
-                    } else {
-                        stickyBucketAssignmentDocs[expFallBackAttribute + "||" + userFallbackAttribute.toHashValue()]?.attributeValue
-                    }
-
-                if (leftOperand != userFallbackAttribute.toHashValue()) {
-                    userContext.stickyBucketAssignmentDocs = emptyMap()
-                }
-            }
-
-            if (userContext.stickyBucketAssignmentDocs != null) {
-                userContext.stickyBucketAssignmentDocs!!.values.forEach { docs ->
-                    mergedAssignments.putAll(
-                        docs.assignments
-                    )
-                }
-            }
 
             fallbackKey?.let { fallback ->
                 stickyBucketAssignmentDocs[fallback]?.let { fallbackAssignments ->

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -273,9 +273,12 @@ internal class GBUtils {
             return filters.any { filter: GBFilter ->
                 val hashAttribute: String = filter.attribute ?: "id"
 
-                val hashValueElement: GBValue =
-                    evaluationContext.userContext
-                        .attributes.getValue(hashAttribute)
+                val merged = getAttributes(
+                    evaluationContext.userContext.attributes,
+                    attributeOverrides
+                )
+
+                val hashValueElement: GBValue = merged.getValue(hashAttribute)
 
                 if (hashValueElement is GBValue.Unknown) return@any true
                 if (hashValueElement.gbSerialize() !is JsonPrimitive) return@any true
@@ -298,6 +301,15 @@ internal class GBUtils {
                     )
                 }
             }
+        }
+
+        /**
+         * The method that merge together attributes of Context and override attribute
+         */
+        fun getAttributes(
+            attributes: Map<String, GBValue>, attributeOverrides: Map<String, GBValue>,
+        ): Map<String, GBValue> {
+            return attributes + attributeOverrides
         }
 
         /**

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/IntegrationTestTools.kt
@@ -6,8 +6,10 @@ import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.tests.MockNetworkClient
 import com.sdk.growthbook.network.NetworkDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
-internal fun buildSDK(
+internal fun TestScope.buildSDK(
     json: String,
     attributes: Map<String, GBValue> = emptyMap(),
     networkDispatcher: NetworkDispatcher = MockNetworkClient(
@@ -23,5 +25,9 @@ internal fun buildSDK(
         encryptionKey = "",
         trackingCallback = trackingCallback,
         networkDispatcher = networkDispatcher,
-    ).initialize()
+    )
+        // Synchronous mock network + Unconfined => payload is applied inline, so feature() reads
+        // right after initialize() are deterministic. Production uses PlatformDependentIODispatcher.
+        .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+        .initialize()
 }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/IntegrationTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/IntegrationTests.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.intellij.lang.annotations.Language
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.tests.MockNetworkClient
@@ -15,7 +16,7 @@ import com.sdk.growthbook.utils.SSEConnectionController
 class IntegrationTests {
 
     @Test
-    fun verifyIsInTheListRule() {
+    fun verifyIsInTheListRule() = runTest {
         // User attributes for targeting and assigning users to experiment variations
         val attrs = HashMap<String, GBValue>()
         attrs["appBuildNumber"] = 3432.toGbNumber()
@@ -53,7 +54,7 @@ class IntegrationTests {
     }
 
     @Test
-    fun `gBExperimentResult name should not be null`() {
+    fun `gBExperimentResult name should not be null`() = runTest {
         @Language("json")
         val json = """
 {
@@ -101,16 +102,16 @@ class IntegrationTests {
     }
 
     @Test
-    fun `autoRefreshFeatures() method usage example`() {
+    fun `autoRefreshFeatures() method usage example`() = runTest {
         val growthBookSdk = buildSDK("")
 
         growthBookSdk
-            .autoRefreshFeatures()
+            .startAutoRefreshFeatures()
             .launchIn(TestScope())
     }
 
     @Test
-    fun `autoRefreshFeatures() method triggers consumeSSEConnection()`() {
+    fun `autoRefreshFeatures() method triggers consumeSSEConnection()`() = runTest {
         var wasMethodCalled = false
 
         val networkDispatcher = object: MockNetworkClient("", null) {
@@ -126,7 +127,7 @@ class IntegrationTests {
             networkDispatcher = networkDispatcher,
         )
 
-        growthBookSdk.autoRefreshFeatures()
+        growthBookSdk.startAutoRefreshFeatures()
 
         assertTrue(wasMethodCalled)
     }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -160,7 +160,7 @@ internal class VerifySDKReturnFeatureValues {
     }
 
     @Test
-    fun `if features fetch fails, suspendFeature() method calls fetchFeature() again`() = runTest {
+    fun `if features fetch fails, suspendFeature() method retries via awaitRefresh()`() = runTest {
         val gbSdk = buildSDK(json = "{}", attributes = emptyMap()) // buildSDK() calls refreshCache(),
         // refreshCache() calls fetchFeature()
         // fetchFeature() triggers featuresFetchFailed()
@@ -182,7 +182,7 @@ internal class VerifySDKReturnFeatureValues {
         job.cancel()
         // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
 
-        coVerify { mockedFeaturesViewModel.fetchFeatures() }
+        coVerify { mockedFeaturesViewModel.awaitRefresh() }
     }
 
 /*

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -25,7 +25,7 @@ import com.sdk.growthbook.kotlinx.serialization.gbSerialize
 internal class VerifySDKReturnFeatureValues {
 
     @Test
-    fun verifySDKReturnFeatureDefaultValue() {
+    fun verifySDKReturnFeatureDefaultValue() = runTest {
         @Language("json")
         val json = """
             {
@@ -63,7 +63,7 @@ internal class VerifySDKReturnFeatureValues {
     }
 
     @Test
-    fun verifySDKReturnFeatureValueByConditionIfAttributeDoesNotExist() {
+    fun verifySDKReturnFeatureValueByConditionIfAttributeDoesNotExist() = runTest {
         @Language("json")
         val json = """
             {
@@ -102,7 +102,7 @@ internal class VerifySDKReturnFeatureValues {
     }
 
     @Test
-    fun verifySDKAttributesCastingTypes() {
+    fun verifySDKAttributesCastingTypes() = runTest {
         @Language("json")
         val json = """
 {
@@ -159,7 +159,7 @@ internal class VerifySDKReturnFeatureValues {
     }
 
     @Test
-    fun `if features fetch fails, suspendFeature() method calls fetchFeature() again`() {
+    fun `if features fetch fails, suspendFeature() method calls fetchFeature() again`() = runTest {
         val gbSdk = buildSDK(json = "{}", attributes = emptyMap()) // buildSDK() calls refreshCache(),
         // refreshCache() calls fetchFeature()
         // fetchFeature() triggers featuresFetchFailed()
@@ -169,21 +169,19 @@ internal class VerifySDKReturnFeatureValues {
         }
         gbSdk.featuresViewModel = mockedFeaturesViewModel
 
-        runTest {
-            val job = launch {
-                gbSdk.suspendFeature("some-feature-id")
-            }
-
-            // it is not mandatory here but just to emphasize that
-            // if call failed, then suspendFeature() method calls fetchFeatures()
-            gbSdk.featuresFetchFailed(GBError(null), true)
-
-            delay(100) // cancel only after 100 millis of waiting
-            job.cancel()
-            // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
-
-            coVerify { mockedFeaturesViewModel.fetchFeatures() }
+        val job = launch {
+            gbSdk.suspendFeature("some-feature-id")
         }
+
+        // it is not mandatory here but just to emphasize that
+        // if call failed, then suspendFeature() method calls fetchFeatures()
+        gbSdk.featuresFetchFailed(GBError(null), true)
+
+        delay(100) // cancel only after 100 millis of waiting
+        job.cancel()
+        // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
+
+        coVerify { mockedFeaturesViewModel.fetchFeatures() }
     }
 
 /*

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -10,6 +10,7 @@ import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
+import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -49,6 +50,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 testGbOptions
             ),
             "3tfeoyW0wlo47bDnbWDkxg==", false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -71,6 +73,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 gbContext, testGbOptions,
             ),
             "3tfeoyW0wlo47bDnbWDkxg==", false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -94,6 +97,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 gbContext, testGbOptions,
             ),
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -118,6 +122,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             encryptionKey = "",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
         viewModel.fetchFeatures()
 
@@ -143,6 +148,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
         val forcedVariation = mapOf("feature" to 123)
@@ -176,6 +182,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
         val forcedVariation = mapOf("feature" to 123)
@@ -206,6 +213,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 gbContext, testGbOptions,
             ),
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -228,6 +236,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = true,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -249,6 +258,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -269,6 +279,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             encryptionKey = "",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -289,6 +300,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             encryptionKey = "",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -310,6 +322,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -335,6 +348,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -358,6 +372,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             cachingEnabled = false,
             cachingLayer = cacheLayer,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         viewModel.fetchFeatures()
@@ -380,6 +395,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            coroutineContext = Dispatchers.Unconfined,
         )
 
         val flow = viewModel.autoRefreshFeatures()

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -415,7 +415,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         isError = false
     }
 
-    override fun featuresAPIModelSuccessfully(model: FeaturesDataModel) {
+    override suspend fun onPayloadReady(model: FeaturesDataModel) {
         isSuccess = true
         isError = false
         hasFeatures = !model.features.isNullOrEmpty()

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -444,7 +444,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testSkipsNetworkWhenCacheIsFresh() {
+    fun testSkipsNetworkWhenCacheIsFresh() =runTest {
         var networkCallCount = 0
         val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
             override fun consumeGETRequestWithNotModified(
@@ -462,12 +462,13 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             cachedAt = Clock.System.now().toEpochMilliseconds()
         )
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
             cacheMaxAge = 48 * 60 * 60 * 1000L,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler)
         )
 
         viewModel.fetchFeatures()
@@ -476,7 +477,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testFetchesNetworkWhenCacheIsStale() {
+    fun testFetchesNetworkWhenCacheIsStale() = runTest {
         var networkCallCount = 0
         val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
             override fun consumeGETRequestWithNotModified(
@@ -495,12 +496,13 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             cachedAt = staleTime
         )
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
             cacheMaxAge = 48 * 60 * 60 * 1000L,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler)
         )
 
         viewModel.fetchFeatures()
@@ -532,7 +534,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
-            scope = backgroundScope,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler)
         )
 
         // Five callers race into awaitRefresh() while no request has completed yet.

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -10,9 +10,14 @@ import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
-import kotlinx.coroutines.Dispatchers
+import com.sdk.growthbook.model.GBString
+import com.sdk.growthbook.stickybucket.GBStickyBucketService
+import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
+import com.sdk.growthbook.utils.GBUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -45,18 +50,18 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     private val testGbOptions = GBOptions("https://example.com", null)
 
     @Test
-    fun testSuccess() {
+    fun testSuccess() = runTest {
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            this,
+            this@FeaturesViewModelTests,
             FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext,
                 testGbOptions
             ),
             "3tfeoyW0wlo47bDnbWDkxg==", false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -67,11 +72,11 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testSuccessForEncryptedFeatures() {
+    fun testSuccessForEncryptedFeatures() = runTest {
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            this,
+            this@FeaturesViewModelTests,
             FeaturesDataSource(
                 MockNetworkClient(
                     MockResponse.successResponseEncryptedFeatures, null
@@ -79,7 +84,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 gbContext, testGbOptions,
             ),
             "3tfeoyW0wlo47bDnbWDkxg==", false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -90,12 +95,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testError() {
+    fun testError() = runTest {
 
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(
                     null, Throwable("UNKNOWN", null)
@@ -103,7 +108,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 gbContext, testGbOptions,
             ),
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -114,12 +119,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testInvalid() {
+    fun testInvalid() = runTest {
 
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(
                     MockResponse.ERROR_RESPONSE, null
@@ -128,7 +133,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             encryptionKey = "",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
         viewModel.fetchFeatures()
 
@@ -138,12 +143,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testForRemoteEvalSuccess() {
+    fun testForRemoteEvalSuccess() = runTest {
         isSuccess = false
         isError = true
 
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource =
                 FeaturesDataSource(
                     dispatcher = MockNetworkClient(
@@ -154,7 +159,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
         val forcedVariation = mapOf("feature" to 123)
@@ -172,12 +177,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testForRemoteEvalFailed() {
+    fun testForRemoteEvalFailed() = runTest {
         isSuccess = false
         isError = true
 
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource =
                 FeaturesDataSource(
                     dispatcher = MockNetworkClient(
@@ -188,7 +193,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
         val forcedVariation = mapOf("feature" to 123)
@@ -207,19 +212,19 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testNotModified() {
+    fun testNotModified() = runTest {
         isSuccess = false
         isError = false
         isNotModified = false
 
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(successResponse = null, error = null, notModified = true),
                 gbContext, testGbOptions,
             ),
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -230,11 +235,11 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testSuccessWithCachingEnabled() {
+    fun testSuccessWithCachingEnabled() = runTest {
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            this,
+            this@FeaturesViewModelTests,
             FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext,
@@ -242,7 +247,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = true,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -253,10 +258,10 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testFeaturesAPIModelSuccessfullyCalled() {
+    fun testFeaturesAPIModelSuccessfullyCalled() = runTest {
         featuresAPIModelCalled = false
         val viewModel = FeaturesViewModel(
-            this,
+            this@FeaturesViewModelTests,
             FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext,
@@ -264,7 +269,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             ),
             "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -273,19 +278,19 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testSavedGroupsFetchedSuccessfully() {
+    fun testSavedGroupsFetchedSuccessfully() = runTest {
         isSuccess = false
         isError = true
 
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponseWithSavedGroups, null),
                 gbContext, testGbOptions,
             ),
             encryptionKey = "",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -295,18 +300,18 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testSavedGroupsFetchFailed() {
+    fun testSavedGroupsFetchFailed() = runTest {
         isSuccess = false
         isError = true
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponseWithEncryptedFeaturesOnly, null),
                 gbContext, testGbOptions,
             ),
             encryptionKey = "",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -316,11 +321,11 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testHandleFetchFeaturesWithoutRemoteEvalPlainFeatures() {
+    fun testHandleFetchFeaturesWithoutRemoteEvalPlainFeatures() = runTest {
         receivedFromCache = false
         val cacheLayer = MockCachingLayer.fromApiResponse(MockResponse.successResponse)
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext, testGbOptions,
@@ -328,7 +333,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -341,12 +346,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testHandleFetchFeaturesWithoutRemoteEvalEncryptedFeatures() {
+    fun testHandleFetchFeaturesWithoutRemoteEvalEncryptedFeatures() = runTest {
         receivedFromCache = false
         val cacheLayer =
             MockCachingLayer.fromApiResponse(MockResponse.successResponseEncryptedFeatures)
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponseEncryptedFeatures, null),
                 gbContext, testGbOptions,
@@ -354,7 +359,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -367,18 +372,18 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testFetchFeaturesWithCacheException() {
+    fun testFetchFeaturesWithCacheException() = runTest {
         receivedCacheError = false
         val cacheLayer = MockCachingLayer(throwOnGet = true)
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(null, Throwable("Network error")),
                 gbContext, testGbOptions,
             ),
             cachingEnabled = false,
             cachingLayer = cacheLayer,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         viewModel.fetchFeatures()
@@ -392,12 +397,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testCacheWriteFailureDoesNotDiscardFetchedFeatures() {
+    fun testCacheWriteFailureDoesNotDiscardFetchedFeatures() = runTest {
         isSuccess = false
         isError = false
         val cacheLayer = MockCachingLayer(throwOnPut = true)
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext, testGbOptions,
@@ -405,6 +410,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = true,
             cachingLayer = cacheLayer,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler)
         )
 
         viewModel.fetchFeatures()
@@ -415,16 +421,16 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testAutoRefreshFeaturesReturnsFlow() {
+    fun testAutoRefreshFeaturesReturnsFlow() = runTest {
         val viewModel = FeaturesViewModel(
-            delegate = this,
+            delegate = this@FeaturesViewModelTests,
             dataSource = FeaturesDataSource(
                 MockNetworkClient(MockResponse.successResponse, null),
                 gbContext, testGbOptions,
             ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
-            coroutineContext = Dispatchers.Unconfined,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
 
         val flow = viewModel.autoRefreshFeatures()
@@ -435,7 +441,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     /**
      * Proves the race-condition fix: features are applied to context only AFTER the sticky-bucket
      * refresh (onPayloadReady) has fully completed — verified under a NON-immediate dispatcher so
-     * the ordering is enforced by code, not masked by Dispatchers.Unconfined running everything inline.
+     * the ordering is enforced by code, not masked by UnconfinedTestDispatcher(testScheduler) running everything inline.
      */
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     @Test
@@ -499,6 +505,105 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             listOf("stickyRefreshStart", "stickyRefreshDone", "featuresApplied"),
             events,
             "featuresFetchedSuccessfully must fire strictly after onPayloadReady completes"
+        )
+    }
+
+    /**
+     * Integration-level companion to [testFeaturesAppliedOnlyAfterStickyRefreshCompletes]: instead of a
+     * fake onPayloadReady that merely delays, this drives the REAL [GBUtils.refreshStickyBuckets] over the
+     * actual payload (mirroring GrowthBookSDK.onPayloadReady) and asserts that, by the time features are
+     * applied, the user's sticky-bucket docs are already written into the context. Only the storage leaf
+     * (getAllAssignments) is faked — and it suspends on the test scheduler, so the ordering is enforced by
+     * the production code under a NON-immediate dispatcher, not masked by UnconfinedTestDispatcher(testScheduler).
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testStickyDocsPopulatedBeforeFeaturesAppliedWithRealRefresh() = runTest {
+        // Fake only the storage IO. It suspends (delay) on the test scheduler to mimic a read that does
+        // not complete synchronously, and returns a doc for whichever identifier attributes the real
+        // refresh derived from the payload.
+        val service = object : GBStickyBucketService {
+            override val coroutineScope = TestScope(testScheduler)
+            override suspend fun getAssignments(
+                attributeName: String,
+                attributeValue: String
+            ): GBStickyAssignmentsDocument? = null
+
+            override suspend fun saveAssignments(doc: GBStickyAssignmentsDocument) = Unit
+
+            override suspend fun getAllAssignments(
+                attributes: Map<String, String>
+            ): Map<String, GBStickyAssignmentsDocument> {
+                delay(100) // storage read in flight — refresh has NOT completed yet
+                return attributes.entries.associate { (name, value) ->
+                    "$name||$value" to GBStickyAssignmentsDocument(
+                        attributeName = name,
+                        attributeValue = value,
+                        assignments = mapOf("exp__0" to "control"),
+                    )
+                }
+            }
+        }
+
+        val ctx = GBContext(
+            apiKey = "Key",
+            enabled = true,
+            attributes = mapOf("id" to GBString("u1")),
+            forcedVariations = emptyMap(),
+            qaMode = false,
+            trackingCallback = { _, _ -> },
+            encryptionKey = null,
+            stickyBucketService = service,
+        )
+
+        // Snapshot of the context's sticky docs at the exact moment features are applied.
+        var docsAtApplyTime: Map<String, GBStickyAssignmentsDocument>? = null
+
+        val delegate = object : FeaturesFlowDelegate {
+            // Mirrors GrowthBookSDK.onPayloadReady: real refresh against the freshly fetched payload.
+            override suspend fun onPayloadReady(model: FeaturesDataModel) {
+                GBUtils.refreshStickyBuckets(
+                    context = ctx,
+                    data = model,
+                    attributeOverrides = emptyMap(),
+                )
+            }
+
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+                docsAtApplyTime = ctx.stickyBucketAssignmentDocs
+            }
+
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+
+        val viewModel = FeaturesViewModel(
+            delegate = delegate,
+            dataSource = FeaturesDataSource(
+                MockNetworkClient(MockResponse.successResponse, null),
+                ctx, testGbOptions,
+            ),
+            cachingEnabled = false,
+            coroutineContext = StandardTestDispatcher(testScheduler),
+        )
+
+        viewModel.fetchFeatures()
+
+        // Queued, not run: features have not been applied while the refresh is still pending.
+        assertEquals(null, docsAtApplyTime)
+
+        advanceUntilIdle()
+
+        // featuresFetchedSuccessfully fired only after the real refresh wrote the current user's docs.
+        assertNotNull(
+            docsAtApplyTime,
+            "stickyBucketAssignmentDocs must be populated before features are applied",
+        )
+        assertTrue(
+            docsAtApplyTime!!.containsKey("id||u1"),
+            "Refresh must have loaded the current user's assignment doc before features applied",
         )
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -7,6 +7,7 @@ import com.sdk.growthbook.features.FeaturesDataModel
 import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
+import com.sdk.growthbook.features.FetchResult
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
@@ -552,6 +553,80 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         )
         assertTrue(isSuccess, "Network payload must be applied after falling through the broken cache")
         assertTrue(hasFeatures)
+    }
+
+    @Test
+    fun testOnPayloadReadyReceivesDecodedFeaturesForEncryptedPayload() = runTest {
+        // Regression for the sticky-bucket-on-encrypted-payload bug: onPayloadReady (which drives
+        // the sticky-bucket refresh) must receive the DECODED payload, not the raw encrypted model.
+        // Otherwise model.features == null, deriveStickyBucketIdentifierAttributes falls back to the
+        // empty cold-start context, and sticky identifiers are derived from nothing. Mirrors the
+        // reference TS SDK, which decrypts before refreshStickyBuckets.
+        var featuresSeenByPayloadReady: GBFeatures? = null
+        val capturingDelegate = object : FeaturesFlowDelegate {
+            override suspend fun onPayloadReady(model: FeaturesDataModel) {
+                featuresSeenByPayloadReady = model.features
+            }
+
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) = Unit
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = capturingDelegate,
+            dataSource = FeaturesDataSource(
+                MockNetworkClient(MockResponse.successResponseEncryptedFeatures, null),
+                gbContext, testGbOptions,
+            ),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = false,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        viewModel.fetchFeatures()
+
+        assertNotNull(
+            featuresSeenByPayloadReady,
+            "onPayloadReady must receive decoded features for an encrypted payload so sticky-bucket " +
+                "identifier attributes are derived from real features, not the empty raw model"
+        )
+        assertTrue(featuresSeenByPayloadReady!!.isNotEmpty())
+    }
+
+    @Test
+    fun testAwaitRefreshTimesOutWhenDispatcherNeverResponds() = runTest {
+        // A dispatcher that accepts the request but never invokes any callback — mimics a hung
+        // connection (both recommended dispatchers default to an INFINITE read timeout). The
+        // network round must time out to Failed so suspendFeature()'s bounded retry can escape
+        // instead of hanging forever.
+        isError = false
+        val hungClient = object : MockNetworkClient(MockResponse.successResponse, null) {
+            override fun consumeGETRequestWithNotModified(
+                request: String,
+                onSuccess: (String) -> Unit,
+                onError: (Throwable) -> Unit,
+                onNotModified: (() -> Unit)
+            ): Job = Job() // never resumes any callback
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(hungClient, gbContext, testGbOptions),
+            encryptionKey = "",
+            cachingEnabled = false,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // runTest auto-advances virtual time, so the 30s withTimeoutOrNull fires deterministically.
+        val result = viewModel.awaitRefresh()
+
+        assertEquals(
+            FetchResult.Failed,
+            result,
+            "A hung network round must time out to Failed, not hang"
+        )
+        assertTrue(isError, "Timeout must be surfaced as a fetch failure")
     }
 
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -11,8 +11,14 @@ import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -424,6 +430,76 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         val flow = viewModel.autoRefreshFeatures()
 
         assertNotNull(flow)
+    }
+
+    /**
+     * Proves the race-condition fix: features are applied to context only AFTER the sticky-bucket
+     * refresh (onPayloadReady) has fully completed — verified under a NON-immediate dispatcher so
+     * the ordering is enforced by code, not masked by Dispatchers.Unconfined running everything inline.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testFeaturesAppliedOnlyAfterStickyRefreshCompletes() = runTest {
+        val events = mutableListOf<String>()
+
+        // A delegate whose onPayloadReady actually suspends, mimicking sticky-bucket IO that
+        // does not complete synchronously (real GBStickyBucketService reads from storage).
+        val orderingDelegate = object : FeaturesFlowDelegate {
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+                events += "featuresApplied"
+            }
+
+            override suspend fun onPayloadReady(model: FeaturesDataModel) {
+                events += "stickyRefreshStart"
+                delay(100) // suspends — refresh is in flight
+                events += "stickyRefreshDone"
+            }
+
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) {
+                events += "fetchFailed"
+            }
+
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+
+        val viewModel = FeaturesViewModel(
+            delegate = orderingDelegate,
+            dataSource = FeaturesDataSource(
+                MockNetworkClient(MockResponse.successResponse, null),
+                gbContext, testGbOptions,
+            ),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = false,
+            // Non-immediate: launched work is queued on the scheduler, not run inline.
+            coroutineContext = StandardTestDispatcher(testScheduler),
+        )
+
+        viewModel.fetchFeatures()
+
+        // With a non-immediate dispatcher nothing has run yet — proves the work is now async,
+        // unlike the old synchronous fire-and-forget that applied results inside fetchFeatures().
+        assertTrue(
+            events.isEmpty(),
+            "Payload processing must be queued, not executed inline, on a non-immediate dispatcher"
+        )
+
+        // Run up to the first suspension point: refresh has started but NOT finished.
+        runCurrent()
+        assertEquals(
+            listOf("stickyRefreshStart"),
+            events,
+            "Features must not be applied while the sticky-bucket refresh is still suspended"
+        )
+
+        // Let the refresh's suspension resolve.
+        advanceUntilIdle()
+        assertEquals(
+            listOf("stickyRefreshStart", "stickyRefreshDone", "featuresApplied"),
+            events,
+            "featuresFetchedSuccessfully must fire strictly after onPayloadReady completes"
+        )
     }
 
     override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -510,6 +510,50 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         assertEquals(1, networkCallCount, "Network should be called when cache is stale")
     }
 
+    @Test
+    fun testFetchesNetworkWhenFreshCacheIsUndecodable() = runTest {
+        // A fresh (within cacheMaxAge) but undecodable cache: encrypted-only payload with an
+        // empty encryption key, so the decoder yields (features=null, savedGroups=null). Such a
+        // cache must NOT be treated as authoritative — serveCache should fall through to the
+        // network instead of silently serving nothing for the whole freshness window.
+        isSuccess = false
+        var networkCallCount = 0
+        val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
+            override fun consumeGETRequestWithNotModified(
+                request: String,
+                onSuccess: (String) -> Unit,
+                onError: (Throwable) -> Unit,
+                onNotModified: (() -> Unit)
+            ): Job {
+                networkCallCount++
+                return super.consumeGETRequestWithNotModified(request, onSuccess, onError, onNotModified)
+            }
+        }
+        val cacheLayer = MockCachingLayer.fromApiResponse(
+            MockResponse.successResponseWithEncryptedFeaturesOnly,
+            cachedAt = Clock.System.now().toEpochMilliseconds()
+        )
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
+            encryptionKey = "",
+            cachingEnabled = false,
+            cachingLayer = cacheLayer,
+            cacheMaxAge = 48 * 60 * 60 * 1000L,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler)
+        )
+
+        viewModel.fetchFeatures()
+
+        assertEquals(
+            1,
+            networkCallCount,
+            "Network must be called when a fresh cache decodes to nothing usable"
+        )
+        assertTrue(isSuccess, "Network payload must be applied after falling through the broken cache")
+        assertTrue(hasFeatures)
+    }
+
     @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     @Test
     fun testConcurrentAwaitRefreshSharesSingleNetworkCall() = runTest {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextStickyMergeTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextStickyMergeTests.kt
@@ -1,0 +1,69 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [GBContext.mergeStickyAssignmentDoc] — the per-key merge that replaced the old
+ * whole-map write-back. The key contract is that merging one assignment never drops the other keys
+ * already in the context, so it composes with a concurrent background refresh.
+ */
+class GBContextStickyMergeTests {
+
+    private fun context() = GBContext(
+        apiKey = "",
+        enabled = true,
+        attributes = emptyMap(),
+        forcedVariations = emptyMap(),
+        qaMode = false,
+        trackingCallback = { _, _ -> },
+        encryptionKey = "",
+    )
+
+    private fun doc(attr: String, value: String) = GBStickyAssignmentsDocument(
+        attributeName = attr,
+        attributeValue = value,
+        assignments = mapOf("exp__0" to value),
+    )
+
+    @Test
+    fun mergeIntoNullDocsCreatesMap() {
+        val gb = context()
+        assertNull(gb.stickyBucketAssignmentDocs)
+
+        val d = doc("id", "1")
+        gb.mergeStickyAssignmentDoc("id||1", d)
+
+        assertEquals(mapOf("id||1" to d), gb.stickyBucketAssignmentDocs)
+    }
+
+    @Test
+    fun mergePreservesOtherKeys() {
+        val gb = context()
+        val existing = doc("id", "1")
+        gb.stickyBucketAssignmentDocs = mapOf("id||1" to existing)
+
+        val added = doc("companyId", "42")
+        gb.mergeStickyAssignmentDoc("companyId||42", added)
+
+        // Both keys must be present — a whole-map replace would have dropped "id||1".
+        assertEquals(
+            mapOf("id||1" to existing, "companyId||42" to added),
+            gb.stickyBucketAssignmentDocs,
+        )
+    }
+
+    @Test
+    fun mergeReplacesSameKey() {
+        val gb = context()
+        gb.stickyBucketAssignmentDocs = mapOf("id||1" to doc("id", "1"))
+
+        val updated = doc("id", "1").copy(assignments = mapOf("exp__0" to "treatment"))
+        gb.mergeStickyAssignmentDoc("id||1", updated)
+
+        assertEquals(mapOf("id||1" to updated), gb.stickyBucketAssignmentDocs)
+    }
+}

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertEquals
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonObject
 import com.sdk.growthbook.integration.buildSDK
+import kotlinx.coroutines.test.runTest
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.serializable_model.gbDeserialize
@@ -175,7 +176,7 @@ class GBExperimentRunTests {
     }
 
     @Test
-    fun `forcing example`() {
+    fun `forcing example`() = runTest {
         val gb = buildSDK(
             json = "",
             attributes = mapOf("id" to 1.toGbNumber())

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBExperimentRunTests.kt
@@ -4,9 +4,13 @@ import kotlin.test.Test
 import kotlin.test.BeforeTest
 import kotlin.test.assertTrue
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonObject
+import com.sdk.growthbook.GBSDKBuilder
 import com.sdk.growthbook.integration.buildSDK
+import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBExperiment
@@ -200,5 +204,49 @@ class GBExperimentRunTests {
         assertTrue(result2.inExperiment)
         assertEquals(result2.hashUsed, false)
         assertEquals(result2.value, GBNumber(0))
+    }
+
+    /**
+     * End-to-end check that a sticky assignment generated during run() is merged back into the
+     * shared context via [com.sdk.growthbook.evaluators.EvaluationContext.onStickyAssignmentChanged]
+     * — i.e. the production callback wiring works, not just the merge primitive in isolation. Guards
+     * against a regression where removing the old whole-map write-back would silently stop sticky
+     * assignments from persisting to the context.
+     */
+    @Test
+    fun stickyAssignmentGeneratedDuringRunIsMergedIntoContext() = runTest {
+        val service = GBStickyBucketServiceImp(
+            coroutineScope = this,
+            localStorage = MapCachingLayer(),
+        )
+        val gb = GBSDKBuilder(
+            "some_key",
+            "http://host.com",
+            attributes = mapOf("id" to 1.toGbNumber()),
+            remoteEval = false,
+            encryptionKey = "",
+            trackingCallback = { _, _ -> },
+            networkDispatcher = MockNetworkClient("", null),
+        )
+            .setStickyBucketService(service)
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .initialize()
+
+        // Nothing assigned before the first evaluation.
+        assertTrue(gb.getGBContext().stickyBucketAssignmentDocs.isNullOrEmpty())
+
+        val experiment = GBExperiment(
+            key = "key-576",
+            variations = listOf(GBNumber(0), GBNumber(1)),
+        )
+        val result = gb.run(experiment)
+        assertTrue(result.inExperiment)
+
+        // The assignment must now live in the shared context (merged per-key by the callback).
+        val docs = gb.getGBContext().stickyBucketAssignmentDocs
+        assertNotNull(docs)
+        val doc = docs["id||1"]
+        assertNotNull(doc)
+        assertTrue(doc.assignments.containsKey("key-576__0"))
     }
 }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBStickyBucketServiceImpTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBStickyBucketServiceImpTests.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertNull
  * CachingLayer fake that stores and retrieves content by file name,
  * so multiple keys can coexist in the same test.
  */
-private class MapCachingLayer : CachingLayer {
+internal class MapCachingLayer : CachingLayer {
     val store = mutableMapOf<String, JsonElement>()
 
     override fun getContent(fileName: String): JsonElement? = store[fileName]

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBStickyBucketingFeatureTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBStickyBucketingFeatureTests.kt
@@ -1,13 +1,16 @@
 package com.sdk.growthbook.tests
 
-import kotlinx.coroutines.test.TestScope
 import com.sdk.growthbook.evaluators.GBFeatureEvaluator
+import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
 import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
 import com.sdk.growthbook.utils.GBStickyAttributeKey
+import com.sdk.growthbook.utils.GBUtils
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
@@ -17,16 +20,13 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertTrue
-import com.sdk.growthbook.kotlinx.serialization.from
 
 class GBStickyBucketingFeatureTests {
     private lateinit var evalConditions: JsonArray
-    private lateinit var service: GBStickyBucketServiceImp
 
     @Before
     fun setUp() {
         evalConditions = GBTestHelper.getStickyBucketingData()
-        service = GBStickyBucketServiceImp(TestScope())
     }
 
     @Test
@@ -46,15 +46,18 @@ class GBStickyBucketingFeatureTests {
                     .attributes.jsonObject
                     .mapValues { GBValue.from(it.value) }
 
+                val service = GBStickyBucketServiceImp(
+                    coroutineScope = TestScope(),
+                    localStorage = MapCachingLayer()
+                )
+
                 val gbContext = GBContext(
                     apiKey = "",
                     enabled = true,
                     attributes = attributes,
                     forcedVariations = emptyMap(),
                     qaMode = false,
-                    trackingCallback = { _, _ ->
-
-                    },
+                    trackingCallback = { _, _ -> },
                     encryptionKey = "",
                     stickyBucketService = service
                 )
@@ -64,20 +67,24 @@ class GBStickyBucketingFeatureTests {
                         .mapValues { it.value.gbDeserialize() }
                 }
 
-                val listActualStickyAssignmentsDoc =
-                    mutableListOf<GBStickyAssignmentsDocument>()
-
-                item[2].jsonArray.forEach {
-                    listActualStickyAssignmentsDoc.add(
-                        Json.decodeFromJsonElement(GBStickyAssignmentsDocument.serializer(), it)
-                    )
+                // Seed the service with the input docs, then let getAllAssignments filter
+                // to only the docs that belong to the current user — same as TypeScript.
+                val inputDocs = item[2].jsonArray.map {
+                    Json.decodeFromJsonElement(GBStickyAssignmentsDocument.serializer(), it)
                 }
 
-                val mapOfDocForContext =
-                    mutableMapOf<String, GBStickyAssignmentsDocument>()
-                for (doc in listActualStickyAssignmentsDoc) {
-                    val key = "${doc.attributeName}||${doc.attributeValue}"
-                    mapOfDocForContext[key] = doc
+                val attributesAsStrings = attributes.keys.associateWith { key ->
+                    GBUtils.getHashAttribute(
+                        attr = key,
+                        fallback = null,
+                        attributes = attributes,
+                        attributeOverrides = attributes,
+                    ).second
+                }
+
+                val mapOfDocForContext = runBlocking {
+                    inputDocs.forEach { service.saveAssignments(it) }
+                    service.getAllAssignments(attributesAsStrings)
                 }
 
                 gbContext.stickyBucketAssignmentDocs = mapOfDocForContext
@@ -95,7 +102,10 @@ class GBStickyBucketingFeatureTests {
                     mutableMapOf<GBStickyAttributeKey, GBStickyAssignmentsDocument>()
                 for (doc in item[5].jsonObject) {
                     expectedStickyAssignmentDocs[doc.key] =
-                        Json.decodeFromJsonElement(GBStickyAssignmentsDocument.serializer(), doc.value)
+                        Json.decodeFromJsonElement(
+                            GBStickyAssignmentsDocument.serializer(),
+                            doc.value
+                        )
                 }
 
                 val testScopeEvalContext =

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -14,6 +14,7 @@ import com.sdk.growthbook.model.GBString
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.model.toGbBoolean
 import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -17,6 +17,7 @@ import com.sdk.growthbook.model.toGbBoolean
 import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -101,7 +102,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSDKInitilizationData() {
+    fun testSDKInitilizationData() = runTest {
 
         val variations: HashMap<String, Int> = HashMap()
 
@@ -113,7 +114,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setRefreshHandler { isRefreshed, gbError ->
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setRefreshHandler { isRefreshed, gbError ->
 
         }
             .setEnabled(false).setForcedVariations(variations).setQAMode(true).initialize()
@@ -125,7 +126,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSDKRefreshHandler() {
+    fun testSDKRefreshHandler() = runTest {
 
         var isRefreshed = false
 
@@ -137,7 +138,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setRefreshHandler { _, gbError ->
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setRefreshHandler { _, gbError ->
             isRefreshed = true
         }.initialize()
 
@@ -178,7 +179,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSDKFeaturesData() {
+    fun testSDKFeaturesData() = runTest {
 
         var isRefreshed = false
         val gbError = GBError(error = null)
@@ -192,7 +193,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setRefreshHandler { _, gbError ->
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setRefreshHandler { _, gbError ->
             isRefreshed = true
         }.initialize()
 
@@ -203,7 +204,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSDKRunMethods() {
+    fun testSDKRunMethods() = runTest {
 
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -213,7 +214,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setRefreshHandler { isRefreshed, gbError ->
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setRefreshHandler { isRefreshed, gbError ->
         }.initialize()
 
         val featureValue = sdkInstance.feature("fwrfewrfe")
@@ -224,7 +225,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSDKInitializationDataWithEncrypted() {
+    fun testSDKInitializationDataWithEncrypted() = runTest {
         // val viewModel: FeaturesViewModel()
         val variations: HashMap<String, Int> = HashMap()
 
@@ -239,7 +240,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setPrefixForStickyBucketCachedDirectory_Ok() {
+    fun test_setPrefixForStickyBucketCachedDirectory_Ok() = runTest {
         val sdkInstance = GBSDKBuilder(
             testApiKey,
             testHostURL,
@@ -248,7 +249,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setPrefixForStickyBucketCachedDirectory(
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setPrefixForStickyBucketCachedDirectory(
             coroutineScope = TestScope(), prefix = "test_prefix",
         ).initialize()
 
@@ -257,7 +258,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setStickyBucketService_Ok() {
+    fun test_setStickyBucketService_Ok() = runTest {
         val sdkInstance = GBSDKBuilder(
             testApiKey,
             testHostURL,
@@ -266,7 +267,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setStickyBucketService(TestScope())
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setStickyBucketService(TestScope())
             .initialize()
 
         assertTrue { sdkInstance.getGBContext().stickyBucketService != null }
@@ -274,7 +275,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setForcedVariations_Ok() {
+    fun test_setForcedVariations_Ok() = runTest {
         val expectedForcedVariation = mapOf("user" to 1234)
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -284,7 +285,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
-        ).setForcedVariations(expectedForcedVariation)
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setForcedVariations(expectedForcedVariation)
             .initialize()
 
         val actualForcedVariation = sdkInstance.getGBContext().forcedVariations
@@ -294,7 +295,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setForcedVariationsWithRemoteEval_Ok() {
+    fun test_setForcedVariationsWithRemoteEval_Ok() = runTest {
         val expectedForcedVariation = mapOf("user" to 1234)
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -304,7 +305,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = true
-        ).setForcedVariations(expectedForcedVariation)
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setForcedVariations(expectedForcedVariation)
             .initialize()
         sdkInstance.setForcedFeatures(
             mapOf("featureForce" to GBNumber(112))
@@ -318,7 +319,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setAttributesOverrides_Ok() {
+    fun test_setAttributesOverrides_Ok() = runTest {
         val expectedAttributes = mapOf("user" to false.toGbBoolean())
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -329,6 +330,7 @@ class GrowthBookSDKBuilderTests {
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = false
         )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
             .initialize()
 
         sdkInstance.setAttributeOverrides(expectedAttributes)
@@ -340,7 +342,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_setAttributesOverridesWithStickyBucketing_Ok() {
+    fun test_setAttributesOverridesWithStickyBucketing_Ok() = runTest {
         val expectedAttributes = mapOf("user" to GBBoolean(false))
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -350,7 +352,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
             remoteEval = true
-        ).setStickyBucketService(GBStickyBucketServiceImp(TestScope()))
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).setStickyBucketService(GBStickyBucketServiceImp(TestScope()))
             .initialize()
 
         sdkInstance.setAttributeOverrides(expectedAttributes)
@@ -413,7 +415,7 @@ class GrowthBookSDKBuilderTests {
         }
 
     @Test
-    fun test_savedGroupsFetchFailed_isRemoteTrue_callsRefreshHandlerWithFalse() {
+    fun test_savedGroupsFetchFailed_isRemoteTrue_callsRefreshHandlerWithFalse() = runTest {
         var handlerSuccess: Boolean? = null
         val sdk = buildSdkWithHandler(refreshHandler = { success, _ -> handlerSuccess = success })
 
@@ -423,7 +425,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchFailed_isRemoteFalse_doesNotCallRefreshHandler() {
+    fun test_savedGroupsFetchFailed_isRemoteFalse_doesNotCallRefreshHandler() = runTest {
         var handlerCallCount = 0
         val sdk = buildSdkWithHandler(refreshHandler = { _, _ -> handlerCallCount++ })
         val countAfterInit = handlerCallCount
@@ -434,7 +436,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchFailed_passesErrorToHandler() {
+    fun test_savedGroupsFetchFailed_passesErrorToHandler() = runTest {
         val expectedError = GBError(error = RuntimeException("network failure"))
         var receivedError: GBError? = null
         val sdk = buildSdkWithHandler(refreshHandler = { _, error -> receivedError = error })
@@ -445,7 +447,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_updatesSavedGroups() {
+    fun test_savedGroupsFetchedSuccessfully_updatesSavedGroups() = runTest {
         val sdk = buildSdkWithHandler()
         val jsonGroups = buildJsonObject {
             put("premium", JsonPrimitive(true))
@@ -461,7 +463,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_isRemoteTrue_callsRefreshHandlerWithTrue() {
+    fun test_savedGroupsFetchedSuccessfully_isRemoteTrue_callsRefreshHandlerWithTrue() = runTest {
         var handlerSuccess: Boolean? = null
         var handlerError: GBError? = GBError(null)
         val sdk = buildSdkWithHandler(refreshHandler = { success, error ->
@@ -479,7 +481,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_isRemoteFalse_doesNotCallRefreshHandler() {
+    fun test_savedGroupsFetchedSuccessfully_isRemoteFalse_doesNotCallRefreshHandler() = runTest {
         var handlerCallCount = 0
         val sdk = buildSdkWithHandler(refreshHandler = { _, _ -> handlerCallCount++ })
         val countAfterInit = handlerCallCount
@@ -493,7 +495,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_withEmptyJson_setEmptySavedGroups() {
+    fun test_savedGroupsFetchedSuccessfully_withEmptyJson_setEmptySavedGroups() = runTest {
         val sdk = buildSdkWithHandler()
 
         sdk.savedGroupsFetchedSuccessfully(buildJsonObject { }, isRemote = false)
@@ -576,7 +578,7 @@ class GrowthBookSDKBuilderTests {
                 trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
                 networkDispatcher = networkClient,
                 remoteEval = true,
-            ).initialize()
+            ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).initialize()
             val countBeforeCall = postCount
 
             sdk.setAttributeOverridesSync(mapOf("plan" to GBString("pro")))
@@ -585,7 +587,7 @@ class GrowthBookSDKBuilderTests {
         }
 
     @Test
-    fun test_refreshStickyBucketService_withoutService_contextHasNoStickyBucketService() {
+    fun test_refreshStickyBucketService_withoutService_contextHasNoStickyBucketService() = runTest {
         val sdk = buildSdkWithHandler(withStickyBucket = false)
 
         sdk.setAttributes(mapOf("id" to GBString("user-1")))
@@ -594,7 +596,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_refreshStickyBucketService_withService_stickyBucketServicePresentInContext() {
+    fun test_refreshStickyBucketService_withService_stickyBucketServicePresentInContext() = runTest {
         val sdk = buildSdkWithHandler(withStickyBucket = true)
 
         sdk.setAttributes(mapOf("id" to GBString("user-1")))
@@ -603,7 +605,7 @@ class GrowthBookSDKBuilderTests {
         assertTrue(sdk.getGBContext().stickyBucketService is GBStickyBucketServiceImp)
     }
 
-    private fun buildSDK(
+    private fun TestScope.buildSDK(
         json: String,
         attributes: Map<String, GBValue> = mapOf(),
         encryptionKey: String?
@@ -616,10 +618,10 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _, _ -> },
             networkDispatcher = MockNetworkClient(json, null),
             remoteEval = false
-        ).initialize()
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).initialize()
     }
 
-    private fun buildSdkWithHandler(
+    private fun TestScope.buildSdkWithHandler(
         remoteEval: Boolean = false,
         withStickyBucket: Boolean = false,
         networkResponse: String? = MockResponse.successResponse,
@@ -637,6 +639,7 @@ class GrowthBookSDKBuilderTests {
         )
         if (refreshHandler != null) builder.setRefreshHandler(refreshHandler)
         if (withStickyBucket) builder.setStickyBucketService(testScope)
+        builder.setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
         return builder.initialize()
     }
 
@@ -678,7 +681,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSetInitialFeaturesOverwrittenByNetworkRefresh() {
+    fun testSetInitialFeaturesOverwrittenByNetworkRefresh() = runTest {
         val bundledFeatures: GBFeatures = mapOf("bundled-feature" to GBFeature())
         var refreshCalled = false
 
@@ -690,6 +693,7 @@ class GrowthBookSDKBuilderTests {
             trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
             networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
         )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
             .setInitialFeatures(bundledFeatures)
             .setRefreshHandler { success, _ -> refreshCalled = success }
             .initialize()

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -436,6 +436,31 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
+    fun test_close_cancelsScope_soSubsequentRemoteFetchDoesNotRun() = runTest {
+        var handlerCallCount = 0
+        val sdk = buildSdkWithHandler(refreshHandler = { _, _ -> handlerCallCount++ })
+        // initialize() ran one successful remote fetch, so the handler fired at least once.
+        val countAfterInit = handlerCallCount
+        assertTrue(countAfterInit > 0)
+
+        sdk.close()
+
+        // After close() the background scope is cancelled, so the payload-processing coroutine
+        // launched by a remote fetch never runs and the (isRemote=true) handler is not invoked again.
+        sdk.refreshCache()
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(countAfterInit, handlerCallCount)
+    }
+
+    @Test
+    fun test_close_isIdempotent() = runTest {
+        val sdk = buildSdkWithHandler()
+        sdk.close()
+        sdk.close() // must not throw
+    }
+
+    @Test
     fun test_savedGroupsFetchFailed_passesErrorToHandler() = runTest {
         val expectedError = GBError(error = RuntimeException("network failure"))
         var receivedError: GBError? = null

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
@@ -482,6 +482,18 @@
       false
     ],
     [
+      "$in - fail (case sensitive mismatch)",
+      {
+        "country": {
+          "$in": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
       "$nin - pass",
       {
         "num": {
@@ -576,6 +588,198 @@
         "tags": []
       },
       true
+    ],
+    [
+      "$nin - pass (case sensitive mismatch)",
+      {
+        "country": {
+          "$nin": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (case insensitive match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - pass (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$ini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      true
+    ],
+    [
+      "$ini - pass (mixed case)",
+      {
+        "country": {
+          "$ini": ["Us", "Uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      true
+    ],
+    [
+      "$ini - fail (no match)",
+      {
+        "country": {
+          "$ini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      false
+    ],
+    [
+      "$ini - array pass 1",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      true
+    ],
+    [
+      "$ini - array pass 2",
+      {
+        "tags": {
+          "$ini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      true
+    ],
+    [
+      "$ini - array fail",
+      {
+        "tags": {
+          "$ini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      false
+    ],
+    [
+      "$ini - not array",
+      {
+        "num": {
+          "$ini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
+    ],
+    [
+      "$nini - pass (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "CA"
+      },
+      true
+    ],
+    [
+      "$nini - fail (case insensitive match)",
+      {
+        "country": {
+          "$nini": ["us", "uk"]
+        }
+      },
+      {
+        "country": "US"
+      },
+      false
+    ],
+    [
+      "$nini - fail (uppercase pattern, lowercase value)",
+      {
+        "country": {
+          "$nini": ["US", "UK"]
+        }
+      },
+      {
+        "country": "us"
+      },
+      false
+    ],
+    [
+      "$nini - array pass",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "f"]
+      },
+      true
+    ],
+    [
+      "$nini - array fail 1",
+      {
+        "tags": {
+          "$nini": ["a", "b"]
+        }
+      },
+      {
+        "tags": ["d", "e", "A"]
+      },
+      false
+    ],
+    [
+      "$nini - array fail 2",
+      {
+        "tags": {
+          "$nini": ["A", "B"]
+        }
+      },
+      {
+        "tags": ["d", "b", "f"]
+      },
+      false
+    ],
+    [
+      "$nini - not array",
+      {
+        "num": {
+          "$nini": 1
+        }
+      },
+      {
+        "num": 1
+      },
+      false
     ],
     [
       "$elemMatch - pass - flat arrays",
@@ -758,6 +962,18 @@
       false
     ],
     [
+      "$regex - fail (case sensitive mismatch)",
+      {
+        "userAgent": {
+          "$regex": "(mobile|tablet)"
+        }
+      },
+      {
+        "userAgent": "Android Mobile Browser"
+      },
+      false
+    ],
+    [
       "$regexi - pass (case insensitive match)",
       {
         "userAgent": {
@@ -790,138 +1006,6 @@
       },
       {
         "userAgent": "Chrome Desktop Browser"
-      },
-      false
-    ],
-    [
-      "$notRegex - pass",
-      {
-        "userAgent": {
-          "$notRegex": "(Mobile|Tablet)"
-        }
-      },
-      {
-        "userAgent": "Chrome Desktop Browser"
-      },
-      true
-    ],
-    [
-      "$notRegex - fail",
-      {
-        "userAgent": {
-          "$notRegex": "(Mobile|Tablet)"
-        }
-      },
-      {
-        "userAgent": "Android Mobile Browser"
-      },
-      false
-    ],
-    [
-      "$notRegexi - pass",
-      {
-        "userAgent": {
-          "$notRegexi": "(mobile|tablet)"
-        }
-      },
-      {
-        "userAgent": "Chrome Desktop Browser"
-      },
-      true
-    ],
-    [
-      "$notRegexi - fail",
-      {
-        "userAgent": {
-          "$notRegexi": "(mobile|tablet)"
-        }
-      },
-      {
-        "userAgent": "Android Mobile Browser"
-      },
-      false
-    ],
-    [
-      "$ini - pass",
-      {
-        "tags": {
-          "$ini": ["A", "B"]
-        }
-      },
-      {
-        "tags": "a"
-      },
-      true
-    ],
-    [
-      "$ini - fail",
-      {
-        "tags": {
-          "$ini": ["a", "b"]
-        }
-      },
-      {
-        "tags": "c"
-      },
-      false
-    ],
-    [
-      "$ini - array pass",
-      {
-        "tags": {
-          "$ini": ["A", "B"]
-        }
-      },
-      {
-        "tags": ["d", "a"]
-      },
-      true
-    ],
-    [
-      "$nini - pass",
-      {
-        "tags": {
-          "$nini": ["A", "B"]
-        }
-      },
-      {
-        "tags": "c"
-      },
-      true
-    ],
-    [
-      "$nini - fail",
-      {
-        "tags": {
-          "$nini": ["A", "B"]
-        }
-      },
-      {
-        "tags": "a"
-      },
-      false
-    ],
-    [
-      "$alli - pass",
-      {
-        "tags": {
-          "$alli": ["A", "B"]
-        }
-      },
-      {
-        "tags": ["a", "b", "c"]
-      },
-      true
-    ],
-    [
-      "$alli - fail",
-      {
-        "tags": {
-          "$alli": ["A", "B"]
-        }
-      },
-      {
-        "tags": ["a", "c"]
       },
       false
     ],
@@ -1603,6 +1687,78 @@
       {
         "tags": {
           "$all": ["one", "three"]
+        }
+      },
+      {
+        "tags": "hello"
+      },
+      false
+    ],
+    [
+      "$all - fail (case sensitive mismatch)",
+      {
+        "tags": {
+          "$all": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      false
+    ],
+    [
+      "$alli - pass (case insensitive match)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "THREE"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (uppercase pattern, lowercase value)",
+      {
+        "tags": {
+          "$alli": ["ONE", "THREE"]
+        }
+      },
+      {
+        "tags": ["one", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - pass (mixed case)",
+      {
+        "tags": {
+          "$alli": ["One", "Three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "three"]
+      },
+      true
+    ],
+    [
+      "$alli - fail (case insensitive, missing value)",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
+        }
+      },
+      {
+        "tags": ["ONE", "two", "four"]
+      },
+      false
+    ],
+    [
+      "$alli - fail not array",
+      {
+        "tags": {
+          "$alli": ["one", "three"]
         }
       },
       {
@@ -6546,65 +6702,6 @@
       }
     ],
     [
-      "disables sticky bucketing when disabled by experiment",
-      {
-        "attributes": {
-          "id": "i123",
-          "foo": "bar",
-          "country": "USA"
-        },
-        "features": {
-          "exp1": {
-            "defaultValue": "control",
-            "rules": [
-              {
-                "key": "feature-exp",
-                "seed": "feature-exp",
-                "hashAttribute": "id",
-                "fallbackAttribute": "deviceId",
-                "hashVersion": 2,
-                "bucketVersion": 1,
-                "disableStickyBucketing": true,
-                "condition": { "country": "USA" },
-                "variations": ["control", "red", "blue"],
-                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
-                "coverage": 1,
-                "weights": [0.3334, 0.3333, 0.3333],
-                "phase": "0"
-              }
-            ]
-          }
-        }
-      },
-      [
-        {
-          "attributeName": "id",
-          "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
-        }
-      ],
-      "exp1",
-      {
-        "bucket": 0.9943,
-        "featureId": "exp1",
-        "hashAttribute": "id",
-        "hashUsed": true,
-        "hashValue": "i123",
-        "inExperiment": true,
-        "key": "2",
-        "stickyBucketUsed": false,
-        "value": "blue",
-        "variationId": 2
-      },
-      {
-        "id||i123": {
-          "attributeName": "id",
-          "attributeValue": "i123",
-          "assignments": { "feature-exp__0": "1" }
-        }
-      }
-    ],
-    [
       "uses a sticky bucket when sticky bucket version == experiment.minBucketVersion === experiment.bucketVersion",
       {
         "attributes": {
@@ -6844,6 +6941,65 @@
           },
           "attributeName": "deviceId",
           "attributeValue": "d123"
+        }
+      }
+    ],
+    [
+      "disables sticky bucketing when disabled by experiment",
+      {
+        "attributes": {
+          "id": "i123",
+          "foo": "bar",
+          "country": "USA"
+        },
+        "features": {
+          "exp1": {
+            "defaultValue": "control",
+            "rules": [
+              {
+                "key": "feature-exp",
+                "seed": "feature-exp",
+                "hashAttribute": "id",
+                "fallbackAttribute": "deviceId",
+                "hashVersion": 2,
+                "bucketVersion": 1,
+                "disableStickyBucketing": true,
+                "condition": { "country": "USA" },
+                "variations": ["control", "red", "blue"],
+                "meta": [{ "key": "0" }, { "key": "1" }, { "key": "2" }],
+                "coverage": 1,
+                "weights": [0.3334, 0.3333, 0.3333],
+                "phase": "0"
+              }
+            ]
+          }
+        }
+      },
+      [
+        {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": { "feature-exp__0": "1" }
+        }
+      ],
+      "exp1",
+      {
+        "bucket": 0.9943,
+        "featureId": "exp1",
+        "hashAttribute": "id",
+        "hashUsed": true,
+        "hashValue": "i123",
+        "inExperiment": true,
+        "key": "2",
+        "stickyBucketUsed": false,
+        "value": "blue",
+        "variationId": 2
+      },
+      {
+        "id||i123": {
+          "attributeName": "id",
+          "attributeValue": "i123",
+          "assignments": { "feature-exp__0": "1" }
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -154,19 +154,7 @@ and returns a feature value typed with specified type.
 - stop receiving Features automatically during SSE connection
 
   ```kotlin
-  fun stopAutoRefreshFeatures(): Flow<Resource<GBFeatures?>>{}
-  ```
-
-- Delegate that set to Context successfully fetched features
-
-  ```kotlin
-  fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {}
-  ```
-
-- Delegate which inform that fetching features failed
-
-  ```kotlin
-  fun featuresFetchFailed(error: GBError, isRemote: Boolean) {}
+  fun stopAutoRefreshFeatures() {}
   ```
 
 - The isOn method takes a single string argument, which is the unique identifier for the feature and returns the feature
@@ -179,54 +167,48 @@ and returns a feature value typed with specified type.
 - The setForcedFeatures method setup the Map of user's (forced) features
 
   ```kotlin
-  fun setForcedFeatures(forcedFeatures: Map<String, Any>) {}
+  fun setForcedFeatures(forcedFeatures: Map<String, GBValue>) {}
   ```
 
-- The getForcedFeatures method for mapping model object for request's body type
-
-  ```kotlin
-  fun getForcedFeatures(): List<List<Any>> {}
-  ```
-
-- The setAttributes method replaces the Map of user attributes that are used to assign variations
+- The getForcedFeatures method returns the Map of currently set forced features
 
   ```kotlin
-  fun setAttributes(attributes: Map<String, Any>) {}
+  fun getForcedFeatures(): Map<String, GBValue> {}
   ```
-- **NEW:** The setAttributesSync method is a synchronous version that waits for sticky bucket assignments to load before returning. Use this for login, logout, and user switching to prevent race conditions.
+
+- The setAttributes method replaces the Map of user attributes that are used to assign variations.
+
   ```kotlin
-    suspend fun setAttributesSync(attributes: Map) {}
+  fun setAttributes(attributes: Map<String, GBValue>) {}
   ```
-  Example usage:
-    ```kotlin
-   lifecycleScope.launch {
+
+- The setAttributeOverrides method replaces the Map of attribute overrides used for Sticky Bucketing.
+
+  ```kotlin
+  fun setAttributeOverrides(overrides: Map<String, GBValue>) {}
+  ```
+
+- If you use Sticky Bucketing and need to guarantee that assignments are loaded before evaluating
+  experiments (e.g. after login or user switch), use the coroutine versions:
+
+  ```kotlin
+  suspend fun setAttributesSync(attributes: Map<String, GBValue>) {}
+  suspend fun setAttributeOverridesSync(overrides: Map<String, GBValue>) {}
+  ```
+
+  Example:
+  ```kotlin
+  lifecycleScope.launch {
       sdk.setAttributesSync(loginAttributes)
-      // Sticky buckets are guaranteed to be loaded here
-      val result = sdk.feature("my-experiment")
+      val result = sdk.feature("my-experiment") // sticky buckets guaranteed
   }
   ```
-
-- The setAttributeOverrides method replaces the Map of user overrides attribute that are used for Sticky Bucketing
-
-  ```kotlin
-  fun setAttributeOverrides(overrides: Map<String, Any>) {}
-  ```
-- **NEW:** The setAttributeOverridesSync method is a synchronous version that waits for sticky bucket assignments to load
-    ```kotlin
-  suspend fun setAttributeOverridesSync(overrides: Map) {}
-    ```
 
 - The setForcedVariations method setup the Map of user's (forced) variations to assign a specific variation (used for
   QA)
 
   ```kotlin
   fun setForcedVariations(forcedVariations: Map<String, Any>) {}
-  ```
-
-- Delegate that call refresh Sticky Bucket Service after success fetched features
-
-  ```kotlin
-  fun featuresAPIModelSuccessfully(model: FeaturesDataModel) {}
   ```
 
 ## Models

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ var sdkInstance: GrowthBookSDK = GBSDKBuilder(
 ```
 If you are accessing features the first time there will be no features right after `initialize()` method call because features are not got from Backend yet. If you need to access features as soon as possible, you need to use `GBCacheRefreshHandler`. You can pass your implementation of `GBCacheRefreshHandler` through `setRefreshHandler()` method.
 
+> **Threading:** the fetched payload is processed on a background dispatcher, so `GBCacheRefreshHandler` is invoked off the main thread. Marshal back to your UI thread yourself if the callback touches UI state. `feature()`/`run()` are safe to call from any thread and always evaluate against a single consistent snapshot of the loaded state.
+
 #### There are additional properties which can be setup at the time of initialization
 
 ```kotlin


### PR DESCRIPTION
# Problem

Sticky bucketing had several correctness bugs, plus an underlying thread-safety flaw that made evaluation state inconsistent under concurrent refresh.

1. Wrong attribute lookup - `getStickyBucketAssignments` passed arguments in the wrong order (`attr = null`, `fallback = expFallBackAttribute`), causing incorrect bucket filtering. Users could receive assignments that weren't theirs.
2. Assignments overwriting each other - each `feature()`/`run()` built a fresh evaluation context from `gbContext`; new sticky assignments lived only on that local context and were lost between calls, so sequential experiments clobbered each other in `stickyBucketAssignmentDocs`.
3. Race condition - sticky buckets were refreshed fire-and-forget while features were applied immediately, so `feature() `could evaluate before assignments were loaded.
4. Torn reads under concurrency - evaluation read `features`, `attributes`, `stickyBucketAssignmentDocs`, etc. as separate fields, so a background refresh could expose a mix of new features with stale sticky docs.
5. Constructor `savedGroups` ignored - `savedGroups` passed to the SDK were written to an unused private field and never reached evaluation.

## Changes

### Correctness
- `GBUtils` - fixed argument order in `getStickyBucketAssignments` (`attr = expFallBackAttribute`, `fallback = null`); renamed efreshStickyBucketsSync → refreshStickyBuckets (drop misleading "Sync").
- Ordering - added suspend fun `onPayloadReady` to `FeaturesFlowDelegate`, awaited before features are applied (mirrors TypeScript setPayload: await refreshStickyBuckets → set features).
- `savedGroups` - constructor-supplied saved groups are now stored on the context so they reach evaluation.
- `attributeOverrides` — wired into evaluation.

### Thread-safety (root cause)
- All cross-thread evaluation inputs (`features`, `attributes`, `forcedVariations`, `stickyBucketAssignmentDocs`, `stickyBucketIdentifierAttributes`, `savedGroups`) now live in a single immutable `EvalSnapshot` behind an `AtomicReference`. Evaluation reads one snapshot, so it never observes a torn mix of state.
- Sticky assignments generated during evaluation are merged back into the context one key at a time, atomically (`GBContext.mergeStickyAssignmentDoc` via a new `EvaluationContext.onStickyAssignmentChanged` callback), replacing the previous whole-map write-back that could clobber a concurrent refresh. Mirrors the TypeScript SDK's single-key update, made atomic for the multithreaded context. So a concurrent reader can't see new attributes paired with the old user's docs.
    
### Dispatcher / lifecycle
- The fetched payload is processed on `PlatformDependentIODispatcher` (IO) instead of `Dispatchers.Unconfined`; the dispatcher is injectable (`GBSDKBuilder.setCoroutineContext`) so tests drive the pipeline deterministically.
Note: refreshHandler is now invoked on a background thread.
- Added `GrowthBookSDK.close() `(stops SSE + cancels the background scope) to avoid leaking coroutines across repeated initializations.
    
### Breaking
- `GBContext` is no longer a data class: the generated `copy()`, `equals()`, `hashCode()` and `componentN()` members are gone. The constructor signature and all property accessors are unchanged.