### PR TITLE
fix: cache reliability improvements and setInitialFeatures for 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache write failure (disk full, I/O error) no longer discards a successfully fetched features payload; the write is now isolated in its own try/catch and its failure is logged but does not affect the current session
 - Android cache write is now crash-safe: `fsync` is called before rename, and a `false` return from `renameTo` now throws `IOException` instead of silently leaving a stale cache file
 - Concurrent SDK instances with the same `clientKey` no longer corrupt the shared cache file; `CachingAndroid` is now a singleton so its per-filename lock correctly serializes all writers
-- Upgrading from 6.x to 7.x no longer silently discards the cached features on first launch; `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt`. Apps using multiple SDK instances with different `clientKey`s may see one cold start on the first launch after upgrade — features self-correct after the first successful fetch
+- Upgrading from 6.x to 7.x no longer silently discards the cached features on first launch (Android only — other platforms do not persist a disk cache); `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt`. Apps using multiple SDK instances with different `clientKey`s may see one cold start on the first launch after upgrade — features self-correct after the first successful fetch
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache write failure (disk full, I/O error) no longer discards a successfully fetched features payload; the write is now isolated in its own try/catch and its failure is logged but does not affect the current session
 - Android cache write is now crash-safe: `fsync` is called before rename, and a `false` return from `renameTo` now throws `IOException` instead of silently leaving a stale cache file
 - Concurrent SDK instances with the same `clientKey` no longer corrupt the shared cache file; `CachingAndroid` is now a singleton so its per-filename lock correctly serializes all writers
