### PR TITLE
feat: configurable cache TTL and exponential backoff for suspendFeature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [7.3.0] - 2026-06-00
 
-## [7.2.0] - 2026-06-12
+### Added
+- `GBSDKBuilder.setCacheMaxAge()` — configurable cache freshness window; while the
+  cache is younger than the given age, the next fetch is served from cache and the
+  network call is skipped. `refreshCache()` always bypasses this window.
+
+### Changed
+- `suspendFeature()` now retries failed fetches with exponential backoff (capped)
+  instead of an unbounded recursive loop, preventing DNS request flooding when the
+  network is unavailable (#236).
+- Concurrent feature refreshes are now coalesced into a single shared in-flight
+  request, so N parallel `suspendFeature()` callers no longer trigger N network
+  fetches.
+
+---
+
+## [7.2.0] - 2026-06-119
 
 ### Added
 - `GBSDKBuilder.setInitialFeatures()` — seed the SDK with a bundled fallback payload; features are applied immediately and the normal cache/network refresh still runs on top (network > disk cache > seed > code defaults)

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.2.0"
+version = "7.3.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -126,6 +126,9 @@ class GBSDKBuilder(
         return this
     }
 
+    /**
+    * Method for enable  default sticky bucket service
+    */
     fun setStickyBucketService(coroutineScope: CoroutineScope): GBSDKBuilder {
         return setStickyBucketService(
             GBStickyBucketServiceImp(
@@ -179,6 +182,8 @@ class GBSDKBuilder(
      * result. Once the cache is older, the SDK refetches from the network.
      * This is a cache-staleness gate evaluated on the next fetch, not a
      * background polling mechanism. When unset, the SDK always refetches.
+     * To force a network refresh regardless of this window, call
+     * [GrowthBookSDK.refreshCache].
      *
      * @param cacheMaxAge freshness window in milliseconds.
      */

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -105,7 +105,7 @@ class GBSDKBuilder(
     private var stickyBucketService: GBStickyBucketService? = null
     private var featureUsageCallback: GBFeatureUsageCallback? = null
     private var initialFeatures: GBFeatures? = null
-    private var backgroundFetchInterval: Long? = null
+    private var cacheMaxAge: Long? = null
 
     /**
      * Set Refresh Handler - Will be called when cache is refreshed
@@ -171,8 +171,19 @@ class GBSDKBuilder(
         return this
     }
 
-    fun setBackgroundFetchInterval(intervalMs: Long): GBSDKBuilder {
-        this.backgroundFetchInterval = intervalMs
+    /**
+     * Sets the freshness window for cached features.
+     *
+     * While the cache is younger than this age, the network call on the next
+     * fetch is skipped and the cached features are served as the authoritative
+     * result. Once the cache is older, the SDK refetches from the network.
+     * This is a cache-staleness gate evaluated on the next fetch, not a
+     * background polling mechanism. When unset, the SDK always refetches.
+     *
+     * @param cacheMaxAge freshness window in milliseconds.
+     */
+    fun setCacheMaxAge(cacheMaxAge: Long): GBSDKBuilder {
+        this.cacheMaxAge = cacheMaxAge
         return this
     }
 
@@ -215,7 +226,7 @@ class GBSDKBuilder(
             refreshHandler,
             networkDispatcher,
             cachingEnabled = cachingEnabled,
-            backgroundFetchInterval = backgroundFetchInterval,
+            cacheMaxAge = cacheMaxAge,
         )
     }
 
@@ -268,7 +279,7 @@ class GBSDKBuilder(
                 internalRefreshHandler,
                 networkDispatcher,
                 cachingEnabled = cachingEnabled,
-                backgroundFetchInterval = backgroundFetchInterval
+                cacheMaxAge = cacheMaxAge
             )
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -103,6 +103,7 @@ class GBSDKBuilder(
     private var refreshHandler: GBCacheRefreshHandler? = null
     private var stickyBucketService: GBStickyBucketService? = null
     private var featureUsageCallback: GBFeatureUsageCallback? = null
+    private var backgroundFetchInterval: Long? = null
 
     /**
      * Set Refresh Handler - Will be called when cache is refreshed
@@ -157,6 +158,11 @@ class GBSDKBuilder(
         return this
     }
 
+    fun setBackgroundFetchInterval(intervalMs: Long): GBSDKBuilder {
+        this.backgroundFetchInterval = intervalMs
+        return this
+    }
+
     /**
      * Initialize the Kotlin SDK and provide it when ready
      */
@@ -194,6 +200,7 @@ class GBSDKBuilder(
             refreshHandler,
             networkDispatcher,
             cachingEnabled = cachingEnabled,
+            backgroundFetchInterval = backgroundFetchInterval,
         )
     }
 
@@ -244,6 +251,7 @@ class GBSDKBuilder(
                 internalRefreshHandler,
                 networkDispatcher,
                 cachingEnabled = cachingEnabled,
+                backgroundFetchInterval = backgroundFetchInterval
             )
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -58,6 +58,7 @@ class GrowthBookSDK(
     features: GBFeatures? = null,
     savedGroups: Map<String, GBValue>? = null,
     cachingEnabled: Boolean,
+    private val backgroundFetchInterval: Long? = null,
 ) : FeaturesFlowDelegate {
 
     private var savedGroups: Map<String, GBValue>? = emptyMap()
@@ -82,6 +83,7 @@ class GrowthBookSDK(
         ),
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,
+        backgroundFetchInterval = backgroundFetchInterval,
         cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
     )
 
@@ -89,7 +91,11 @@ class GrowthBookSDK(
         if (features != null) {
             gbContext.features = features
         } else {
-            refreshCache()
+            if (gbContext.remoteEval) {
+                refreshForRemoteEval()
+            } else {
+                featuresViewModel.fetchFeatures()
+            }
         }
         this.savedGroups = savedGroups
         refreshStickyBucketService()
@@ -102,7 +108,7 @@ class GrowthBookSDK(
         if (gbContext.remoteEval) {
             refreshForRemoteEval()
         } else {
-            featuresViewModel.fetchFeatures()
+            featuresViewModel.fetchFeatures(forceRefresh = true)
         }
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -249,20 +249,22 @@ class GrowthBookSDK(
      * @returns a [GBFeatureResult] object
      */
     suspend fun suspendFeature(id: String): GBFeatureResult {
-        return when (remoteSourceFeaturesFetchResult) {
-            FeaturesFetchResult.Success -> {
-                feature(id)
-            }
+        var attempt = 0
+        var delaysMs = INITIAL_RETRY_DELAY_MILLIS
 
-            FeaturesFetchResult.NoResultYet -> {
-                delay(TIME_FOR_CALL_WAIT_MILLIS)
-                suspendFeature(id)
-            }
+        while (true) {
+            when (remoteSourceFeaturesFetchResult) {
+                FeaturesFetchResult.Success -> return feature(id)
 
-            FeaturesFetchResult.Failed -> {
-                featuresViewModel.fetchFeatures()
-                delay(TIME_FOR_CALL_WAIT_MILLIS)
-                suspendFeature(id)
+                FeaturesFetchResult.NoResultYet -> delay(TIME_FOR_CALL_WAIT_MILLIS)
+
+                FeaturesFetchResult.Failed -> {
+                    if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
+                    featuresViewModel.fetchFeatures(forceRefresh = true)
+                    delay(delaysMs)
+                    delaysMs = minOf(delaysMs * 2, MAX_RETRY_DELAY_MILLIS)
+                    attempt++
+                }
             }
         }
     }
@@ -519,6 +521,9 @@ class GrowthBookSDK(
 
         // After this period of time a call status is checked again
         private const val TIME_FOR_CALL_WAIT_MILLIS = 1000L
+        private const val INITIAL_RETRY_DELAY_MILLIS = 1000L
+        private const val MAX_RETRY_DELAY_MILLIS = 60_000L
+        private const val MAX_RETRY_ATTEMPTS = 5
 
         private fun createEvaluationContext(
             gbContext: GBContext,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -261,6 +261,9 @@ class GrowthBookSDK(
                 FeaturesFetchResult.Failed -> {
                     if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
                     featuresViewModel.fetchFeatures(forceRefresh = true)
+                    if (gbContext.enableLogging) {
+                        GB.log("GrowthBookSDK: suspendFeature: retry attempt ${attempt + 1}/$MAX_RETRY_ATTEMPTS, waiting ${delaysMs}ms")
+                    }
                     delay(delaysMs)
                     delaysMs = minOf(delaysMs * 2, MAX_RETRY_DELAY_MILLIS)
                     attempt++

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -21,7 +21,6 @@ import com.sdk.growthbook.features.FeaturesDataModel
 import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
-import com.sdk.growthbook.features.FetchPolicy
 import com.sdk.growthbook.model.GBJson
 import com.sdk.growthbook.model.GBNull
 import com.sdk.growthbook.model.GBArray
@@ -119,7 +118,7 @@ class GrowthBookSDK(
         if (gbContext.remoteEval) {
             refreshForRemoteEval()
         } else {
-            featuresViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork)
+            featuresViewModel.revalidate()
         }
     }
 
@@ -271,7 +270,7 @@ class GrowthBookSDK(
 
                 FeaturesFetchResult.Failed -> {
                     if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
-                    featuresViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork)
+                    featuresViewModel.awaitRefresh()
                     if (gbContext.enableLogging) {
                         GB.log("GrowthBookSDK: suspendFeature: retry attempt ${attempt + 1}/$MAX_RETRY_ATTEMPTS, waiting ${delaysMs}ms")
                     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -21,6 +21,7 @@ import com.sdk.growthbook.features.FeaturesDataModel
 import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
+import com.sdk.growthbook.features.FetchPolicy
 import com.sdk.growthbook.model.GBJson
 import com.sdk.growthbook.model.GBNull
 import com.sdk.growthbook.model.GBArray
@@ -58,7 +59,7 @@ class GrowthBookSDK(
     features: GBFeatures? = null,
     savedGroups: Map<String, GBValue>? = null,
     cachingEnabled: Boolean,
-    private val backgroundFetchInterval: Long? = null,
+    private val cacheMaxAge: Long? = null,
 ) : FeaturesFlowDelegate {
 
     private var savedGroups: Map<String, GBValue>? = emptyMap()
@@ -87,7 +88,7 @@ class GrowthBookSDK(
         ),
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,
-        backgroundFetchInterval = backgroundFetchInterval,
+        cacheMaxAge = cacheMaxAge,
         cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
     )
 
@@ -107,13 +108,18 @@ class GrowthBookSDK(
     }
 
     /**
-     * Manually Refresh Cache
+     * Manually refreshes features from the network.
+     *
+     * This is an explicit refresh and always bypasses the cache freshness
+     * window set via [GBSDKBuilder.setCacheMaxAge]: it hits the network even
+     * if the cached features are still within their max age. In remote-eval
+     * mode it re-runs the remote evaluation instead.
      */
     fun refreshCache() {
         if (gbContext.remoteEval) {
             refreshForRemoteEval()
         } else {
-            featuresViewModel.fetchFeatures(forceRefresh = true)
+            featuresViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork)
         }
     }
 
@@ -265,7 +271,7 @@ class GrowthBookSDK(
 
                 FeaturesFetchResult.Failed -> {
                     if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
-                    featuresViewModel.fetchFeatures(forceRefresh = true)
+                    featuresViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork)
                     if (gbContext.enableLogging) {
                         GB.log("GrowthBookSDK: suspendFeature: retry attempt ${attempt + 1}/$MAX_RETRY_ATTEMPTS, waiting ${delaysMs}ms")
                     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturePayloadDecoder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturePayloadDecoder.kt
@@ -1,0 +1,26 @@
+package com.sdk.growthbook.features
+
+import com.sdk.growthbook.utils.Crypto
+import com.sdk.growthbook.utils.DefaultCrypto
+import com.sdk.growthbook.utils.GBError
+import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.getFeaturesFromEncryptedFeatures
+import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
+import kotlinx.serialization.json.JsonObject
+
+/** Resolves a [FeaturesDataModel] into usable features/savedGroups, decrypting when needed. */
+internal class FeaturePayloadDecoder(private val encryptionKey: String?) {
+    fun decode(m: FeaturesDataModel) = DecodedPayload(
+        features = decode(m.features, m.encryptedFeatures, ::getFeaturesFromEncryptedFeatures),
+        savedGroups = decode(m.savedGroups, m.encryptedSavedGroups, ::getSavedGroupFromEncryptedSavedGroup)
+    )
+
+    private fun <T: Map<*, *>> decode(plain: T?, encrypted: String?, decrypt: (String, String, Crypto?) -> T?) : T? {
+        plain?.takeIf { it.isNotEmpty() }?.let { return it }
+        val e = encrypted ?: return null
+        val key = encryptionKey?.takeIf { it.isNotEmpty() } ?: return null
+        return decrypt(e, key, DefaultCrypto())
+    }
+}
+
+internal data class DecodedPayload(val features: GBFeatures?, val savedGroups: JsonObject?)

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -13,8 +13,18 @@ import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBRemoteEvalParams
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonObject
+import kotlin.coroutines.resume
 import kotlin.time.Clock
 
 /**
@@ -35,14 +45,61 @@ internal interface FeaturesFlowDelegate {
  * Pipeline: source (cache|network|SSE) -> decode -> FetchOutcome -> dispatch.
  */
 internal class FeaturesViewModel(
+    /**
+     * Receiver of fetch outcomes. Every cache/network/SSE result is reported here
+     * (success, failure, 304-not-modified, saved groups) so the owning SDK can
+     * apply the features to its context and fire the refresh handler.
+     */
     private val delegate: FeaturesFlowDelegate,
+    /**
+     * Performs the actual fetches, independent of caching: network GET (with
+     * 304 handling), remote-eval POST, and the SSE stream. This view model adds
+     * the cache and coalescing logic on top of it.
+     */
     private val dataSource: FeaturesDataSource,
+    /**
+     * Key used to decrypt encrypted payloads; null when features arrive in
+     * plaintext. Also seeds the default [decoder].
+     */
     private val encryptionKey: String? = null,
+    /**
+     * Gates cache *writes* only: when true, a successful network payload is
+     * persisted to [cachingLayer]. Cache *reads* (see [serveCache]) happen
+     * regardless, so bundled/previously cached data can still be served.
+     */
     private val cachingEnabled: Boolean,
+    /**
+     * Filename under which the payload is stored in [cachingLayer]. The caller
+     * namespaces it per API key to keep multiple SDK instances isolated.
+     */
     private val cacheKey: String = Constants.FEATURE_CACHE,
+    /**
+     * Storage backend for the cached payload: read in [serveCache], written in
+     * [handleNetworkModel]. Defaults to the platform's shared caching layer.
+     */
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
+    /**
+     * Cache freshness window in milliseconds. While the cached payload is younger
+     * than this, a [FetchPolicy.CacheFirst] fetch is served from cache and the
+     * network is skipped; once older, the SDK refetches. null means always refetch.
+     * Mirrors [com.sdk.growthbook.GBSDKBuilder.setCacheMaxAge].
+     */
     private val cacheMaxAge: Long? = null,
-    private val decoder: FeaturePayloadDecoder = FeaturePayloadDecoder(encryptionKey)
+    /**
+     * Turns a raw [FeaturesDataModel] into a [DecodedPayload] (features + saved
+     * groups), decrypting with [encryptionKey] when needed. Injectable for tests.
+     */
+    private val decoder: FeaturePayloadDecoder = FeaturePayloadDecoder(encryptionKey),
+    /**
+     * Scope that owns the coalesced refresh started by [awaitRefresh] (used by
+     * suspendFeature() retries and [revalidate]). It must outlive any single
+     * caller, so cancelling one caller never tears down a refresh shared with
+     * others ([SupervisorJob] isolates failures too). Only lightweight coordination
+     * runs here (mutex bookkeeping, continuation resumption); the actual HTTP runs
+     * on the network dispatcher's own IO scope. Injectable so tests can supply a
+     * deterministic dispatcher.
+     */
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
 ) {
 
     /**
@@ -50,6 +107,21 @@ internal class FeaturesViewModel(
      */
     val sseController: SSEConnectionController
         get() = dataSource.sseController
+
+    /**
+     * Guards reads and writes of [inFlight] so the check-or-start decision in
+     * [awaitRefresh] is atomic across concurrent callers. Held only for that brief
+     * bookkeeping, never for the duration of the network call.
+     */
+    private val refreshMutex = Mutex()
+
+    /**
+     * The currently running coalesced refresh, or null when none is in flight.
+     * Concurrent [awaitRefresh] callers await this same [Deferred] instead of each
+     * starting their own request; it is cleared once the request completes (in a
+     * `finally`, before the result is observable), so the next round starts fresh.
+     */
+    private var inFlight: Deferred<FetchResult>? = null
 
     /** Opens an SSE connection and streams feature updates as a [Flow]. */
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
@@ -75,6 +147,63 @@ internal class FeaturesViewModel(
         if (serveCache(remoteEval, policy)) return // fresh cache -> authoritative, skip network
         fetchFromNetwork(remoteEval, payload)
     }
+
+    /**
+     * Coalesced network refresh: concurrent callers share a single in-flight
+     * GET instead of each firing their own. The first caller starts the request
+     * and stores its [Deferred] in [inFlight]; callers arriving while it runs
+     * await the same result. The slot is cleared once the request completes, so
+     * the next round (e.g. a backoff retry) starts a fresh request.
+     *
+     * This is the network primitive beneath the cache-aware [fetchFeatures];
+     * it always hits the network (GET only) and carries no [FetchPolicy].
+     */
+    suspend fun awaitRefresh(): FetchResult {
+        val deferred = refreshMutex.withLock {
+            inFlight ?: scope.async {
+                try {
+                    runNetworkGet()
+                } finally {
+                    refreshMutex.withLock { inFlight = null }
+                }
+            }.also { inFlight = it }
+        }
+        return deferred.await()
+    }
+
+    /**
+     * Stale-while-revalidate refresh backing [com.sdk.growthbook.GrowthBookSDK.refreshCache].
+     * Serves any cached payload immediately as non-authoritative, then triggers a
+     * coalesced network revalidation that joins an in-flight [awaitRefresh] instead
+     * of starting a duplicate request. Always bypasses cache freshness (see
+     * [FetchPolicy.ForceNetwork]).
+     *
+     * Fire-and-forget: the network round runs on [scope]; observe completion via
+     * the refresh handler rather than expecting features to be ready on return.
+     */
+    fun revalidate() {
+        serveCache(remoteEval = false, policy = FetchPolicy.ForceNetwork)
+        scope.launch { awaitRefresh() }
+    }
+
+    /** Bridges the callback-based GET into a suspend result for [awaitRefresh]. */
+    private suspend fun runNetworkGet(): FetchResult =
+        suspendCancellableCoroutine { cont ->
+            dataSource.fetchFeatures(
+                success = {
+                    handleNetworkModel(it)
+                    cont.resume(FetchResult.Success)
+                },
+                failure = {
+                    dispatch(FetchOutcome.Failed(GBError(it), source = Source.NETWORK))
+                    cont.resume(FetchResult.Failed)
+                },
+                onNotModified = {
+                    dispatch(FetchOutcome.NotModified)
+                    cont.resume(FetchResult.NotModified)
+                }
+            )
+        }
 
     private fun serveCache(remoteEval: Boolean, policy: FetchPolicy): Boolean {
         val entry = runCatching { readCache() }.getOrElse {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -17,6 +17,7 @@ import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Clock
 
 /**
  * Interface for Feature API Completion Events
@@ -40,6 +41,7 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
+    private val backgroundFetchInterval: Long? = null
 ) {
 
     /**
@@ -51,13 +53,21 @@ internal class FeaturesViewModel(
     /**
      * Fetch Features
      */
-    fun fetchFeatures(remoteEval: Boolean = false, payload: GBRemoteEvalParams? = null) {
+    fun fetchFeatures(remoteEval: Boolean = false, payload: GBRemoteEvalParams? = null, forceRefresh: Boolean = false) {
         try {
             // Check for cache data
-            val dataModel = getDataFromCache()
-            if (dataModel != null) {
+            val cachedEntry = getDataFromCache()
+            if (cachedEntry != null) {
                 // Call Success Delegate with mention of data available but its not remote
-                handleFetchFeaturesWithoutRemoteEval(dataModel)
+                handleFetchFeaturesWithoutRemoteEval(cachedEntry.first)
+                if (!forceRefresh && !remoteEval) {
+                    val cachedAt = cachedEntry.second
+                    if (backgroundFetchInterval != null && cachedAt != null) {
+                        if (Clock.System.now().toEpochMilliseconds() - cachedAt < backgroundFetchInterval) {
+                            return
+                        }
+                    }
+                }
             }
         } catch (error: Throwable) {
             // Call Error Delegate with mention of data not available but its not remote
@@ -119,12 +129,12 @@ internal class FeaturesViewModel(
         }
     }
 
-    private fun getDataFromCache(): FeaturesDataModel? {
-        val dataModel = cachingLayer.getData(
+    private fun getDataFromCache(): Pair<FeaturesDataModel, Long?>? {
+        val serializable = cachingLayer.getData(
             cacheKey,
             SerializableFeaturesDataModel.serializer()
-        )
-        return dataModel?.gbDeserialize()
+        ) ?: return null
+        return serializable.gbDeserialize() to serializable.cachedAt
     }
 
     /**
@@ -244,7 +254,7 @@ internal class FeaturesViewModel(
     private fun putDataToCache(dataModel: FeaturesDataModel) {
         cachingLayer.putData(
             fileName = cacheKey,
-            content = dataModel.gbSerialize(),
+            content = dataModel.gbSerialize().copy(cachedAt = Clock.System.now().toEpochMilliseconds()),
             serializer = SerializableFeaturesDataModel.serializer()
         )
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -1,21 +1,18 @@
 package com.sdk.growthbook.features
 
-import com.sdk.growthbook.utils.Constants
-import com.sdk.growthbook.utils.DefaultCrypto
-import com.sdk.growthbook.utils.GBError
-import com.sdk.growthbook.utils.GBFeatures
-import com.sdk.growthbook.utils.GBRemoteEvalParams
-import com.sdk.growthbook.utils.Resource
-import com.sdk.growthbook.utils.getFeaturesFromEncryptedFeatures
+import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.sandbox.CachingLayer
 import com.sdk.growthbook.sandbox.getData
 import com.sdk.growthbook.sandbox.putData
 import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
+import com.sdk.growthbook.utils.Constants
+import com.sdk.growthbook.utils.GBError
+import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.GBRemoteEvalParams
+import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
-import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
-import com.sdk.growthbook.logger.GB
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonObject
 import kotlin.time.Clock
@@ -33,7 +30,9 @@ internal interface FeaturesFlowDelegate {
 }
 
 /**
- * View Model for Features
+ * Orchestrates feature loading: serves cache first, then falls back to the
+ * network, decodes the payload and notifies [delegate] of the outcome.
+ * Pipeline: source (cache|network|SSE) -> decode -> FetchOutcome -> dispatch.
  */
 internal class FeaturesViewModel(
     private val delegate: FeaturesFlowDelegate,
@@ -42,7 +41,8 @@ internal class FeaturesViewModel(
     private val cachingEnabled: Boolean,
     private val cacheKey: String = Constants.FEATURE_CACHE,
     private val cachingLayer: CachingLayer = CachingImpl.getLayer(),
-    private val backgroundFetchInterval: Long? = null
+    private val cacheMaxAge: Long? = null,
+    private val decoder: FeaturePayloadDecoder = FeaturePayloadDecoder(encryptionKey)
 ) {
 
     /**
@@ -51,216 +51,144 @@ internal class FeaturesViewModel(
     val sseController: SSEConnectionController
         get() = dataSource.sseController
 
-    /**
-     * Fetch Features
-     */
-    fun fetchFeatures(remoteEval: Boolean = false, payload: GBRemoteEvalParams? = null, forceRefresh: Boolean = false) {
-        try {
-            // Check for cache data
-            val cachedEntry = getDataFromCache()
-            if (cachedEntry != null) {
-                // Call Success Delegate with mention of data available but its not remote
-                handleFetchFeaturesWithoutRemoteEval(cachedEntry.first)
-                if (!forceRefresh && !remoteEval) {
-                    val cachedAt = cachedEntry.second
-                    if (backgroundFetchInterval != null && cachedAt != null) {
-                        if (Clock.System.now().toEpochMilliseconds() - cachedAt < backgroundFetchInterval) {
-                            return
-                        }
-                    }
-                }
-            }
-        } catch (error: Throwable) {
-            GB.error("FeaturesViewModel: cache read failed", error)
-            this.delegate.featuresFetchFailed(GBError(error), false)
-        }
-        handleFetchFeaturesWithRemoteEval(remoteEval, payload)
-    }
-
-    private fun handleFetchFeaturesWithRemoteEval(
-        remoteEval: Boolean,
-        payload: GBRemoteEvalParams?
-    ) {
-        if (remoteEval) {
-            dataSource.fetchRemoteEval(
-                params = payload,
-                success = { responseFeaturesDataModel ->
-                    prepareFeaturesDataForRemoteEval(responseFeaturesDataModel.data)
-                },
-                failure = { error ->
-                    this.delegate.featuresFetchFailed(GBError(error.exception), true)
-                }
-            )
-        } else {
-            dataSource.fetchFeatures(
-                success = { dataModel ->
-                    prepareFeaturesDataForRemoteEval(dataModel)
-                },
-                failure = { error ->
-                    // Call Error Delegate with mention of data not available but its not remote
-                    this.delegate.featuresFetchFailed(GBError(error), true)
-                },
-                onNotModified = {
-                    this.delegate.featuresNotModified()
-                }
-            )
-        }
-    }
-
-    private fun handleFetchFeaturesWithoutRemoteEval(dataModel: FeaturesDataModel) {
-        dataModel.features?.let {
-            this.delegate.featuresFetchedSuccessfully(
-                features = it,
-                isRemote = false
-            )
-        }
-        dataModel.encryptedFeatures?.let { encryptedFeatures: String ->
-            encryptionKey?.let { encryptionKey ->
-                val features = getFeaturesFromEncryptedFeatures(
-                    encryptedString = encryptedFeatures,
-                    encryptionKey = encryptionKey,
-                )
-                features?.let {
-                    this.delegate.featuresFetchedSuccessfully(
-                        features = it,
-                        isRemote = false
-                    )
-                }
-            }
-        }
-    }
-
-    private fun getDataFromCache(): Pair<FeaturesDataModel, Long?>? {
-        val serializable = cachingLayer.getData(
-            cacheKey,
-            SerializableFeaturesDataModel.serializer()
-        ) ?: return null
-        return serializable.gbDeserialize() to serializable.cachedAt
-    }
-
-    /**
-     * Supportive method for automatically refresh features
-     */
+    /** Opens an SSE connection and streams feature updates as a [Flow]. */
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
         sseController.start()
-        return dataSource.autoRefresh(success = { dataModel ->
-            prepareFeaturesDataForRemoteEval(dataModel = dataModel)
-        }, failure = { error ->
-            // Call Error Delegate with mention of data not available but its not remote
-            this.delegate.featuresFetchFailed(GBError(error), true)
-        })
+        return dataSource.autoRefresh(
+            success = { handleNetworkModel(it) },
+            failure = { delegate.featuresFetchFailed(GBError(it), isRemote = true) }
+        )
     }
 
     /**
-     * Cache API Response and push success event
+     * @param remoteEval evaluate features remotely via POST instead of a regular GET.
+     * @param payload attributes/forced features sent with the remote-eval request;
+     *   used only when [remoteEval] is true, ignored otherwise.
+     * @param policy whether a fresh cache may satisfy this fetch or the network
+     *   must always be hit; see [FetchPolicy].
      */
-    private fun prepareFeaturesDataForRemoteEval(dataModel: FeaturesDataModel?) {
-        var features = dataModel?.features
-        var savedGroups = dataModel?.savedGroups
-        val encryptedFeatures = dataModel?.encryptedFeatures
-        val encryptedSavedGroups = dataModel?.encryptedSavedGroups
+    fun fetchFeatures(
+        remoteEval: Boolean = false,
+        payload: GBRemoteEvalParams? = null,
+        policy: FetchPolicy = FetchPolicy.CacheFirst
+    ) {
+        if (serveCache(remoteEval, policy)) return // fresh cache -> authoritative, skip network
+        fetchFromNetwork(remoteEval, payload)
+    }
 
-        try {
-            if (dataModel != null) {
-                delegate.featuresAPIModelSuccessfully(dataModel)
-                if (cachingEnabled) {
-                    try {
-                        putDataToCache(dataModel)
-                    } catch (e: Throwable) {
-                        GB.error("FeaturesViewModel: cache write failed, features still applied", e)
-                    }
-                }
-                if (!features.isNullOrEmpty()) {
-                    this.delegate.featuresFetchedSuccessfully(
-                        features = features,
-                        isRemote = true
-                    )
-                    return
-                } else {
-                    if (encryptedFeatures != null && encryptionKey != null) {
-                        if (encryptionKey.isNotEmpty()) {
-                            val crypto = DefaultCrypto()
-                            features =
-                                getFeaturesFromEncryptedFeatures(
-                                    encryptedString = encryptedFeatures,
-                                    encryptionKey = encryptionKey,
-                                    subtleCrypto = crypto
-                                ) ?: return
+    private fun serveCache(remoteEval: Boolean, policy: FetchPolicy): Boolean {
+        val entry = runCatching { readCache() }.getOrElse {
+            GB.error("FeaturesViewModel: cache read failed", it)
+            delegate.featuresFetchFailed(error = GBError(it), isRemote = false)
+            return false
+        } ?: return false
 
-                            this.delegate.featuresFetchedSuccessfully(
-                                features = features,
-                                isRemote = true
-                            )
-                            return
-                        } else {
-                            features?.let {
-                                this.delegate.featuresFetchedSuccessfully(
-                                    features = features,
-                                    isRemote = true
-                                )
-                                return
-                            }
-                        }
-                    } else {
-                        this.delegate.featuresFetchFailed(
-                            error = GBError(Exception()),
-                            isRemote = true
-                        )
-                        return
-                    }
-                }
+        val (model, cachedAt) = entry
+        val fresh = policy == FetchPolicy.CacheFirst && !remoteEval && cacheMaxAge != null
+            && cachedAt != null
+            && Clock.System.now().toEpochMilliseconds() - cachedAt < cacheMaxAge
 
-                if (!savedGroups.isNullOrEmpty()) {
-                    this.delegate.savedGroupsFetchedSuccessfully(
-                        savedGroups = savedGroups,
-                        isRemote = true
-                    )
-                } else {
-                    if (encryptedSavedGroups != null && encryptionKey != null) {
-                        if (encryptionKey.isNotEmpty()) {
-                            val crypto = DefaultCrypto()
-                            savedGroups =
-                                getSavedGroupFromEncryptedSavedGroup(
-                                    encryptedString = encryptedSavedGroups,
-                                    encryptionKey = encryptionKey,
-                                    subtleCrypto = crypto
-                                ) ?: return
+        dispatch(
+            outcome = FetchOutcome.Ready(
+                payload = decoder.decode(m = model),
+                source = Source.CACHE,
+                authoritative = fresh
+            )
+        )
+        return fresh
+    }
 
-                            this.delegate.savedGroupsFetchedSuccessfully(
-                                savedGroups = savedGroups,
-                                isRemote = true
-                            )
-                            return
-                        } else {
-                            savedGroups?.let {
-                                this.delegate.savedGroupsFetchedSuccessfully(
-                                    savedGroups = savedGroups,
-                                    isRemote = true
-                                )
-                                return
-                            }
-                        }
-                    } else {
-                        this.delegate.savedGroupsFetchFailed(
-                            error = GBError(Exception()),
-                            isRemote = true
-                        )
-                        return
-                    }
-                }
+    private fun fetchFromNetwork(remoteEval: Boolean, payload: GBRemoteEvalParams?) {
+        if (remoteEval) dataSource.fetchRemoteEval(
+            params = payload,
+            success = { handleNetworkModel(it.data) },
+            failure = {
+                delegate.featuresFetchFailed(
+                    error = GBError(it.exception),
+                    isRemote = true
+                )
             }
+        ) else dataSource.fetchFeatures(
+            success = { handleNetworkModel(it) },
+            failure = { delegate.featuresFetchFailed(error = GBError(it), isRemote = true) },
+            onNotModified = { dispatch(outcome = FetchOutcome.NotModified) }
+        )
+    }
+
+    private fun handleNetworkModel(model: FeaturesDataModel) {
+        try {
+            delegate.featuresAPIModelSuccessfully(model)
+            if (cachingEnabled) {
+                runCatching { writeCache(model) }
+                    .onFailure {
+                        GB.error(
+                            errorMessage = "FeaturesViewModel: cache write failed, features still applied",
+                            throwable = it
+                        )
+                    }
+            }
+
+            dispatch(
+                outcome = outcomeOf(
+                    payload = decoder.decode(model),
+                    source = Source.NETWORK
+                )
+            )
         } catch (error: Throwable) {
-            GB.error("FeaturesViewModel: failed to process remote features payload", error)
-            this.delegate.featuresFetchFailed(error = GBError(error), isRemote = true)
-            return
+            GB.error(
+                errorMessage = "FeaturesViewModel: failed to process remote features payload",
+                throwable = error
+            )
+
+            delegate.featuresFetchFailed(error = GBError(error), isRemote = true)
         }
     }
 
-    private fun putDataToCache(dataModel: FeaturesDataModel) {
-        cachingLayer.putData(
-            fileName = cacheKey,
-            content = dataModel.gbSerialize().copy(cachedAt = Clock.System.now().toEpochMilliseconds()),
-            serializer = SerializableFeaturesDataModel.serializer()
-        )
+    private fun outcomeOf(payload: DecodedPayload, source: Source): FetchOutcome =
+        if (payload.features == null && payload.savedGroups == null)
+            FetchOutcome.Failed(GBError(Exception()), source)
+        else FetchOutcome.Ready(payload, source, authoritative = true)
+
+    private fun dispatch(outcome: FetchOutcome) = when (outcome) {
+        is FetchOutcome.Ready -> {
+            outcome.payload.features?.let {
+                delegate.featuresFetchedSuccessfully(
+                    features = it,
+                    isRemote = outcome.authoritative
+                )
+            }
+            outcome.payload.savedGroups?.let {
+                delegate.savedGroupsFetchedSuccessfully(
+                    savedGroups = it,
+                    isRemote = outcome.authoritative
+                )
+            }
+        }
+
+        is FetchOutcome.Failed -> {
+            delegate.featuresFetchFailed(
+                error = outcome.error,
+                isRemote = outcome.source == Source.NETWORK
+            )
+        }
+
+        is FetchOutcome.NotModified -> {
+            delegate.featuresNotModified()
+        }
     }
+
+    private fun readCache(): Pair<FeaturesDataModel, Long?>? {
+        val s = cachingLayer
+            .getData(
+                fileName = cacheKey,
+                serializer = SerializableFeaturesDataModel.serializer()
+            ) ?: return null
+        return s.gbDeserialize() to s.cachedAt
+    }
+
+    private fun writeCache(model: FeaturesDataModel) = cachingLayer.putData(
+        fileName = cacheKey,
+        content = model.gbSerialize().copy(cachedAt = Clock.System.now().toEpochMilliseconds()),
+        serializer = SerializableFeaturesDataModel.serializer()
+    )
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchOutcome.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchOutcome.kt
@@ -1,0 +1,16 @@
+package com.sdk.growthbook.features
+
+import com.sdk.growthbook.utils.GBError
+
+/** Result of a feature fetch, flowing into [FeaturesViewModel.dispatch]. */
+internal sealed interface FetchOutcome {
+    /**
+     * Usable payload.
+     * @param authoritative true when this result unblocks suspendFeature()/initialize{}
+     *   (network, or cache still fresh within the TTL); maps to delegate's isRemote.
+     */
+    data class Ready(val payload: DecodedPayload, val source: Source, val authoritative: Boolean) : FetchOutcome
+    data class Failed(val error: GBError, val source: Source) : FetchOutcome
+    data object NotModified : FetchOutcome
+}
+internal enum class Source { CACHE, NETWORK }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchPolicy.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchPolicy.kt
@@ -1,0 +1,12 @@
+package com.sdk.growthbook.features
+
+/**
+ * Controls how [FeaturesViewModel.fetchFeatures] balances cache and network.
+ */
+internal enum class FetchPolicy {
+    /** Serve fresh cache (within the configured max age) and skip the network when possible. */
+    CacheFirst,
+
+    /** Ignore cache freshness and always hit the network. */
+    ForceNetwork
+}

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchResult.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchResult.kt
@@ -1,0 +1,13 @@
+package com.sdk.growthbook.features
+
+/**
+ * Outcome of a single coalesced network refresh round, returned by
+ * [FeaturesViewModel.awaitRefresh]. Lets a suspending caller (e.g.
+ * suspendFeature()) observe how the shared in-flight refresh completed
+ * without polling delegate state.
+ */
+internal enum class FetchResult {
+    Success,
+    Failed,
+    NotModified
+}

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableFeaturesDataModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableFeaturesDataModel.kt
@@ -12,7 +12,8 @@ internal data class SerializableFeaturesDataModel(
     val features: Map<String, SerializableGBFeature>? = null,
     val encryptedFeatures: String? = null,
     val savedGroups: JsonObject? = null,
-    val encryptedSavedGroups: String? = null
+    val encryptedSavedGroups: String? = null,
+    val cachedAt: Long? = null
 )
 
 internal fun SerializableFeaturesDataModel.gbDeserialize() =

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -11,7 +11,7 @@ import com.sdk.growthbook.model.GBString
 import com.sdk.growthbook.model.toGbNumber
 import com.sdk.growthbook.utils.GBError
 import io.mockk.mockk
-import io.mockk.every
+import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -20,7 +20,7 @@ import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
 import com.sdk.growthbook.features.FeaturesViewModel
-import com.sdk.growthbook.features.FetchPolicy
+import com.sdk.growthbook.features.FetchResult
 import com.sdk.growthbook.kotlinx.serialization.gbSerialize
 
 internal class VerifySDKReturnFeatureValues {
@@ -166,7 +166,7 @@ internal class VerifySDKReturnFeatureValues {
         // fetchFeature() triggers featuresFetchFailed()
 
         val mockedFeaturesViewModel: FeaturesViewModel = mockk {
-            every { fetchFeatures(any(), any(), any()) } returns Unit
+            coEvery { awaitRefresh() } returns FetchResult.Failed
         }
         gbSdk.featuresViewModel = mockedFeaturesViewModel
 
@@ -176,14 +176,14 @@ internal class VerifySDKReturnFeatureValues {
             }
 
             // it is not mandatory here but just to emphasize that
-            // if call failed, then suspendFeature() method calls fetchFeatures()
+            // if call failed, then suspendFeature() retries via the coalesced awaitRefresh()
             gbSdk.featuresFetchFailed(GBError(null), true)
 
             delay(100) // cancel only after 100 millis of waiting
             job.cancel()
             // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
 
-            coVerify { mockedFeaturesViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork) }
+            coVerify { mockedFeaturesViewModel.awaitRefresh() }
         }
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -165,7 +165,7 @@ internal class VerifySDKReturnFeatureValues {
         // fetchFeature() triggers featuresFetchFailed()
 
         val mockedFeaturesViewModel: FeaturesViewModel = mockk {
-            every { fetchFeatures() } returns Unit
+            every { fetchFeatures(any(), any(), any()) } returns Unit
         }
         gbSdk.featuresViewModel = mockedFeaturesViewModel
 
@@ -182,7 +182,7 @@ internal class VerifySDKReturnFeatureValues {
             job.cancel()
             // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
 
-            coVerify { mockedFeaturesViewModel.fetchFeatures() }
+            coVerify { mockedFeaturesViewModel.fetchFeatures(forceRefresh = true) }
         }
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -20,6 +20,7 @@ import org.intellij.lang.annotations.Language
 import org.junit.Test
 import kotlin.test.assertEquals
 import com.sdk.growthbook.features.FeaturesViewModel
+import com.sdk.growthbook.features.FetchPolicy
 import com.sdk.growthbook.kotlinx.serialization.gbSerialize
 
 internal class VerifySDKReturnFeatureValues {
@@ -182,7 +183,7 @@ internal class VerifySDKReturnFeatureValues {
             job.cancel()
             // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
 
-            coVerify { mockedFeaturesViewModel.fetchFeatures(forceRefresh = true) }
+            coVerify { mockedFeaturesViewModel.fetchFeatures(policy = FetchPolicy.ForceNetwork) }
         }
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -301,7 +301,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testHandleFetchFeaturesWithoutRemoteEvalPlainFeatures() {
+    fun testApplyCachedFeaturesForPlainFeatures() {
         receivedFromCache = false
         val cacheLayer = MockCachingLayer.fromApiResponse(MockResponse.successResponse)
         val viewModel = FeaturesViewModel(
@@ -325,7 +325,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
-    fun testHandleFetchFeaturesWithoutRemoteEvalEncryptedFeatures() {
+    fun testApplyCachedFeaturesForEncryptedFeatures() {
         receivedFromCache = false
         val cacheLayer =
             MockCachingLayer.fromApiResponse(MockResponse.successResponseEncryptedFeatures)
@@ -437,7 +437,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
-            backgroundFetchInterval = 48 * 60 * 60 * 1000L,
+            cacheMaxAge = 48 * 60 * 60 * 1000L,
         )
 
         viewModel.fetchFeatures()
@@ -470,7 +470,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
             cachingLayer = cacheLayer,
-            backgroundFetchInterval = 48 * 60 * 60 * 1000L,
+            cacheMaxAge = 48 * 60 * 60 * 1000L,
         )
 
         viewModel.fetchFeatures()

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -11,6 +11,9 @@ import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -476,6 +479,58 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         viewModel.fetchFeatures()
 
         assertEquals(1, networkCallCount, "Network should be called when cache is stale")
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testConcurrentAwaitRefreshSharesSingleNetworkCall() = runTest {
+        var networkCallCount = 0
+        val pending = mutableListOf<(String) -> Unit>()
+        // Captures the request callback instead of resolving it, so the refresh
+        // stays "in flight" while all callers arrive.
+        val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
+            override fun consumeGETRequestWithNotModified(
+                request: String,
+                onSuccess: (String) -> Unit,
+                onError: (Throwable) -> Unit,
+                onNotModified: (() -> Unit)
+            ): Job {
+                networkCallCount++
+                pending.add(onSuccess)
+                return Job()
+            }
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = false,
+            scope = backgroundScope,
+        )
+
+        // Five callers race into awaitRefresh() while no request has completed yet.
+        repeat(5) { backgroundScope.launch { viewModel.awaitRefresh() } }
+        runCurrent()
+
+        assertEquals(
+            1,
+            networkCallCount,
+            "Concurrent awaitRefresh() callers must share a single in-flight network request"
+        )
+
+        // Complete the shared request, freeing the slot.
+        pending.forEach { it(MockResponse.successResponse) }
+        runCurrent()
+        assertTrue(isSuccess)
+
+        // A fresh refresh after completion starts a new request (slot was cleared).
+        backgroundScope.launch { viewModel.awaitRefresh() }
+        runCurrent()
+        assertEquals(
+            2,
+            networkCallCount,
+            "A refresh after the in-flight one completes must start a new request"
+        )
     }
 
     override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -10,10 +10,13 @@ import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
+import kotlinx.coroutines.Job
 import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 
 class FeaturesViewModelTests : FeaturesFlowDelegate {
 
@@ -385,6 +388,71 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         val flow = viewModel.autoRefreshFeatures()
 
         assertNotNull(flow)
+    }
+
+    @Test
+    fun testSkipsNetworkWhenCacheIsFresh() {
+        var networkCallCount = 0
+        val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
+            override fun consumeGETRequestWithNotModified(
+                request: String,
+                onSuccess: (String) -> Unit,
+                onError: (Throwable) -> Unit,
+                onNotModified: (() -> Unit)
+            ): Job {
+                networkCallCount++
+                return super.consumeGETRequestWithNotModified(request, onSuccess, onError, onNotModified)
+            }
+        }
+        val cacheLayer = MockCachingLayer.fromApiResponse(
+            MockResponse.successResponse,
+            cachedAt = Clock.System.now().toEpochMilliseconds()
+        )
+        val viewModel = FeaturesViewModel(
+            delegate = this,
+            dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = false,
+            cachingLayer = cacheLayer,
+            backgroundFetchInterval = 48 * 60 * 60 * 1000L,
+        )
+
+        viewModel.fetchFeatures()
+
+        assertEquals(0, networkCallCount, "Network should not be called when cache is fresh")
+    }
+
+    @Test
+    fun testFetchesNetworkWhenCacheIsStale() {
+        var networkCallCount = 0
+        val mockClient = object : MockNetworkClient(MockResponse.successResponse, null) {
+            override fun consumeGETRequestWithNotModified(
+                request: String,
+                onSuccess: (String) -> Unit,
+                onError: (Throwable) -> Unit,
+                onNotModified: (() -> Unit)
+            ): Job {
+                networkCallCount++
+                return super.consumeGETRequestWithNotModified(request, onSuccess, onError, onNotModified)
+            }
+        }
+        val staleTime = Clock.System.now().toEpochMilliseconds() - (49 * 60 * 60 * 1000L)
+        val cacheLayer = MockCachingLayer.fromApiResponse(
+            MockResponse.successResponse,
+            cachedAt = staleTime
+        )
+        val viewModel = FeaturesViewModel(
+            delegate = this,
+            dataSource = FeaturesDataSource(mockClient, gbContext, testGbOptions),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = false,
+            cachingLayer = cacheLayer,
+            backgroundFetchInterval = 48 * 60 * 60 * 1000L,
+        )
+
+        viewModel.fetchFeatures()
+
+        assertEquals(1, networkCallCount, "Network should be called when cache is stale")
     }
 
     override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -127,6 +129,10 @@ class GrowthBookSDKBuilderTests {
     fun testSDKRefreshHandler() {
 
         var isRefreshed = false
+        // refreshCache() revalidates on a background scope, so wait on the
+        // refresh handler signal (deterministic, no sleeps) rather than reading
+        // the flag synchronously.
+        var refreshLatch = CountDownLatch(1)
 
         val sdkInstance = GBSDKBuilder(
             testApiKey,
@@ -138,14 +144,17 @@ class GrowthBookSDKBuilderTests {
             remoteEval = false
         ).setRefreshHandler { _, gbError ->
             isRefreshed = true
+            refreshLatch.countDown()
         }.initialize()
 
+        assertTrue(refreshLatch.await(2, TimeUnit.SECONDS), "refresh handler should fire on init")
         assertTrue(isRefreshed)
 
         isRefreshed = false
+        refreshLatch = CountDownLatch(1)
 
         sdkInstance.refreshCache()
-
+        assertTrue(refreshLatch.await(2, TimeUnit.SECONDS), "refresh handler should fire on refreshCache")
         assertTrue(isRefreshed)
     }
 
@@ -153,6 +162,7 @@ class GrowthBookSDKBuilderTests {
     fun testSDKRefreshHandlerCalledOn304NotModified() {
         var refreshCalled = false
         var refreshSuccess: Boolean? = null
+        var refreshLatch = CountDownLatch(1)
 
         val growthBookSDK = GBSDKBuilder(
             testApiKey,
@@ -169,10 +179,17 @@ class GrowthBookSDKBuilderTests {
         ).setRefreshHandler { isRefreshed, _ ->
             refreshCalled = true
             refreshSuccess = isRefreshed
+            refreshLatch.countDown()
         }.initialize()
+
+        // Reset so the assertion specifically captures the refreshCache() round,
+        // not the init round (which also fires the handler).
+        refreshCalled = false
+        refreshLatch = CountDownLatch(1)
 
         growthBookSDK.refreshCache()
 
+        assertTrue(refreshLatch.await(2, TimeUnit.SECONDS), "refresh handler should fire on refreshCache")
         assertTrue(refreshCalled)
     }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockCachingLayer.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockCachingLayer.kt
@@ -35,10 +35,10 @@ internal class MockCachingLayer(
          * Builds a JsonElement that represents a cached FeaturesDataModel
          * by deserializing the given raw API response string and re-encoding it.
          */
-        fun fromApiResponse(rawJson: String): MockCachingLayer {
+        fun fromApiResponse(rawJson: String, cachedAt: Long? = null): MockCachingLayer {
             val serializable = json.decodeFromString(
                 SerializableFeaturesDataModel.serializer(), rawJson
-            )
+            ).copy(cachedAt = cachedAt)
             val element = Json.encodeToJsonElement(
                 SerializableFeaturesDataModel.serializer(), serializable
             )

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If you are accessing features the first time there will be no features right aft
     .setQAMode(true) // Enable / Disable QA Mode
     .setForcedVariations(<HashMap>) // Pass Forced Variations
     .setInitialFeatures(<GBFeatures>) // Seed bundled fallback features (see below)
+    .setCacheMaxAge(<Long>) // Cache freshness window in ms (see below)
 .initialize()
 ```
 
@@ -109,6 +110,24 @@ The seeded features are applied immediately. The normal cache/network refresh st
 
 > **Upgrading from 6.x (Android):** Persistent caching is only implemented on Android; other platforms do not cache features to disk, so this upgrade note does not apply to them. On Android the cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch. Single-instance apps migrate transparently with no cold start. Apps that use multiple SDK instances with different `clientKey`s may see one cold start without cache on the first launch after upgrade — features self-correct after the first successful fetch.
 
+#### Cache freshness window (`setCacheMaxAge`)
+
+By default the SDK refetches features from the network on every `initialize()`. Pass `setCacheMaxAge(<ms>)` to define a freshness window: while the cached features are younger than that window, the network call on the next fetch is skipped and the cache is served as the authoritative result. Once the cache is older, the SDK refetches. This is a staleness gate evaluated on the next fetch, not a background polling mechanism.
+
+```kotlin
+var sdkInstance: GrowthBookSDK = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    hostURL = <GrowthBook_URL>,
+    attributes = hashMapOf(),
+    trackingCallback = { _, _ -> },
+    networkDispatcher = GBNetworkDispatcherKtor(),
+)
+    .setCacheMaxAge(60 * 60 * 1000) // serve cache for up to 1 hour, then refetch
+    .initialize()
+```
+
+An explicit `refreshCache()` call always bypasses this window and hits the network regardless of how fresh the cache is.
+
 ## Usage
 
 - Initialization returns SDK instance - GrowthBookSDK
@@ -129,8 +148,9 @@ and returns a feature value typed with specified type.
   inline fun <reified V>featureValue(id: String): V?
     ```
 
-- If you changed, added or removed any features, you can call the refreshCache method to clear the cache and download
-  the latest feature definitions.
+- If you changed, added or removed any features, you can call the refreshCache method to fetch the latest feature
+  definitions from the network. It always bypasses the `setCacheMaxAge` freshness window, so it refetches even when the
+  cache is still fresh.
 
   ```kotlin
   fun refreshCache()


### PR DESCRIPTION
### Summary

- Add `setCacheMaxAge(maxAgeMs: Long)` to `GBSDKBuilder` - while the cache is _younger_ than the configured window, the next fetch is served from cache and the network call is skipped. `refreshCache() `always bypasses this window. (Renamed from the initial `setBackgroundFetchInterval`() for clearer intent.)
- Replace the recursive retry loop in `suspendFeature()` with exponential backoff (1s → 2s → 4s → 8s → 16s, max 5 attempts) to prevent DNS request flooding when the network is unavailable.
- Coalesce concurrent feature refreshes into a single shared in-flight request: parallel `suspendFeature()` callers (and `refreshCache()`) now share one network GET instead of each firing its own, so N callers no longer produce N retry loops.

### Motivation

- **Cache TTL**: other GrowthBook SDKs (TypeScript, Java, Python) all support configurable refresh intervals; the Kotlin SDK always fetched on every init.
- **Exponential backoff + dedup**: reported in #236 - multiple parallel `suspendFeature` calls with no retry limit caused anomalously high DNS error rates on startup. Backoff caps each caller; the shared in-flight refresh removes the duplication across callers.

### Docs

- **KDoc** + **README** for `setCacheMaxAge()` and the `refreshCache()` TTL-bypass behavior.