-- Upgrading from 6.x to 7.x no longer silently discards the cached features on first launch; `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt`
+- Upgrading from 6.x to 7.x no longer silently discards the cached features on first launch; `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt`. Apps using multiple SDK instances with different `clientKey`s may see one cold start on the first launch after upgrade — features self-correct after the first successful fetch
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [7.2.0] - 2026-06-12
+
+### Added
+- `GBSDKBuilder.setInitialFeatures()` — seed the SDK with a bundled fallback payload; features are applied immediately and the normal cache/network refresh still runs on top (network > disk cache > seed > code defaults)
+
+### Fixed
+- Cache write failure (disk full, I/O error) no longer discards a successfully fetched features payload; the write is now isolated in its own try/catch and its failure is logged but does not affect the current session
+- Android cache write is now crash-safe: `fsync` is called before rename, and a `false` return from `renameTo` now throws `IOException` instead of silently leaving a stale cache file
+- Concurrent SDK instances with the same `clientKey` no longer corrupt the shared cache file; `CachingAndroid` is now a singleton so its per-filename lock correctly serializes all writers
+- Upgrading from 6.x to 7.x no longer silently discards the cached features on first launch; `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt`
+
+---
+
 ## [7.1.1] - 2026-04-23
 
 ### Fixed

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.1.1"
+version = "7.2.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -36,8 +36,13 @@ class CachingAndroid : CachingLayer {
             val tempFile = File(file.parent, "${file.name}.tmp")
             val jsonContents = json.encodeToString(JsonElement.serializer(), content)
             try {
-                tempFile.writeText(jsonContents)
-                tempFile.renameTo(file)
+                FileOutputStream(tempFile).use { out ->
+                    out.write(jsonContents.toByteArray())
+                    out.fd.sync()
+                }
+                if (!tempFile.renameTo(file)) {
+                    throw IOException("Failed to rename ${tempFile.name} to ${file.name}")
+                }
             } catch (e: Exception) {
                 tempFile.delete()
                 throw e

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -96,6 +96,7 @@ class CachingAndroid : CachingLayer {
     }
 
     private fun migrateLegacyCache(newFile: File) {
+        if (!newFile.name.startsWith("FeatureCache")) return
         val legacyFile = getTargetFile("FeatureCache") ?: return
         if (!legacyFile.exists()) return
         if (!legacyFile.renameTo(newFile)) {

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -1,9 +1,12 @@
 package com.sdk.growthbook.sandbox
 
 import android.content.Context
+import com.sdk.growthbook.logger.GB
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -56,6 +59,10 @@ class CachingAndroid : CachingLayer {
         synchronized(getLock(fileName)) {
             val file = getTargetFile(fileName) ?: return null
 
+            if (!file.exists()) {
+                migrateLegacyCache(newFile = file)
+            }
+
             if (!file.exists()) return null
 
             // Read File Contents
@@ -86,6 +93,14 @@ class CachingAndroid : CachingLayer {
             targetFileName = fileName.removeSuffix(".txt")
         }
         return File(letDirectory, "$targetFileName.txt")
+    }
+
+    private fun migrateLegacyCache(newFile: File) {
+        val legacyFile = getTargetFile("FeatureCache") ?: return
+        if (!legacyFile.exists()) return
+        if (!legacyFile.renameTo(newFile)) {
+            legacyFile.delete()
+        }
     }
 
     private fun getLock(fileName: String): Any {

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -10,9 +10,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Actual Implementation for Caching in Android - As expected in KMM
  */
 internal actual object CachingImpl {
-    actual fun getLayer(): CachingLayer {
-        return CachingAndroid()
-    }
+    actual fun getLayer(): CachingLayer = CachingAndroid.instance
 }
 
 /**
@@ -64,8 +62,8 @@ class CachingAndroid : CachingLayer {
             return try {
                 val inputAsString = file.readText()
                 json.decodeFromString(JsonElement.serializer(), inputAsString)
-            } catch (_: Exception) {
-                // Corrupt cache — delete and return null
+            } catch (e: Exception) {
+                GB.error("CachingAndroid: corrupt cache file '$fileName', deleting", e)
                 file.delete()
                 null
             }
@@ -95,6 +93,8 @@ class CachingAndroid : CachingLayer {
     }
 
     companion object {
+        internal val instance: CachingAndroid = CachingAndroid()
+
         internal var filesDir: File? = null
 
         /**

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -100,7 +100,8 @@ class CachingAndroid : CachingLayer {
         val legacyFile = getTargetFile("FeatureCache") ?: return
         if (!legacyFile.exists()) return
         if (!legacyFile.renameTo(newFile)) {
-            legacyFile.delete()
+            GB.warning("CachingAndroid: failed to migrate legacy cache to " +
+                "${newFile.name}, will retry on next launch")
         }
     }
 

--- a/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
+++ b/GrowthBook/src/androidMain/kotlin/com/sdk/growthbook/sandbox/KMMCaching.kt
@@ -34,8 +34,13 @@ class CachingAndroid : CachingLayer {
     override fun saveContent(fileName: String, content: JsonElement) {
         synchronized(getLock(fileName)) {
             val file = getTargetFile(fileName) ?: return
-            val tempFile = File(file.parent, "${file.name}.tmp")
             val jsonContents = json.encodeToString(JsonElement.serializer(), content)
+            // Unique temp file per write: the per-file lock only serializes writers within
+            // a single process, so a fixed temp name could still be interleaved by another
+            // process (or a separately-constructed instance) writing the same cache file.
+            // A unique temp keeps each write self-contained; rename is then last-writer-wins
+            // of a complete payload, never a corrupt one.
+            val tempFile = File.createTempFile(file.name, ".tmp", file.parentFile)
             try {
                 FileOutputStream(tempFile).use { out ->
                     out.write(jsonContents.toByteArray())

--- a/GrowthBook/src/androidUnitTest/kotlin/com/sdk/growthbook/AndroidCachingTest.kt
+++ b/GrowthBook/src/androidUnitTest/kotlin/com/sdk/growthbook/AndroidCachingTest.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -49,5 +51,31 @@ class AndroidCachingTest {
 
         assertTrue(fileContents != null)
         assertTrue(fileContents.jsonPrimitive.content == "GrowthBook")
+    }
+
+    @Test
+    fun testLegacyCacheMigratedToScopedFeatureCache() {
+        val manager = CachingAndroid()
+        val gbDir = File(CachingAndroid.filesDir, "GrowthBook-KMM").also { it.mkdirs() }
+        File(gbDir, "FeatureCache.txt").writeText("\"cached-features\"")
+
+        val result = manager.getContent("FeatureCache_myApiKey")
+
+        assertTrue(result != null)
+        assertTrue(result.jsonPrimitive.content == "cached-features")
+        assertTrue(!File(gbDir, "FeatureCache.txt").exists())
+    }
+
+    @Test
+    fun testLegacyCacheNotMigratedToStickyBucketFile() {
+        val manager = CachingAndroid()
+        val gbDir = File(CachingAndroid.filesDir, "GrowthBook-KMM").also { it.mkdirs() }
+        val legacyFile = File(gbDir, "FeatureCache.txt")
+        legacyFile.writeText("\"cached-features\"")
+
+        val stickyBucketResult = manager.getContent("gbStickyBuckets__id||user123")
+
+        assertNull(stickyBucketResult)
+        assertTrue(legacyFile.exists(), "Legacy FeatureCache.txt must not be consumed by a sticky bucket read")
     }
 }

--- a/GrowthBook/src/androidUnitTest/kotlin/com/sdk/growthbook/AndroidCachingTest.kt
+++ b/GrowthBook/src/androidUnitTest/kotlin/com/sdk/growthbook/AndroidCachingTest.kt
@@ -7,10 +7,14 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.io.IOException
+import java.util.concurrent.CyclicBarrier
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class AndroidCachingTest {
 
@@ -77,5 +81,69 @@ class AndroidCachingTest {
 
         assertNull(stickyBucketResult)
         assertTrue(legacyFile.exists(), "Legacy FeatureCache.txt must not be consumed by a sticky bucket read")
+    }
+
+    @Test
+    fun testRenameFailureThrowsAndPreservesExistingCache() {
+        val manager = CachingAndroid()
+        val gbDir = File(CachingAndroid.filesDir, "GrowthBook-KMM").also { it.mkdirs() }
+
+        // Force renameTo(target) to return false by making the target path a
+        // non-empty directory (rename-over-non-empty-dir fails at the OS level).
+        val target = File(gbDir, "gb-features.txt").also { it.mkdirs() }
+        File(target, "blocker").writeText("x")
+
+        assertFailsWith<IOException> {
+            manager.saveContent("gb-features.txt", JsonPrimitive("GrowthBook"))
+        }
+
+        assertTrue(
+            gbDir.listFiles()?.none { it.name.endsWith(".tmp") } ?: true,
+            "temp file must be deleted when the rename fails",
+        )
+        assertTrue(
+            target.isDirectory,
+            "a failed rename must not silently destroy the existing cache entry",
+        )
+    }
+
+    @Test
+    fun testGetLayerReturnsSharedInstance() {
+        assertSame(
+            CachingImpl.getLayer(),
+            CachingImpl.getLayer(),
+            "getLayer() must return a shared instance so the per-file lock serializes all writers",
+        )
+    }
+
+    @Test
+    fun testConcurrentWritersFromSeparateLayersDoNotCorruptCache() {
+        val fileName = "gb-features.txt"
+        val threadCount = 8
+        val iterations = 50
+        // Distinct, large payloads so any interleaving of writes produces invalid JSON.
+        val payloads = (0 until threadCount).map { t ->
+            JsonPrimitive("payload-$t-" + "x".repeat(2000))
+        }
+
+        val barrier = CyclicBarrier(threadCount)
+        val workers = (0 until threadCount).map { t ->
+            Thread {
+                barrier.await()
+                repeat(iterations) {
+                    // Each "SDK instance" obtains its layer the way production does.
+                    CachingImpl.getLayer().saveContent(fileName, payloads[t])
+                }
+            }
+        }
+        workers.forEach { it.start() }
+        workers.forEach { it.join() }
+
+        val result = CachingImpl.getLayer().getContent(fileName)
+        assertTrue(result != null, "cache must be readable after concurrent writes")
+        assertTrue(
+            payloads.any { it == result },
+            "cache must hold exactly one writer's complete payload, not interleaved content",
+        )
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -10,6 +10,7 @@ import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
 import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
 import com.sdk.growthbook.utils.GBCacheRefreshHandler
+import com.sdk.growthbook.utils.GBFeatures
 
 /**
  * SDKBuilder - Root Class for SDK Initializers for GrowthBook SDK
@@ -103,12 +104,24 @@ class GBSDKBuilder(
     private var refreshHandler: GBCacheRefreshHandler? = null
     private var stickyBucketService: GBStickyBucketService? = null
     private var featureUsageCallback: GBFeatureUsageCallback? = null
+    private var initialFeatures: GBFeatures? = null
 
     /**
      * Set Refresh Handler - Will be called when cache is refreshed
      */
     fun setRefreshHandler(refreshHandler: GBCacheRefreshHandler): GBSDKBuilder {
         this.refreshHandler = refreshHandler
+        return this
+    }
+
+    /**
+     * Seed the SDK with a bundled fallback payload (e.g. snapshotted at build time).
+     * Features are applied immediately so flags are available from the first millisecond,
+     * and the normal cache/network refresh still runs on top — overwriting the seed as
+     * fresher data arrives. Effective precedence: network > disk cache > seed > code defaults.
+     */
+    fun setInitialFeatures(features: GBFeatures): GBSDKBuilder {
+        this.initialFeatures = features
         return this
     }
 
@@ -186,6 +199,8 @@ class GBSDKBuilder(
             )
         }
 
+        initialFeatures?.let { gbContext.features = it }
+
         val gbOptions = GBOptions(apiHost, streamingHost)
 
         return GrowthBookSDK(
@@ -237,6 +252,8 @@ class GBSDKBuilder(
                 handleWaitForCallCallback = null
                 growthBookSDK = null
             }
+            initialFeatures?.let { gbContext.features = it }
+
             val gbOptions = GBOptions(apiHost, streamingHost)
             growthBookSDK = GrowthBookSDK(
                 gbContext,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -69,7 +69,11 @@ class GrowthBookSDK(
     private var subscriptions: MutableList<GBExperimentRunCallback> = mutableListOf()
     private var assigned: MutableMap<String, Pair<GBExperiment, GBExperimentResult>> =
         mutableMapOf()
-    private var hasFeaturesPayload: Boolean = false
+    // True once any usable feature payload is present. Initialized from the context so
+    // bundled features seeded via setInitialFeatures() before construction count as a
+    // payload — otherwise a 304 arriving before the first remote fetch would be treated
+    // as a failure, breaking the offline-first fallback.
+    private var hasFeaturesPayload: Boolean = gbContext.features.isNotEmpty()
 
     /**
      * JAVA Consumers preset Features
@@ -88,6 +92,7 @@ class GrowthBookSDK(
     init {
         if (features != null) {
             gbContext.features = features
+            hasFeaturesPayload = true
         } else {
             refreshCache()
         }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -15,6 +15,7 @@ import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.SSEConnectionController
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
+import com.sdk.growthbook.logger.GB
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonObject
 
@@ -60,7 +61,7 @@ internal class FeaturesViewModel(
                 handleFetchFeaturesWithoutRemoteEval(dataModel)
             }
         } catch (error: Throwable) {
-            // Call Error Delegate with mention of data not available but its not remote
+            GB.error("FeaturesViewModel: cache read failed", error)
             this.delegate.featuresFetchFailed(GBError(error), false)
         }
         handleFetchFeaturesWithRemoteEval(remoteEval, payload)
@@ -151,11 +152,14 @@ internal class FeaturesViewModel(
 
         try {
             if (dataModel != null) {
-                if (cachingEnabled) {
-                    putDataToCache(dataModel)
-                }
-
                 delegate.featuresAPIModelSuccessfully(dataModel)
+                if (cachingEnabled) {
+                    try {
+                        putDataToCache(dataModel)
+                    } catch (e: Throwable) {
+                        GB.error("FeaturesViewModel: cache write failed, features still applied", e)
+                    }
+                }
                 if (!features.isNullOrEmpty()) {
                     this.delegate.featuresFetchedSuccessfully(
                         features = features,
@@ -236,6 +240,7 @@ internal class FeaturesViewModel(
                 }
             }
         } catch (error: Throwable) {
+            GB.error("FeaturesViewModel: failed to process remote features payload", error)
             this.delegate.featuresFetchFailed(error = GBError(error), isRemote = true)
             return
         }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -371,6 +371,29 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     }
 
     @Test
+    fun testCacheWriteFailureDoesNotDiscardFetchedFeatures() {
+        isSuccess = false
+        isError = false
+        val cacheLayer = MockCachingLayer(throwOnPut = true)
+        val viewModel = FeaturesViewModel(
+            delegate = this,
+            dataSource = FeaturesDataSource(
+                MockNetworkClient(MockResponse.successResponse, null),
+                gbContext, testGbOptions,
+            ),
+            encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
+            cachingEnabled = true,
+            cachingLayer = cacheLayer,
+        )
+
+        viewModel.fetchFeatures()
+
+        assertTrue(isSuccess, "Features should be applied even when cache write fails")
+        assertTrue(!isError, "A cache write failure should not be reported as a fetch failure")
+        assertTrue(hasFeatures)
+    }
+
+    @Test
     fun testAutoRefreshFeaturesReturnsFlow() {
         val viewModel = FeaturesViewModel(
             delegate = this,

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -700,6 +700,43 @@ class GrowthBookSDKBuilderTests {
         )
     }
 
+    @Test
+    fun testSetInitialFeaturesTreats304AsSuccess() {
+        val bundledFeatures: GBFeatures = mapOf("bundled-feature" to GBFeature())
+        var refreshCalled = false
+        var refreshSuccess: Boolean? = null
+
+        val sdkInstance = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = testAttributes,
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(
+                successResponse = null,
+                error = null,
+                notModified = true
+            ),
+        )
+            .setInitialFeatures(bundledFeatures)
+            .setRefreshHandler { success, _ ->
+                refreshCalled = true
+                refreshSuccess = success
+            }
+            .initialize()
+
+        assertTrue(refreshCalled, "Refresh handler should be invoked on a 304 response")
+        assertEquals(
+            true, refreshSuccess,
+            "A 304 must be treated as success when bundled initial features are present, " +
+                "preserving offline-first behavior"
+        )
+        assertTrue(
+            sdkInstance.getFeatures().containsKey("bundled-feature"),
+            "Bundled initial features should remain available after a 304"
+        )
+    }
+
 //    @Test
 //    fun testSDKFeaturesDataJAVA() {
 //

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -8,6 +8,7 @@ import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBExperimentResult
+import com.sdk.growthbook.model.GBFeature
 import com.sdk.growthbook.model.GBFeatureSource
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBString
@@ -654,6 +655,51 @@ class GrowthBookSDKBuilderTests {
 //
 //    }
 //
+    @Test
+    fun testSetInitialFeaturesAvailableImmediatelyWithoutNetwork() {
+        val bundledFeatures: GBFeatures = mapOf("bundled-feature" to GBFeature())
+
+        val sdkInstance = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = testAttributes,
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(null, Throwable("no network")),
+        )
+            .setInitialFeatures(bundledFeatures)
+            .initialize()
+
+        assertTrue(
+            sdkInstance.getFeatures().containsKey("bundled-feature"),
+            "Initial features should be available immediately even when network is unavailable"
+        )
+    }
+
+    @Test
+    fun testSetInitialFeaturesOverwrittenByNetworkRefresh() {
+        val bundledFeatures: GBFeatures = mapOf("bundled-feature" to GBFeature())
+        var refreshCalled = false
+
+        val sdkInstance = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = testAttributes,
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+        )
+            .setInitialFeatures(bundledFeatures)
+            .setRefreshHandler { success, _ -> refreshCalled = success }
+            .initialize()
+
+        assertTrue(refreshCalled, "Network refresh should still run when initialFeatures is set")
+        assertTrue(
+            sdkInstance.getFeatures().containsKey("onboarding"),
+            "Network features should overwrite the seed"
+        )
+    }
+
 //    @Test
 //    fun testSDKFeaturesDataJAVA() {
 //

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockCachingLayer.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockCachingLayer.kt
@@ -10,10 +10,12 @@ import kotlinx.serialization.json.JsonElement
  *
  * @param initialContent  pre-loaded JsonElement returned by getContent (null = empty cache)
  * @param throwOnGet      if true, getContent throws to simulate a corrupted/unreadable cache
+ * @param throwOnPut      if true, saveContent throws to simulate disk full / write failure
  */
 internal class MockCachingLayer(
     private val initialContent: JsonElement? = null,
     private val throwOnGet: Boolean = false,
+    private val throwOnPut: Boolean = false,
 ) : CachingLayer {
 
     var savedContent: JsonElement? = null
@@ -25,6 +27,7 @@ internal class MockCachingLayer(
     }
 
     override fun saveContent(fileName: String, content: JsonElement) {
+        if (throwOnPut) throw Exception("Disk full")
         savedContent = content
     }
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ var sdkInstance: GrowthBookSDK = GBSDKBuilder(
 
 The seeded features are applied immediately. The normal cache/network refresh still runs on top and overwrites the seed as fresher data arrives. Effective precedence: **network > disk cache > seed > code defaults**.
 
-> **Upgrading from 6.x:** The cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch. Single-instance apps migrate transparently with no cold start. Apps that use multiple SDK instances with different `clientKey`s may see one cold start without cache on the first launch after upgrade — features self-correct after the first successful fetch.
+> **Upgrading from 6.x (Android):** Persistent caching is only implemented on Android; other platforms do not cache features to disk, so this upgrade note does not apply to them. On Android the cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch. Single-instance apps migrate transparently with no cold start. Apps that use multiple SDK instances with different `clientKey`s may see one cold start without cache on the first launch after upgrade — features self-correct after the first successful fetch.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     // Add GrowthBook module:
-    implementation 'io.growthbook.sdk:GrowthBook:7.1.0'
+    implementation 'io.growthbook.sdk:GrowthBook:7.2.0'
 
     // Add Network Dispatcher you prefer:
     // 1) NetworkDispatcherKtor — supports Android, iOS, JVM, JS, Wasm
@@ -80,8 +80,34 @@ If you are accessing features the first time there will be no features right aft
     .setEnabled(true) // Enable / Disable experiments
     .setQAMode(true) // Enable / Disable QA Mode
     .setForcedVariations(<HashMap>) // Pass Forced Variations
+    .setInitialFeatures(<GBFeatures>) // Seed bundled fallback features (see below)
 .initialize()
 ```
+
+#### Bundled fallback features (`setInitialFeatures`)
+
+For a robust offline-first setup, you can bundle a known-good features payload (snapshotted from the API at build time) and seed the SDK with it at init. This gives flags a valid value from the first millisecond — on first installs, offline launches, and empty/corrupt cache — instead of falling back to hardcoded code defaults.
+
+```kotlin
+val bundledFeatures: GBFeatures = mapOf(
+    "dark-mode" to GBFeature(defaultValue = GBBoolean(false)),
+    "new-checkout" to GBFeature(defaultValue = GBBoolean(true)),
+)
+
+var sdkInstance: GrowthBookSDK = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    hostURL = <GrowthBook_URL>,
+    attributes = hashMapOf(),
+    trackingCallback = { _, _ -> },
+    networkDispatcher = GBNetworkDispatcherKtor(),
+)
+    .setInitialFeatures(bundledFeatures)
+    .initialize()
+```
+
+The seeded features are applied immediately. The normal cache/network refresh still runs on top and overwrites the seed as fresher data arrives. Effective precedence: **network > disk cache > seed > code defaults**.
+
+> **Upgrading from 6.x:** The cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch — no cold start on code defaults.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ var sdkInstance: GrowthBookSDK = GBSDKBuilder(
 
 The seeded features are applied immediately. The normal cache/network refresh still runs on top and overwrites the seed as fresher data arrives. Effective precedence: **network > disk cache > seed > code defaults**.
 
-> **Upgrading from 6.x:** The cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch — no cold start on code defaults.
+> **Upgrading from 6.x:** The cache file is automatically migrated from `FeatureCache.txt` to the new scoped `FeatureCache_<clientKey>.txt` on first launch. Single-instance apps migrate transparently with no cold start. Apps that use multiple SDK instances with different `clientKey`s may see one cold start without cache on the first launch after upgrade — features self-correct after the first successful fetch.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Addresses issues #239, #240, #241, #242 and feature request #243.

- **fix(#239):** Cache write failure (disk full, I/O error) no longer discards a successfully fetched features payload. The write is now isolated in its own `try/catch` — failure is logged via `GB.error` but does not affect the current session.
- **fix(#240):** Android cache write is now crash-safe: `fsync` is called before rename, and a `false` return from `renameTo` now throws `IOException` instead of silently leaving a stale cache file.
- **fix(#241):** `CachingAndroid` is now a singleton (`CachingImpl.getLayer()` returns a shared instance) so the per-filename lock correctly serializes writes across multiple SDK instances with the same `clientKey`.
- **fix(#242):** Upgrading from 6.x to 7.x no longer silently discards cached features on first launch. `FeatureCache.txt` is automatically migrated to `FeatureCache_<clientKey>.txt` on first read.
- **feat(#243):** Added `GBSDKBuilder.setInitialFeatures()` to seed the SDK with a bundled fallback payload. Features are applied immediately from the first millisecond (first installs, offline launches, empty cache) and the normal cache/network refresh still runs on top. Precedence: network > disk cache > seed > code defaults.