### PR TITLE
feat: updateAttributes merge API + remote-eval refresh and robustness

### DIFF
--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.15] - Unreleased
+## [1.0.15] - 2026-08-14
 
 ### Fixed
 - `consumePOSTRequest()` no longer wraps the request in `client.use { }`, which closed the

--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.15] - Unreleased
+
+### Fixed
+- `consumePOSTRequest()` no longer wraps the request in `client.use { }`, which closed the
+  shared, long-lived `HttpClient` after the first POST and broke every subsequent
+  GET/POST/SSE request. This surfaced in remote-eval mode, where each attribute change
+  issues a POST.
+- `Map`/`List.toJsonElement()` now pass an already-serialized `JsonElement` through
+  untouched (branch added before `Map`/`List`, since `JsonObject`/`JsonArray` are
+  themselves `Map`/`List`), so pre-encoded POST-body values are no longer re-stringified
+  and double-quoted.
+
+---
+
 ## [1.0.14] - 2026-04-30
 
 ### Added

--- a/CHANGELOG-NetworkDispatcherOkhttp.md
+++ b/CHANGELOG-NetworkDispatcherOkhttp.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.9] - Unreleased
+## [1.0.9] - 2026-08-14
 
 ### Fixed
 - `Map`/`List.toJsonElement()` now pass an already-serialized `JsonElement` through

--- a/CHANGELOG-NetworkDispatcherOkhttp.md
+++ b/CHANGELOG-NetworkDispatcherOkhttp.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.0.9] - Unreleased
+
+### Fixed
+- `Map`/`List.toJsonElement()` now pass an already-serialized `JsonElement` through
+  untouched (branch added before `Map`/`List`, since `JsonObject`/`JsonArray` are
+  themselves `Map`/`List`), so pre-encoded POST-body values are no longer re-stringified
+  and double-quoted.
+
+---
+
 ## [1.0.8] - 2026-04-23
 
 ### Add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-personalized (unevaluated) feature definitions.
 - Rapid attribute or forced-feature changes in remote-eval mode could apply an
   out-of-order (stale) evaluation when a slower earlier request completed after a newer
-  one; responses from superseded remote-eval requests are now discarded.
+  one; responses from superseded remote-eval requests are now discarded. A caller
+  awaiting such a superseded request is no longer reported a successful refresh, so
+  `suspendFeature()` cannot return the older, stale evaluation — it re-joins the latest
+  generation instead.
 - `setForcedFeatures()` and `setAttributeOverrides()` values are now published atomically
   alongside the other evaluation inputs, so an evaluation running on another thread always
   observes the latest values as part of a single consistent snapshot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [7.4.0] - Unreleased
+
+### Added
+- `GrowthBookSDK.updateAttributes()` / `updateAttributesSync()` — shallow-merge user
+  attributes into the current map (parity with the TS SDK's `updateAttributes`): new
+  keys are added, existing keys overwritten, untouched keys preserved. A `GBNull` value
+  keeps the key with a null value (it is not removed); use `setAttributes()` to replace
+  the whole map.
+
+### Fixed
+- Remote evaluation now re-runs when user attributes or forced features change:
+  `setAttributes()`, `setAttributesSync()` and `setForcedFeatures()` were not triggering
+  a fresh remote evaluation, so remote-eval consumers kept stale results after those
+  changes.
+- In remote-eval mode, `suspendFeature()`'s internal retry now goes through the
+  remote-eval POST instead of a plain GET, so a retry can no longer momentarily surface
+  non-personalized (unevaluated) feature definitions.
+- Rapid attribute or forced-feature changes in remote-eval mode could apply an
+  out-of-order (stale) evaluation when a slower earlier request completed after a newer
+  one; responses from superseded remote-eval requests are now discarded.
+- `setForcedFeatures()` and `setAttributeOverrides()` values are now published atomically
+  alongside the other evaluation inputs, so an evaluation running on another thread always
+  observes the latest values as part of a single consistent snapshot.
+- A custom `NetworkDispatcher` that throws synchronously while starting a request is now
+  reported through the refresh handler as a fetch failure, instead of being swallowed or
+  propagating out of `initialize()`/`setAttributes()`.
+- Remote-eval POST body is now well-formed. User attributes and forced features were
+  serialized via their `GBValue.toString()` (e.g. `"GBNumber(value=8490047)"`) instead of
+  the underlying JSON value, so server-side targeting saw garbage; they are now encoded as
+  real JSON. Forced features are also sent as an array of `[key, value]` pairs (matching
+  the reference SDK) instead of a JSON object, which the GrowthBook proxy rejected with
+  `400 Bad Request`.
+
+---
 ## [7.3.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [7.4.0] - Unreleased
+## [7.4.0] - 2026-08-14
 
 ### Added
 - `GrowthBookSDK.updateAttributes()` / `updateAttributesSync()` — shallow-merge user

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.3.0"
+version = "7.4.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -21,6 +21,7 @@ import com.sdk.growthbook.features.FeaturesDataModel
 import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
+import com.sdk.growthbook.features.FetchResult
 import com.sdk.growthbook.model.GBJson
 import com.sdk.growthbook.model.GBNull
 import com.sdk.growthbook.model.GBArray
@@ -322,9 +323,12 @@ class GrowthBookSDK internal constructor(
 
                 FeaturesFetchResult.Failed -> {
                     if (attempt >= MAX_RETRY_ATTEMPTS) return feature(id)
-                    featuresViewModel.awaitRefresh()
-
+                    // A superseded round is not a failure (nothing went wrong, its payload was just
+                    // discarded by a newer generation): re-join the latest generation without burning
+                    // a retry attempt or applying backoff.
+                    if (featuresViewModel.awaitRefresh() == FetchResult.Superseded) continue
                     if (remoteSourceFeaturesFetchResult != FeaturesFetchResult.Failed) continue
+
                     if (gbContext.enableLogging) {
                         GB.log("GrowthBookSDK: suspendFeature: retry attempt ${attempt + 1}/$MAX_RETRY_ATTEMPTS, waiting ${delaysMs}ms")
                     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -29,6 +29,7 @@ import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBString
 import com.sdk.growthbook.model.GBOptions
 import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.EvalSnapshot
 import com.sdk.growthbook.model.GBBoolean
 import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBFeatureResult
@@ -95,8 +96,6 @@ class GrowthBookSDK internal constructor(
         cacheMaxAge = null,
         coroutineContext = PlatformDependentIODispatcher,
     )
-    private var forcedFeatures: Map<String, GBValue> = emptyMap()
-    private var attributeOverrides: Map<String, GBValue> = emptyMap()
     private var remoteSourceFeaturesFetchResult: FeaturesFetchResult =
         FeaturesFetchResult.NoResultYet
     private val gbExperimentHelper: GBExperimentHelper = GBExperimentHelper()
@@ -122,6 +121,8 @@ class GrowthBookSDK internal constructor(
         cachingEnabled = cachingEnabled,
         cacheMaxAge = cacheMaxAge,
         cacheKey = "${Constants.FEATURE_CACHE}_${gbContext.apiKey}",
+        remoteEval = gbContext.remoteEval,
+        remoteEvalPayloadProvider = ::buildRemoteEvalParams,
         coroutineContext = coroutineContext,
     )
 
@@ -300,12 +301,9 @@ class GrowthBookSDK internal constructor(
      * If a call is in progress, it waits for the result. If network
      * call failed, it tries to call again.
      *
-     * Known limitation (remote-eval): the internal retry uses the coalesced GET refresh
-     * ([FeaturesViewModel.awaitRefresh]), not the remote-eval POST. In remote-eval mode, if this is
-     * called while the initial remote-eval POST is still in flight or has failed, the retry issues a
-     * plain GET, so a GET that lands first can momentarily surface non-personalized (unevaluated)
-     * feature definitions until the POST completes and overwrites them. Routing the retry through the
-     * remote-eval path is deferred to a later release.
+     * In remote-eval mode the retry goes through the remote-eval POST (see
+     * [FeaturesViewModel.awaitRefresh] / [buildRemoteEvalParams]), so it never momentarily surfaces
+     * non-personalized (unevaluated) feature definitions.
      *
      * @returns a [GBFeatureResult] object
      */
@@ -350,9 +348,12 @@ class GrowthBookSDK internal constructor(
      * (and sticky-bucket assignments) are loaded before evaluating, use [suspendFeature] instead.
      */
     fun feature(id: String): GBFeatureResult {
-        val evalContext = createEvaluationContext()
-        val evaluator = GBFeatureEvaluator(evalContext, this.forcedFeatures)
-        val result = evaluator.evaluateFeature(featureKey = id, attributeOverrides = attributeOverrides)
+        // Single atomic snapshot for every evaluation input (attributes, forced features/variations,
+        // attribute overrides, sticky docs), so a concurrent setter can't yield a torn mix.
+        val snapshot = gbContext.evalSnapshot()
+        val evalContext = createEvaluationContext(snapshot)
+        val evaluator = GBFeatureEvaluator(evalContext, snapshot.forcedFeatures)
+        val result = evaluator.evaluateFeature(featureKey = id, attributeOverrides = snapshot.attributeOverrides)
         // Newly-generated sticky assignments are merged into the context per-key during evaluation
         // (see EvaluationContext.onStickyAssignmentChanged) — no whole-map write-back needed here.
         return result
@@ -399,13 +400,14 @@ class GrowthBookSDK internal constructor(
      * The run method takes an Experiment object and returns an ExperimentResult
      */
     fun run(experiment: GBExperiment): GBExperimentResult {
-        val evalContext = createEvaluationContext()
+        val snapshot = gbContext.evalSnapshot()
+        val evalContext = createEvaluationContext(snapshot)
         val evaluator = GBExperimentEvaluator(
             evalContext
         )
         val result = evaluator.evaluateExperiment(
             experiment = experiment,
-            attributeOverrides = attributeOverrides
+            attributeOverrides = snapshot.attributeOverrides
         )
 
         // Newly-generated sticky assignments are merged into the context per-key during evaluation
@@ -427,6 +429,27 @@ class GrowthBookSDK internal constructor(
         // with the previous user's stale sticky docs (the docs are repopulated by the refresh below).
         gbContext.setAttributesClearingStickyDocs(attributes)
         refreshStickyBucketService()
+        refreshForRemoteEval()
+    }
+
+    /**
+     * Shallow-merges [attributes] into the current user attributes (parity with the TypeScript
+     * SDK's `updateAttributes`): new keys are added, existing keys are overwritten, and untouched
+     * keys are preserved. To fully replace the attribute map use [setAttributes] instead.
+     *
+     * The merge is one level deep — nested [GBJson]/[GBArray] values are replaced wholesale, not
+     * deep-merged. A key mapped to [GBNull] keeps the key with a null value (it is NOT removed);
+     * remove a key by rebuilding the map with [setAttributes].
+     *
+     * Sticky bucket refresh runs in the background (fire-and-forget). If you use Sticky Bucketing
+     * and need to evaluate experiments immediately after updating, use [updateAttributesSync].
+     */
+    fun updateAttributes(attributes: Map<String, GBValue>) {
+        // Merge inside the context's atomic CAS loop (not read-then-setAttributes), so two concurrent
+        // updateAttributes calls can't lose each other's keys. Side effects mirror setAttributes.
+        gbContext.mergeAttributesClearingStickyDocs(attributes)
+        refreshStickyBucketService()
+        refreshForRemoteEval()
     }
 
     /**
@@ -451,9 +474,33 @@ class GrowthBookSDK internal constructor(
             refreshStickyBuckets(
                 context = gbContext,
                 data = null,
-                attributeOverrides = attributeOverrides
+                attributeOverrides = gbContext.attributeOverrides
             )
         }
+
+        refreshForRemoteEval()
+    }
+
+    /**
+     * Coroutine version of [updateAttributes] that awaits sticky bucket refresh before returning.
+     * Shallow-merges [attributes] into the current user attributes (see [updateAttributes] for the
+     * exact merge and [GBNull] semantics).
+     *
+     * Note: despite the "Sync" suffix this is a suspend function — it does not block the thread.
+     */
+    suspend fun updateAttributesSync(attributes: Map<String, GBValue>) {
+        // Atomic merge (see updateAttributes); side effects mirror setAttributesSync.
+        gbContext.mergeAttributes(attributes)
+
+        if (gbContext.stickyBucketService != null) {
+            refreshStickyBuckets(
+                context = gbContext,
+                data = null,
+                attributeOverrides = gbContext.attributeOverrides
+            )
+        }
+
+        refreshForRemoteEval()
     }
 
     /**
@@ -464,7 +511,7 @@ class GrowthBookSDK internal constructor(
      * use [setAttributeOverridesSync] instead.
      */
     fun setAttributeOverrides(overrides: Map<String, GBValue>) {
-        attributeOverrides = overrides
+        gbContext.attributeOverrides = overrides
         if (gbContext.stickyBucketService != null) {
             gbContext.stickyBucketAssignmentDocs = null
             refreshStickyBucketService()
@@ -478,13 +525,13 @@ class GrowthBookSDK internal constructor(
      * Note: despite the "Sync" suffix this is a suspend function — it does not block the thread.
      */
     suspend fun setAttributeOverridesSync(overrides: Map<String, GBValue>) {
-        attributeOverrides = overrides
+        gbContext.attributeOverrides = overrides
 
         if (gbContext.stickyBucketService != null) {
             refreshStickyBuckets(
                 context = gbContext,
                 data = null,
-                attributeOverrides = attributeOverrides
+                attributeOverrides = gbContext.attributeOverrides
             )
         }
 
@@ -492,12 +539,19 @@ class GrowthBookSDK internal constructor(
     }
 
     fun getAttributeOverrides(): Map<String, Any> {
-        return attributeOverrides
+        return gbContext.attributeOverrides
     }
 
-    fun getForcedFeatures(): Map<String, GBValue> = forcedFeatures
+    fun getForcedFeatures(): Map<String, GBValue> = gbContext.forcedFeatures
+
+    /**
+     * Sets the Map of forced feature values. In remote evaluation mode this triggers a fresh
+     * remote evaluation, since forced features are part of the remote-eval request payload
+     * (see [GBRemoteEvalParams]).
+     */
     fun setForcedFeatures(forcedFeatures: Map<String, GBValue>) {
-        this.forcedFeatures = forcedFeatures
+        gbContext.forcedFeatures = forcedFeatures
+        refreshForRemoteEval()
     }
 
     /**
@@ -518,7 +572,7 @@ class GrowthBookSDK internal constructor(
             refreshStickyBuckets(
                 context = gbContext,
                 data = model,
-                attributeOverrides = attributeOverrides
+                attributeOverrides = gbContext.attributeOverrides
             )
         } catch (e: Exception) {
             if (gbContext.enableLogging) {
@@ -533,7 +587,7 @@ class GrowthBookSDK internal constructor(
                 refreshStickyBuckets(
                     context = gbContext,
                     data = dataModel,
-                    attributeOverrides = attributeOverrides
+                    attributeOverrides = gbContext.attributeOverrides
                 )
             } catch (e: Exception) {
                 if (gbContext.enableLogging) {
@@ -572,17 +626,27 @@ class GrowthBookSDK internal constructor(
     }
 
     /**
+     * Builds the remote-eval request payload from the current context, or null when not in
+     * remote-eval mode. Used both to kick off an eager re-evaluation ([refreshForRemoteEval]) and,
+     * via a provider seam, so the coalesced retry in [FeaturesViewModel.awaitRefresh] can issue a
+     * remote-eval POST with the latest context instead of a bare GET.
+     */
+    private fun buildRemoteEvalParams(): GBRemoteEvalParams? {
+        if (!gbContext.remoteEval) {
+            return null
+        }
+        return GBRemoteEvalParams(
+            gbContext.attributes,
+            gbContext.forcedFeatures, gbContext.forcedVariations
+        )
+    }
+
+    /**
      * Method for sending request evaluate features remotely
      */
     private fun refreshForRemoteEval() {
-        if (!gbContext.remoteEval) {
-            return
-        }
-        val payload = GBRemoteEvalParams(
-            gbContext.attributes,
-            this.forcedFeatures, gbContext.forcedVariations
-        )
-        featuresViewModel.fetchFeatures(gbContext.remoteEval, payload)
+        val payload = buildRemoteEvalParams() ?: return
+        featuresViewModel.fetchFeatures(payload = payload)
     }
 
     private fun fireSubscriptions(experiment: GBExperiment, experimentResult: GBExperimentResult) {
@@ -610,8 +674,8 @@ class GrowthBookSDK internal constructor(
         NoResultYet, Success, Failed
     }
 
-    private fun createEvaluationContext() =
-        createEvaluationContext(gbContext, gbExperimentHelper)
+    private fun createEvaluationContext(snapshot: EvalSnapshot = gbContext.evalSnapshot()) =
+        createEvaluationContext(gbContext, gbExperimentHelper, snapshot)
 
     //@ThreadLocal
     internal companion object {
@@ -625,11 +689,12 @@ class GrowthBookSDK internal constructor(
         private fun createEvaluationContext(
             gbContext: GBContext,
             gbExperimentHelper: GBExperimentHelper,
+            // One atomic read of the whole shared state: features, savedGroups, attributes, forced
+            // features/variations, attribute overrides and the sticky-bucket docs come from the SAME
+            // snapshot, so the evaluation can never observe a torn mix (e.g. new features with stale
+            // sticky docs, or new attributes with old overrides). Callers pass the snapshot they read.
+            snapshot: EvalSnapshot,
         ): EvaluationContext {
-            // One atomic read of the whole shared state: features, savedGroups, attributes and the
-            // sticky-bucket docs come from the SAME snapshot, so the evaluation can never observe a
-            // torn mix (e.g. new features with stale sticky docs).
-            val snapshot = gbContext.evalSnapshot()
             return EvaluationContext(
                 enabled = gbContext.enabled,
                 features = snapshot.features,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -1,8 +1,10 @@
 package com.sdk.growthbook.features
 
+import com.sdk.growthbook.kotlinx.serialization.gbSerialize
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBOptions
+import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.network.NetworkDispatcher
 import com.sdk.growthbook.network.NetworkDispatcherWithNotModified
 import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
@@ -15,6 +17,8 @@ import com.sdk.growthbook.utils.SSEConnectionController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.transform
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * DataSource for Feature API
@@ -115,8 +119,22 @@ internal class FeaturesDataSource(
          * Create body for request
          */
         params?.let {
-            payload["attributes"] = params.attributes
-            payload["forcedFeatures"] = params.forcedFeatures
+            // Attributes / forced features arrive as GBValue (or already-native) values. Convert
+            // them to JsonElement here — at the SDK boundary that owns the serialization bridge —
+            // so the injected dispatcher receives plain JSON. Otherwise the dispatcher's generic
+            // Map.toJsonElement() falls through to value.toString() and ships garbage like
+            // "GBNumber(value=8490047)" instead of 8490047, breaking server-side targeting.
+            payload["attributes"] = params.attributes.mapValues { (_, value) ->
+                if (value is GBValue) value.gbSerialize() else value
+            }
+            // The remote-eval API expects forcedFeatures as an array of [key, value] pairs
+            // (mirroring sdk-js `Array.from(forcedFeatures)`), NOT a JSON object. Sending an
+            // object makes the GrowthBook proxy reject the request with 400 Bad Request.
+            payload["forcedFeatures"] = JsonArray(
+                params.forcedFeatures.map { (key, value) ->
+                    JsonArray(listOf(JsonPrimitive(key), value.gbSerialize()))
+                }
+            )
             payload["forcedVariations"] = params.forcedVariations
         }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -263,24 +263,33 @@ internal class FeaturesViewModel(
             if (remoteEval) {
                 // [generation] tags this remote-eval round (assigned by the caller at the ordering
                 // point). Remote-eval POSTs are independent and un-cancelled, so a slower older one
-                // can complete after a newer one; apply/report a response only if it is still the
+                // can complete after a newer one. Apply/report a response only while it is still the
                 // latest generation, otherwise a stale evaluation (e.g. for the previous attributes)
-                // would overwrite the current one.
+                // would overwrite the current one. A superseded round still resumes its continuation
+                // (as FetchResult.Superseded, never Success) so the awaiter re-joins the current
+                // generation instead of hanging or being told a discarded round succeeded.
                 dataSource.fetchRemoteEval(
                     params = payload,
                     success = {
                         coroutineScope.launch {
                             if (generation == remoteEvalGeneration.load()) {
                                 handleNetworkModel(it.data)
+                                resumeOnce(FetchResult.Success)
+                            } else {
+                                // Stale: payload not applied → do not report Success. Always resume
+                                // (no leak / no 30s timeout hang), but with a distinct result.
+                                resumeOnce(FetchResult.Superseded)
                             }
-                            resumeOnce(FetchResult.Success)
                         }
                     },
                     failure = {
                         if (generation == remoteEvalGeneration.load()) {
                             dispatch(FetchOutcome.Failed(GBError(it.exception), source = Source.NETWORK))
+                            resumeOnce(FetchResult.Failed)
+                        } else {
+                            // A stale failure is not the current fetch's failure either.
+                            resumeOnce(FetchResult.Superseded)
                         }
-                        resumeOnce(FetchResult.Failed)
                     }
                 )
             } else {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -161,8 +161,19 @@ internal class FeaturesViewModel(
      * in-coroutine right before [performNetworkRound]. A remote-eval response is applied/reported
      * only while its captured generation is still the latest, so a slow older POST cannot overwrite
      * the result of a newer one (out-of-order responses after rapid attribute/forced-feature changes).
+     * The generation check and the (suspend) apply are made atomic by [applyMutex]; the check alone is
+     * not enough — see there.
      */
     private val remoteEvalGeneration = AtomicLong(0)
+
+    /**
+     * Serializes the *application* of a remote-eval payload (the generation check + [handleNetworkModel]).
+     * Without it the `generation == remoteEvalGeneration.load()` check and the suspend apply are not
+     * atomic: on a multi-threaded dispatcher an older round whose check passed could finish its slow
+     * sticky-bucket apply *after* a newer round already applied, overwriting the newer personalized
+     * features. Holding this lock across check+apply makes the newest generation win deterministically.
+     */
+    private val applyMutex = Mutex()
 
     /** Opens an SSE connection and streams feature updates as a [Flow]. */
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
@@ -272,13 +283,18 @@ internal class FeaturesViewModel(
                     params = payload,
                     success = {
                         coroutineScope.launch {
-                            if (generation == remoteEvalGeneration.load()) {
-                                handleNetworkModel(it.data)
-                                resumeOnce(FetchResult.Success)
-                            } else {
-                                // Stale: payload not applied → do not report Success. Always resume
-                                // (no leak / no 30s timeout hang), but with a distinct result.
-                                resumeOnce(FetchResult.Superseded)
+                            // Check the generation and apply the payload atomically under applyMutex:
+                            // the check must hold until handleNetworkModel finishes, or a newer round
+                            // could apply in between and then be overwritten by this (older) one.
+                            applyMutex.withLock {
+                                if (generation == remoteEvalGeneration.load()) {
+                                    handleNetworkModel(it.data)
+                                    resumeOnce(FetchResult.Success)
+                                } else {
+                                    // Stale: payload not applied → do not report Success. Always resume
+                                    // (no leak / no 30s timeout hang), but with a distinct result.
+                                    resumeOnce(FetchResult.Superseded)
+                                }
                             }
                         }
                     },

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAtomicApi::class)
+
 package com.sdk.growthbook.features
 
 import com.sdk.growthbook.logger.GB
@@ -13,6 +15,7 @@ import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBRemoteEvalParams
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
@@ -25,12 +28,15 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonObject
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 
-// Upper bound on a single network round in [FeaturesViewModel.runNetworkGet]. Both recommended
+// Upper bound on a single network round in [FeaturesViewModel.runNetworkRound]. Both recommended
 // dispatchers (Ktor/OkHttp) default to an INFINITE read timeout so a server that accepts the
 // connection then never responds would otherwise leave awaitRefresh()/suspendFeature() hanging
 // forever. Kept dispatcher-agnostic here so custom NetworkDispatcher impls are bounded too.
@@ -100,6 +106,20 @@ internal class FeaturesViewModel(
      */
     private val decoder: FeaturePayloadDecoder = FeaturePayloadDecoder(encryptionKey),
     /**
+     * Whether this view model fetches via remote evaluation (POST) instead of a plain GET.
+     * When true, the coalesced refresh ([awaitRefresh], used by suspendFeature() retries) issues
+     * a remote-eval POST built from [remoteEvalPayloadProvider] rather than a bare GET, so a retry
+     * cannot momentarily surface non-personalized (unevaluated) features. Mirrors the reference
+     * sdk-js `fetchFeatures()` branching on `isRemoteEval()`.
+     */
+    private val remoteEval: Boolean = false,
+    /**
+     * Builds the remote-eval request payload (attributes + forced features + forced variations)
+     * live at call time. Invoked only when [remoteEval] is true; kept live so a retry reflects the
+     * latest context. The payload lives on the owning SDK, hence the provider seam.
+     */
+    private val remoteEvalPayloadProvider: () -> GBRemoteEvalParams? = { null },
+    /**
      * Context on which fetched payloads are processed (decode + sticky-bucket
      * refresh + feature application) and on which the coalesced refresh started by
      * [awaitRefresh] (used by suspendFeature() retries and [revalidate]) runs. It
@@ -134,6 +154,16 @@ internal class FeaturesViewModel(
      */
     private var inFlight: Deferred<FetchResult>? = null
 
+    /**
+     * Monotonic counter bumped when a remote-eval round is initiated, by the wrappers that own the
+     * ordering point: [fetchFromNetwork] increments synchronously *before* its `launch` (so the
+     * generation tracks the payload captured at the same call), and [runNetworkRound] increments
+     * in-coroutine right before [performNetworkRound]. A remote-eval response is applied/reported
+     * only while its captured generation is still the latest, so a slow older POST cannot overwrite
+     * the result of a newer one (out-of-order responses after rapid attribute/forced-feature changes).
+     */
+    private val remoteEvalGeneration = AtomicLong(0)
+
     /** Opens an SSE connection and streams feature updates as a [Flow]. */
     fun autoRefreshFeatures(): Flow<Resource<GBFeatures?>> {
         sseController.start()
@@ -144,19 +174,20 @@ internal class FeaturesViewModel(
     }
 
     /**
-     * @param remoteEval evaluate features remotely via POST instead of a regular GET.
+     * Whether this fetches remotely (POST) or via a regular GET is decided by the instance
+     * [remoteEval] mode, not per call.
+     *
      * @param payload attributes/forced features sent with the remote-eval request;
-     *   used only when [remoteEval] is true, ignored otherwise.
+     *   used only in [remoteEval] mode, ignored otherwise.
      * @param policy whether a fresh cache may satisfy this fetch or the network
      *   must always be hit; see [FetchPolicy].
      */
     fun fetchFeatures(
-        remoteEval: Boolean = false,
         payload: GBRemoteEvalParams? = null,
         policy: FetchPolicy = FetchPolicy.CacheFirst
     ) {
-        if (serveCache(remoteEval, policy)) return // fresh cache -> authoritative, skip network
-        fetchFromNetwork(remoteEval, payload)
+        if (serveCache(policy)) return // fresh cache -> authoritative, skip network
+        fetchFromNetwork(payload)
     }
 
     /**
@@ -166,14 +197,15 @@ internal class FeaturesViewModel(
      * await the same result. The slot is cleared once the request completes, so
      * the next round (e.g. a backoff retry) starts a fresh request.
      *
-     * This is the network primitive beneath the cache-aware [fetchFeatures];
-     * it always hits the network (GET only) and carries no [FetchPolicy].
+     * This is the network primitive beneath the cache-aware [fetchFeatures]; it always hits the
+     * network (a remote-eval POST when [remoteEval] is set, otherwise a GET) and carries no
+     * [FetchPolicy].
      */
     suspend fun awaitRefresh(): FetchResult {
         val deferred = refreshMutex.withLock {
             inFlight ?: coroutineScope.async {
                 try {
-                    runNetworkGet()
+                    runNetworkRound()
                 } finally {
                     refreshMutex.withLock { inFlight = null }
                 }
@@ -193,7 +225,7 @@ internal class FeaturesViewModel(
      * via the refresh handler rather than expecting features to be ready on return.
      */
     fun revalidate() {
-        serveCache(remoteEval = false, policy = FetchPolicy.ForceNetwork)
+        serveCache(policy = FetchPolicy.ForceNetwork)
         coroutineScope.launch { awaitRefresh() }
     }
 
@@ -207,30 +239,93 @@ internal class FeaturesViewModel(
         coroutineScope.cancel()
     }
 
-    /** Bridges the callback-based GET into a suspend result for [awaitRefresh]. */
-    private suspend fun runNetworkGet(): FetchResult =
-        withTimeoutOrNull(NETWORK_ROUND_TIMEOUT_MILLIS.milliseconds) {
-            suspendCancellableCoroutine { cont ->
+    /**
+     * The single network round: issues a remote-eval POST when [remoteEval] is true (mirroring the
+     * reference sdk-js `fetchFeatures()` branch on `isRemoteEval()`), otherwise a plain GET with 304
+     * handling, and feeds every result through the same [dispatch] pipeline. Returns only after the
+     * payload is fully applied (incl. the suspend sticky-bucket refresh in [handleNetworkModel] /
+     * onPayloadReady), so callers observe a completed refresh, not just a completed HTTP round.
+     *
+     * This is the one place the data-source callbacks are wired; [fetchFromNetwork] (fire-and-forget,
+     * cache-aware) and [runNetworkRound] (coalesced, timeout-bounded) are thin wrappers over it.
+     */
+    private suspend fun performNetworkRound(
+        payload: GBRemoteEvalParams?,
+        generation: Long
+    ): FetchResult = suspendCancellableCoroutine { cont ->
+        // Resume the continuation at most once: the synchronous catch below and an async data-source
+        // callback could otherwise both resume it (e.g. a misbehaving dispatcher that invokes a
+        // callback and then also throws synchronously), which is a hard error for a continuation.
+        fun resumeOnce(result: FetchResult) {
+            if (cont.isActive) cont.resume(result)
+        }
+        try {
+            if (remoteEval) {
+                // [generation] tags this remote-eval round (assigned by the caller at the ordering
+                // point). Remote-eval POSTs are independent and un-cancelled, so a slower older one
+                // can complete after a newer one; apply/report a response only if it is still the
+                // latest generation, otherwise a stale evaluation (e.g. for the previous attributes)
+                // would overwrite the current one.
+                dataSource.fetchRemoteEval(
+                    params = payload,
+                    success = {
+                        coroutineScope.launch {
+                            if (generation == remoteEvalGeneration.load()) {
+                                handleNetworkModel(it.data)
+                            }
+                            resumeOnce(FetchResult.Success)
+                        }
+                    },
+                    failure = {
+                        if (generation == remoteEvalGeneration.load()) {
+                            dispatch(FetchOutcome.Failed(GBError(it.exception), source = Source.NETWORK))
+                        }
+                        resumeOnce(FetchResult.Failed)
+                    }
+                )
+            } else {
                 dataSource.fetchFeatures(
                     success = {
-                        // Resume only after the payload is fully applied (incl. the
-                        // suspend sticky-bucket refresh in onPayloadReady), so awaitRefresh()
-                        // callers observe a completed refresh, not just a completed HTTP round.
                         coroutineScope.launch {
                             handleNetworkModel(it)
-                            cont.resume(FetchResult.Success)
+                            resumeOnce(FetchResult.Success)
                         }
                     },
                     failure = {
                         dispatch(FetchOutcome.Failed(GBError(it), source = Source.NETWORK))
-                        cont.resume(FetchResult.Failed)
+                        resumeOnce(FetchResult.Failed)
                     },
                     onNotModified = {
                         dispatch(FetchOutcome.NotModified)
-                        cont.resume(FetchResult.NotModified)
+                        resumeOnce(FetchResult.NotModified)
                     }
                 )
             }
+        } catch (cancellation: CancellationException) {
+            // Never swallow cancellation: it must propagate so runNetworkRound's withTimeoutOrNull and
+            // close()/coroutineScope cancellation keep working. Unlike a real error it is not reported
+            // as a fetch failure.
+            throw cancellation
+        } catch (t: Throwable) {
+            // A dispatcher that throws synchronously while enqueuing the request (e.g. a custom
+            // NetworkDispatcher) must be surfaced as a normal fetch failure — not swallowed by the
+            // coroutine machinery (fire-and-forget path) nor rethrown into initialize()/setAttributes()
+            // (coalesced path). Both wrappers then behave consistently.
+            dispatch(FetchOutcome.Failed(GBError(t), source = Source.NETWORK))
+            resumeOnce(FetchResult.Failed)
+        }
+    }
+
+    /**
+     * The coalesced-refresh runner behind [awaitRefresh]: wraps [performNetworkRound] with a bounded
+     * timeout so a dispatcher that accepts the request but never calls back cannot hang
+     * suspendFeature()'s retry loop forever. Uses the instance [remoteEval] mode with a live payload
+     * from [remoteEvalPayloadProvider].
+     */
+    private suspend fun runNetworkRound(): FetchResult =
+        withTimeoutOrNull(NETWORK_ROUND_TIMEOUT_MILLIS.milliseconds) {
+            val generation = if (remoteEval) remoteEvalGeneration.incrementAndFetch() else 0L
+            performNetworkRound(remoteEvalPayloadProvider(), generation)
         } ?: run {
             // Timed out: the dispatcher accepted the request but never invoked any callback.
             // Surface it as a network failure so remoteSourceFeaturesFetchResult leaves NoResultYet
@@ -239,7 +334,7 @@ internal class FeaturesViewModel(
             FetchResult.Failed
         }
 
-    private fun serveCache(remoteEval: Boolean, policy: FetchPolicy): Boolean {
+    private fun serveCache(policy: FetchPolicy): Boolean {
         val entry = runCatching { readCache() }.getOrElse {
             GB.error("FeaturesViewModel: cache read failed", it)
             delegate.featuresFetchFailed(error = GBError(it), isRemote = false)
@@ -262,21 +357,16 @@ internal class FeaturesViewModel(
         return fresh && outcome is FetchOutcome.Ready
     }
 
-    private fun fetchFromNetwork(remoteEval: Boolean, payload: GBRemoteEvalParams?) {
-        if (remoteEval) dataSource.fetchRemoteEval(
-            params = payload,
-            success = { coroutineScope.launch { handleNetworkModel(it.data) }},
-            failure = {
-                delegate.featuresFetchFailed(
-                    error = GBError(it.exception),
-                    isRemote = true
-                )
-            }
-        ) else dataSource.fetchFeatures(
-            success = { coroutineScope.launch { handleNetworkModel(it) } },
-            failure = { delegate.featuresFetchFailed(error = GBError(it), isRemote = true) },
-            onNotModified = { dispatch(outcome = FetchOutcome.NotModified) }
-        )
+    /**
+     * Fire-and-forget network fetch behind the cache-aware [fetchFeatures]. Starts a *fresh*
+     * [performNetworkRound] (never joins the coalesced in-flight request, so a state-change-driven
+     * fetch — e.g. a remote-eval refresh after an attribute change — always sends the current
+     * payload) and reports the result through the delegate. Not timeout-bounded (that is
+     * [awaitRefresh]/[runNetworkRound]'s job); observe completion via the refresh handler.
+     */
+    private fun fetchFromNetwork(payload: GBRemoteEvalParams?) {
+        val generation = if (remoteEval) remoteEvalGeneration.incrementAndFetch() else 0L
+        coroutineScope.launch { performNetworkRound(payload, generation) }
     }
 
     private suspend fun handleNetworkModel(model: FeaturesDataModel) {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -286,10 +286,20 @@ internal class FeaturesViewModel(
                             // Check the generation and apply the payload atomically under applyMutex:
                             // the check must hold until handleNetworkModel finishes, or a newer round
                             // could apply in between and then be overwritten by this (older) one.
+                            //
+                            // This up-front check is necessary but NOT sufficient: handleNetworkModel
+                            // suspends (onPayloadReady's sticky-bucket refresh) and the generation is
+                            // bumped outside applyMutex (incrementAndFetch in runNetworkRound /
+                            // fetchFromNetwork), so a newer round can supersede this one *during* that
+                            // suspend. handleNetworkModel therefore re-validates the generation at the
+                            // final commit point and returns false when it declined to commit — mapped
+                            // to Superseded here so a stale round never overwrites nor reports Success.
                             applyMutex.withLock {
                                 if (generation == remoteEvalGeneration.load()) {
-                                    handleNetworkModel(it.data)
-                                    resumeOnce(FetchResult.Success)
+                                    val committed = handleNetworkModel(it.data, generation)
+                                    resumeOnce(
+                                        if (committed) FetchResult.Success else FetchResult.Superseded
+                                    )
                                 } else {
                                     // Stale: payload not applied → do not report Success. Always resume
                                     // (no leak / no 30s timeout hang), but with a distinct result.
@@ -394,7 +404,18 @@ internal class FeaturesViewModel(
         coroutineScope.launch { performNetworkRound(payload, generation) }
     }
 
-    private suspend fun handleNetworkModel(model: FeaturesDataModel) {
+    /**
+     * Applies a fetched payload: decode → onPayloadReady (sticky-bucket refresh) → cache → dispatch.
+     *
+     * @param generation the remote-eval round token, or null for the non-remote GET path (no fence).
+     * @return true when the payload was committed (Success dispatched) or when it failed and reported
+     *   its own failure; false only when a newer remote-eval generation superseded this round during
+     *   the onPayloadReady suspend, so the caller maps the round to FetchResult.Superseded.
+     */
+    private suspend fun handleNetworkModel(
+        model: FeaturesDataModel,
+        generation: Long? = null,
+    ): Boolean {
         try {
             // Decode/decrypt the payload BEFORE the sticky-bucket refresh, mirroring the reference
             // TS SDK (decryptPayload -> refreshStickyBuckets). For an encrypted payload the raw
@@ -410,6 +431,17 @@ internal class FeaturesViewModel(
                     encryptedSavedGroups = null,
                 )
             )
+
+            // Final payload-commit fence. onPayloadReady above suspends (sticky-bucket refresh) and
+            // the generation is bumped outside applyMutex (incrementAndFetch), so a newer round may
+            // have superseded us while we were suspended. Bail before writing the cache / committing
+            // features / reporting Success, so a stale round never overwrites the fresher state nor
+            // reports Success. The newer round (already queued on applyMutex or still in flight)
+            // commits its own payload. Skipped on the non-remote GET path (generation == null).
+            if (generation != null && generation != remoteEvalGeneration.load()) {
+                return false
+            }
+
             if (cachingEnabled) {
                 runCatching { writeCache(model) }
                     .onFailure {
@@ -426,6 +458,7 @@ internal class FeaturesViewModel(
                     source = Source.NETWORK
                 )
             )
+            return true
         } catch (error: Throwable) {
             GB.error(
                 errorMessage = "FeaturesViewModel: failed to process remote features payload",
@@ -433,6 +466,7 @@ internal class FeaturesViewModel(
             )
 
             delegate.featuresFetchFailed(error = GBError(error), isRemote = true)
+            return true
         }
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchResult.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FetchResult.kt
@@ -9,5 +9,15 @@ package com.sdk.growthbook.features
 internal enum class FetchResult {
     Success,
     Failed,
-    NotModified
+    NotModified,
+
+    /**
+     * The remote-eval round completed but its payload was discarded because a newer generation
+     * superseded it (see the generation guard in [FeaturesViewModel.performNetworkRound]). It is
+     * deliberately neither [Success] (nothing was applied) nor [Failed] (nothing went wrong): a
+     * caller awaiting the older attributes must NOT be told the refresh succeeded, or it could
+     * return a stale evaluation. The awaiter should instead re-join the latest generation (i.e.
+     * loop and await again).
+     */
+    Superseded
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -25,6 +25,8 @@ internal data class EvalSnapshot(
     val features: GBFeatures = HashMap(),
     val attributes: Map<String, GBValue> = emptyMap(),
     val forcedVariations: Map<String, Number> = emptyMap(),
+    val forcedFeatures: Map<String, GBValue> = emptyMap(),
+    val attributeOverrides: Map<String, GBValue> = emptyMap(),
     val stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
     val stickyBucketIdentifierAttributes: List<String>? = null,
     val savedGroups: Map<String, GBValue>? = null,
@@ -179,6 +181,42 @@ class GBContext(
     internal fun setAttributesClearingStickyDocs(attributes: Map<String, GBValue>) = mutate {
         it.copy(attributes = attributes, stickyBucketAssignmentDocs = null)
     }
+
+    /**
+     * Atomically shallow-merge [attributes] into the current attributes (new keys added, existing
+     * overwritten, others preserved). The read-merge-write happens inside the CAS loop, so two
+     * concurrent merges can never lose each other's keys — unlike a read-then-[attributes]-set from
+     * the caller. Mirrors the intent of [setAttributesClearingStickyDocs] for the merge case.
+     */
+    internal fun mergeAttributesClearingStickyDocs(attributes: Map<String, GBValue>) = mutate {
+        it.copy(attributes = it.attributes + attributes, stickyBucketAssignmentDocs = null)
+    }
+
+    /**
+     * Atomically shallow-merge [attributes] into the current attributes without touching the
+     * sticky-bucket docs (mirrors the plain [attributes] setter used by `setAttributesSync`). The
+     * merge is inside the CAS loop, so concurrent merges never lose keys.
+     */
+    internal fun mergeAttributes(attributes: Map<String, GBValue>) = mutate {
+        it.copy(attributes = it.attributes + attributes)
+    }
+
+    /**
+     * Forced feature values, published atomically alongside the other evaluation inputs so a reader
+     * on another thread always sees the latest write (previously a plain field on GrowthBookSDK with
+     * no happens-before guarantee).
+     */
+    internal var forcedFeatures: Map<String, GBValue>
+        get() = state.load().forcedFeatures
+        set(value) = mutate { it.copy(forcedFeatures = value) }
+
+    /**
+     * Attribute overrides used for Sticky Bucketing, published atomically alongside the other
+     * evaluation inputs (previously a plain field on GrowthBookSDK with no happens-before guarantee).
+     */
+    internal var attributeOverrides: Map<String, GBValue>
+        get() = state.load().attributeOverrides
+        set(value) = mutate { it.copy(attributeOverrides = value) }
 
     /**
      * List of user's attributes keys

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -5,6 +5,7 @@ package com.sdk.growthbook.integration
 // import com.sdk.growthbook.GrowthBookSDK
 // import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBBoolean
+import com.sdk.growthbook.model.GBFeature
 // import com.sdk.growthbook.model.GBFeatureResult
 // import com.sdk.growthbook.model.GBFeatureSource
 import com.sdk.growthbook.model.GBString
@@ -183,6 +184,41 @@ internal class VerifySDKReturnFeatureValues {
         // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
 
         coVerify { mockedFeaturesViewModel.awaitRefresh() }
+    }
+
+    @Test
+    fun `suspendFeature on Superseded re-joins and returns the fresh value, never the stale one`() = runTest {
+        // Companion to FeaturesViewModelTests.testRoundSupersededDuringApplyDoesNotCommitNorReportSuccess:
+        // that test proves the final payload-commit fence turns a mid-apply supersession into
+        // FetchResult.Superseded (not Success). This test proves suspendFeature() CONSUMES that signal
+        // correctly — on Superseded it re-joins the newest generation instead of returning the stale
+        // feature that was current while the superseded (older) round was still in flight.
+        val gbSdk = buildSDK(json = "{}", attributes = emptyMap())
+
+        // A stale value is currently in context and the in-flight round is in the Failed/retry state.
+        gbSdk.getGBContext().features = mapOf("flag" to GBFeature(GBBoolean(false)))
+        gbSdk.featuresFetchFailed(GBError(null), true) // remoteSourceFeaturesFetchResult = Failed
+
+        val mockedFeaturesViewModel: FeaturesViewModel = mockk {
+            // 1st awaitRefresh(): the round was superseded (attributes changed mid-apply) → suspendFeature
+            //    must `continue`, NOT return the stale value.
+            // 2nd awaitRefresh(): the newer round lands, applies the FRESH features and reports success.
+            coEvery { awaitRefresh() } returns FetchResult.Superseded andThenAnswer {
+                gbSdk.getGBContext().features = mapOf("flag" to GBFeature(GBBoolean(true)))
+                gbSdk.featuresFetchedSuccessfully(gbSdk.getGBContext().features, true)
+                FetchResult.Success
+            }
+        }
+        gbSdk.featuresViewModel = mockedFeaturesViewModel
+
+        val result = gbSdk.suspendFeature("flag")
+
+        assertEquals(
+            true,
+            result.on,
+            "suspendFeature must return the fresh value applied after supersession, not the stale one",
+        )
+        coVerify(exactly = 2) { mockedFeaturesViewModel.awaitRefresh() }
     }
 
 /*

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -12,6 +12,7 @@ import com.sdk.growthbook.model.GBBoolean
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
@@ -397,6 +398,69 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         // Complete the still-pending latest round so runTest sees no leaked coroutine.
         client.pendingPosts[1]("""{"status":200,"features":{"new_feature":{"defaultValue":true}}}""")
         runCurrent()
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testOlderRemoteEvalApplyCannotOverwriteNewerWhileSuspended() = runTest {
+        // #2: the generation check and the (suspend) payload apply must be atomic. Here the OLDER
+        // round passes its generation check and then SUSPENDS mid-apply (inside onPayloadReady) while
+        // the NEWER round completes. Without serializing the apply under applyMutex, the older round
+        // would resume and apply last, overwriting the newer personalized features. The mutex must
+        // make the newest generation win regardless of how the applies interleave.
+        val client = DeferredPostNetworkClient()
+        val oldApplyGate = CompletableDeferred<Unit>()
+        val appliedOrder = mutableListOf<String>()
+        val delegate = object : FeaturesFlowDelegate {
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+                features.keys.firstOrNull()?.let { appliedOrder.add(it) }
+            }
+            override suspend fun onPayloadReady(model: FeaturesDataModel) {
+                // Hold the OLDER round inside its apply until the test releases the gate.
+                if (model.features?.containsKey("old_feature") == true) oldApplyGate.await()
+            }
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = delegate,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            remoteEval = true,
+            remoteEvalPayloadProvider = { GBRemoteEvalParams(emptyMap(), emptyMap(), emptyMap()) },
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Older round via the COALESCED path (awaitRefresh), so the fetchFromNetwork job ref does not
+        // cancel it — this isolates the applyMutex behaviour from the fire-and-forget cancellation (#3).
+        backgroundScope.launch { viewModel.awaitRefresh() } // generation 1 (older)
+        runCurrent()
+        assertEquals(1, client.pendingPosts.size)
+        client.pendingPosts[0]("""{"status":200,"features":{"old_feature":{"defaultValue":true}}}""")
+        runCurrent()
+        // Older round now holds applyMutex, suspended inside onPayloadReady on the gate.
+
+        viewModel.fetchFeatures() // generation 2 (newer)
+        runCurrent()
+        assertEquals(2, client.pendingPosts.size)
+        client.pendingPosts[1]("""{"status":200,"features":{"new_feature":{"defaultValue":true}}}""")
+        runCurrent()
+        // Newer round is now blocked on applyMutex behind the older round (it must not have applied yet).
+        assertTrue(
+            "new_feature" !in appliedOrder,
+            "the newer round must wait for the older apply to release the mutex",
+        )
+
+        oldApplyGate.complete(Unit) // release older apply; the newer one applies after it, winning.
+        runCurrent()
+
+        assertEquals(
+            "new_feature",
+            appliedOrder.lastOrNull(),
+            "the newest generation must win even when an older apply was suspended mid-flight",
+        )
     }
 
     @Test

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -463,6 +463,88 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         )
     }
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testRoundSupersededDuringApplyDoesNotCommitNorReportSuccess() = runTest {
+        // P1 (final payload-commit fence): the OLDER round passes its up-front generation check and
+        // then SUSPENDS mid-apply (inside onPayloadReady). A NEWER round bumps the generation DURING
+        // that suspend (incrementAndFetch runs outside applyMutex). When the older round resumes it
+        // must RE-VALIDATE the generation at the commit point and bail: it must NOT commit its now
+        // stale features (no featuresFetchedSuccessfully) and its awaiter must resolve as Superseded,
+        // not Success. Without the re-check the older round commits old_feature and reports Success
+        // for a superseded round.
+        //
+        // NB: the sibling test testOlderRemoteEvalApplyCannotOverwriteNewerWhileSuspended only asserts
+        // the newest features win LAST — it does not catch the stale commit / false Success this covers.
+        val client = DeferredPostNetworkClient()
+        val oldApplyGate = CompletableDeferred<Unit>()
+        val committed = mutableListOf<String>()
+        val delegate = object : FeaturesFlowDelegate {
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+                features.keys.firstOrNull()?.let { committed.add(it) }
+            }
+            override suspend fun onPayloadReady(model: FeaturesDataModel) {
+                // Hold the OLDER round inside its apply until the test releases the gate.
+                if (model.features?.containsKey("old_feature") == true) oldApplyGate.await()
+            }
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = delegate,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            remoteEval = true,
+            remoteEvalPayloadProvider = { GBRemoteEvalParams(emptyMap(), emptyMap(), emptyMap()) },
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Older round (generation 1) via the coalesced path so we can observe its FetchResult.
+        var olderResult: FetchResult? = null
+        backgroundScope.launch { olderResult = viewModel.awaitRefresh() }
+        runCurrent()
+        assertEquals(1, client.pendingPosts.size)
+
+        // Its POST returns: the round passes the up-front check, takes applyMutex, and suspends inside
+        // onPayloadReady on the gate.
+        client.pendingPosts[0]("""{"status":200,"features":{"old_feature":{"defaultValue":true}}}""")
+        runCurrent()
+
+        // Newer round (generation 2). fetchFromNetwork's incrementAndFetch bumps the generation to 2
+        // synchronously — no need to resolve its POST yet — while the older round is still mid-apply.
+        viewModel.fetchFeatures() // generation 2 (newer)
+        runCurrent()
+        assertEquals(2, client.pendingPosts.size)
+
+        // Release the older apply; it resumes AFTER the generation moved to 2.
+        oldApplyGate.complete(Unit)
+        runCurrent()
+
+        // 1) The stale older round must NOT commit its features.
+        assertTrue(
+            "old_feature" !in committed,
+            "a remote-eval round superseded during its (suspend) apply must not commit stale features",
+        )
+        // 2) Its awaiter must see Superseded, not Success — so suspendFeature() re-joins the newest
+        //    generation (line 329) instead of returning a stale feature.
+        assertEquals(
+            FetchResult.Superseded,
+            olderResult,
+            "a round superseded during apply must resolve awaitRefresh() as Superseded, not Success",
+        )
+
+        // Let the newest round finish (no leaked coroutine) and confirm it is the one that commits.
+        client.pendingPosts[1]("""{"status":200,"features":{"new_feature":{"defaultValue":true}}}""")
+        runCurrent()
+        assertEquals(
+            "new_feature",
+            committed.lastOrNull(),
+            "the newest generation must be the one that commits",
+        )
+    }
+
     @Test
     fun testSynchronousDispatcherThrowIsReportedAsFailure() = runTest {
         // #3: a dispatcher that throws synchronously while enqueuing must be reported as a fetch

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -354,6 +354,51 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         )
     }
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testStaleRemoteEvalRoundReportsSupersededNotSuccess() = runTest {
+        // P1 (awaiter contract): a remote-eval round whose response is discarded by the generation
+        // guard must NOT resolve awaitRefresh() as Success — otherwise a suspendFeature() awaiting
+        // the OLD attributes would return a stale evaluation while a newer request is still pending.
+        // It must resolve as Superseded so the caller re-joins the current generation. Companion to
+        // testRemoteEvalOutOfOrderResponseIsDiscarded, which only checks the final applied payload.
+        val client = DeferredPostNetworkClient()
+        val emptyParams = GBRemoteEvalParams(emptyMap(), emptyMap(), emptyMap())
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            cachingLayer = MockCachingLayer(), // empty store, keeps the test off disk
+            remoteEval = true,
+            remoteEvalPayloadProvider = { emptyParams },
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Coalesced round for the OLD attributes (generation 1); it suspends awaiting its POST.
+        var awaiterResult: FetchResult? = null
+        backgroundScope.launch { awaiterResult = viewModel.awaitRefresh() }
+        runCurrent()
+
+        // A newer state-change fetch bumps the generation (generation 2), superseding the awaiter.
+        viewModel.fetchFeatures(payload = emptyParams)
+        runCurrent()
+        assertEquals(2, client.pendingPosts.size)
+
+        // The OLD round's response arrives while the newer one is still pending.
+        client.pendingPosts[0]("""{"status":200,"features":{"old_feature":{"defaultValue":true}}}""")
+        runCurrent()
+
+        assertEquals(
+            FetchResult.Superseded,
+            awaiterResult,
+            "a discarded (superseded) remote-eval round must resolve awaitRefresh() as Superseded, not Success",
+        )
+
+        // Complete the still-pending latest round so runTest sees no leaked coroutine.
+        client.pendingPosts[1]("""{"status":200,"features":{"new_feature":{"defaultValue":true}}}""")
+        runCurrent()
+    }
+
     @Test
     fun testSynchronousDispatcherThrowIsReportedAsFailure() = runTest {
         // #3: a dispatcher that throws synchronously while enqueuing must be reported as a fetch

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -8,6 +8,7 @@ import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.features.FetchResult
+import com.sdk.growthbook.model.GBBoolean
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
@@ -26,7 +27,9 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -165,6 +168,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            remoteEval = true,
             coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
@@ -176,7 +180,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             forcedVariations = forcedVariation,
         )
 
-        viewModel.fetchFeatures(remoteEval = true, payload = payload)
+        viewModel.fetchFeatures(payload = payload)
         assertTrue(isSuccess)
         assertTrue(!isError)
         assertTrue(hasFeatures)
@@ -199,6 +203,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 ),
             encryptionKey = "3tfeoyW0wlo47bDnbWDkxg==",
             cachingEnabled = false,
+            remoteEval = true,
             coroutineContext = UnconfinedTestDispatcher(testScheduler),
         )
         val forcedFeature = mapOf("feature" to GBNumber(123))
@@ -210,11 +215,170 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             forcedVariations = forcedVariation
         )
 
-        viewModel.fetchFeatures(remoteEval = true, payload = payload)
+        viewModel.fetchFeatures(payload = payload)
 
         assertTrue(!isSuccess)
         assertTrue(isError)
         assertTrue(!hasFeatures)
+    }
+
+    @Test
+    fun testRemoteEvalPostBodyEncodesNativeValuesAndForcedFeaturesArray() = runTest {
+        // Regression: the remote-eval POST body must carry real JSON, not GBValue.toString().
+        //   - attributes: GBNumber(8490047) -> 8490047 (NOT the string "GBNumber(value=8490047)")
+        //   - forcedFeatures: an array of [key, value] pairs (mirroring sdk-js), NOT a JSON object,
+        //     otherwise the GrowthBook proxy rejects the request with 400 Bad Request.
+        val client = CapturingPostNetworkClient(MockResponse.successResponse)
+        val payload = GBRemoteEvalParams(
+            attributes = mapOf(
+                "user_id" to GBNumber(8490047),
+                "os_platform" to GBString("Android"),
+            ),
+            forcedFeatures = mapOf("demo-forced-flag" to GBBoolean(true)),
+            forcedVariations = emptyMap(),
+        )
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            remoteEval = true,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        viewModel.fetchFeatures(payload = payload)
+
+        val body = assertNotNull(client.lastBodyParams)
+
+        @Suppress("UNCHECKED_CAST")
+        val attrs = body["attributes"] as Map<String, Any?>
+        // Real JSON primitives — never the GBValue.toString() fallback.
+        assertEquals(JsonPrimitive(8490047), attrs["user_id"])
+        assertEquals(JsonPrimitive("Android"), attrs["os_platform"])
+
+        val forced = body["forcedFeatures"]
+        assertTrue(forced is JsonArray, "forcedFeatures must be a JsonArray, was ${forced?.let { it::class }}")
+        assertEquals(1, forced.size)
+        val pair = forced[0]
+        assertTrue(pair is JsonArray, "each forcedFeatures entry must be a [key, value] JsonArray")
+        assertEquals(JsonPrimitive("demo-forced-flag"), pair[0])
+        assertEquals(JsonPrimitive(true), pair[1])
+    }
+
+    @Test
+    fun testAwaitRefreshUsesRemoteEvalPostWhenRemoteEval() = runTest {
+        // #8: in remote-eval mode the coalesced retry (awaitRefresh, driven by suspendFeature)
+        // must issue a remote-eval POST, never a bare GET that could surface unevaluated features.
+        val client = CountingPostNetworkClient(MockResponse.successResponse)
+        val payload = GBRemoteEvalParams(
+            attributes = mapOf("id" to "1"),
+            forcedFeatures = emptyMap(),
+            forcedVariations = emptyMap(),
+        )
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            remoteEval = true,
+            remoteEvalPayloadProvider = { payload },
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = viewModel.awaitRefresh()
+
+        assertEquals(FetchResult.Success, result)
+        assertEquals(1, client.postCount)
+        assertEquals(0, client.getCount)
+        assertTrue(isSuccess)
+        assertTrue(hasFeatures)
+    }
+
+    @Test
+    fun testAwaitRefreshUsesGetWhenNotRemoteEval() = runTest {
+        val client = CountingPostNetworkClient(MockResponse.successResponse)
+        val viewModel = FeaturesViewModel(
+            delegate = this@FeaturesViewModelTests,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = viewModel.awaitRefresh()
+
+        assertEquals(FetchResult.Success, result)
+        assertEquals(0, client.postCount)
+        assertEquals(1, client.getCount)
+    }
+
+    @Test
+    fun testRemoteEvalOutOfOrderResponseIsDiscarded() = runTest {
+        // #2: two remote-eval POSTs are in flight; the OLDER one completing last must NOT overwrite
+        // the newer one's evaluated features (generation guard).
+        val client = DeferredPostNetworkClient()
+        var appliedFeatures: GBFeatures? = null
+        val delegate = object : FeaturesFlowDelegate {
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+                appliedFeatures = features
+            }
+            override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = delegate,
+            dataSource = FeaturesDataSource(client, gbContext, testGbOptions),
+            cachingEnabled = false,
+            remoteEval = true,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+        val respOld = """{"status":200,"features":{"old_feature":{"defaultValue":true}}}"""
+        val respNew = """{"status":200,"features":{"new_feature":{"defaultValue":true}}}"""
+
+        viewModel.fetchFeatures() // generation 1 (older)
+        viewModel.fetchFeatures() // generation 2 (newer)
+        assertEquals(2, client.pendingPosts.size)
+
+        // Respond newest first, then the stale older one arrives late.
+        client.pendingPosts[1](respNew)
+        client.pendingPosts[0](respOld)
+
+        assertNotNull(appliedFeatures)
+        assertTrue(
+            appliedFeatures!!.containsKey("new_feature"),
+            "the newest remote-eval response must be applied"
+        )
+        assertTrue(
+            !appliedFeatures!!.containsKey("old_feature"),
+            "a stale older remote-eval response must be discarded, not applied last"
+        )
+    }
+
+    @Test
+    fun testSynchronousDispatcherThrowIsReportedAsFailure() = runTest {
+        // #3: a dispatcher that throws synchronously while enqueuing must be reported as a fetch
+        // failure — not swallowed by the coroutine machinery, and not rethrown into the caller.
+        var failed = false
+        val delegate = object : FeaturesFlowDelegate {
+            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) = Unit
+            override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
+            override fun featuresFetchFailed(error: GBError, isRemote: Boolean) { failed = true }
+            override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
+            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
+            override fun featuresNotModified() = Unit
+        }
+        val viewModel = FeaturesViewModel(
+            delegate = delegate,
+            dataSource = FeaturesDataSource(SynchronouslyThrowingNetworkClient(), gbContext, testGbOptions),
+            cachingEnabled = false,
+            coroutineContext = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Must return (not throw) and surface the error through the delegate.
+        val result = viewModel.awaitRefresh()
+
+        assertEquals(FetchResult.Failed, result)
+        assertTrue(failed, "a synchronous dispatcher throw must be reported via featuresFetchFailed")
     }
 
     @Test

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -10,6 +10,7 @@ import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.model.GBFeature
 import com.sdk.growthbook.model.GBFeatureSource
+import com.sdk.growthbook.model.GBNull
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBString
 import com.sdk.growthbook.model.GBValue
@@ -432,6 +433,161 @@ class GrowthBookSDKBuilderTests {
         }
 
     @Test
+    fun test_updateAttributes_mergesNewKeysAndPreservesExisting() = TestScope().runTest {
+        val sdk = buildSdkWithHandler()
+        sdk.setAttributesSync(mapOf("id" to GBString("1")))
+
+        sdk.updateAttributes(mapOf("plan" to GBString("pro")))
+
+        val attrs = sdk.getGBContext().attributes
+        assertEquals("1", (attrs["id"] as? GBString)?.value)
+        assertEquals("pro", (attrs["plan"] as? GBString)?.value)
+    }
+
+    @Test
+    fun test_updateAttributes_overwritesExistingKey() = TestScope().runTest {
+        val sdk = buildSdkWithHandler()
+        sdk.setAttributesSync(mapOf("plan" to GBString("free"), "id" to GBString("1")))
+
+        sdk.updateAttributes(mapOf("plan" to GBString("pro")))
+
+        val attrs = sdk.getGBContext().attributes
+        assertEquals("pro", (attrs["plan"] as? GBString)?.value)
+        assertEquals("1", (attrs["id"] as? GBString)?.value)
+    }
+
+    @Test
+    fun test_updateAttributes_gbNullKeepsKey_matchesTypeScript() = TestScope().runTest {
+        // Parity with the TS reference SDK: a null value keeps the key with a null value,
+        // it does NOT remove the key (removal requires a full setAttributes replace).
+        val sdk = buildSdkWithHandler()
+        sdk.setAttributesSync(mapOf("plan" to GBString("pro")))
+
+        sdk.updateAttributes(mapOf("plan" to GBNull))
+
+        val attrs = sdk.getGBContext().attributes
+        assertTrue(attrs.containsKey("plan"))
+        assertTrue(attrs["plan"] is GBNull)
+    }
+
+    @Test
+    fun test_updateAttributesSync_mergesNewKeysAndPreservesExisting() = TestScope().runTest {
+        val sdk = buildSdkWithHandler()
+        sdk.setAttributesSync(mapOf("id" to GBString("1")))
+
+        sdk.updateAttributesSync(mapOf("plan" to GBString("pro")))
+
+        val attrs = sdk.getGBContext().attributes
+        assertEquals("1", (attrs["id"] as? GBString)?.value)
+        assertEquals("pro", (attrs["plan"] as? GBString)?.value)
+    }
+
+    @Test
+    fun test_updateAttributes_concurrentMergesDoNotLoseKeys() {
+        // Regression for the non-atomic read-modify-write: each thread adds its own disjoint keys
+        // concurrently; with a read-then-setAttributes merge some writes would be lost. The atomic
+        // GBContext.mergeAttributesClearingStickyDocs keeps every key.
+        val sdk = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = emptyMap(),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+            remoteEval = false,
+        ).initialize()
+
+        val threadCount = 8
+        val perThread = 200
+        val ready = CountDownLatch(threadCount)
+        val start = CountDownLatch(1)
+        val threads = (0 until threadCount).map { t ->
+            Thread {
+                ready.countDown()
+                start.await()
+                repeat(perThread) { i -> sdk.updateAttributes(mapOf("k_${t}_$i" to GBString("v"))) }
+            }
+        }
+        threads.forEach { it.start() }
+        ready.await()
+        start.countDown() // release all threads at once to maximize contention
+        threads.forEach { it.join() }
+
+        assertEquals(
+            threadCount * perThread,
+            sdk.getGBContext().attributes.size,
+            "concurrent updateAttributes must not drop any keys"
+        )
+    }
+
+    @Test
+    fun test_setAttributes_withRemoteEval_triggersRemoteRefresh() = runTest {
+        val client = CountingPostNetworkClient(MockResponse.successResponse)
+        val sdk = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = mapOf("id" to GBString("1")),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = client,
+            remoteEval = true,
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).initialize()
+
+        val countAfterInit = client.postCount
+        sdk.setAttributes(mapOf("id" to GBString("2")))
+
+        assertTrue(
+            client.postCount > countAfterInit,
+            "Changing attributes in remote-eval mode must trigger a fresh remote evaluation request"
+        )
+    }
+
+    @Test
+    fun test_updateAttributes_withRemoteEval_triggersRemoteRefresh() = runTest {
+        val client = CountingPostNetworkClient(MockResponse.successResponse)
+        val sdk = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = mapOf("id" to GBString("1")),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = client,
+            remoteEval = true,
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).initialize()
+
+        val countAfterInit = client.postCount
+        sdk.updateAttributes(mapOf("plan" to GBString("pro")))
+
+        assertTrue(
+            client.postCount > countAfterInit,
+            "updateAttributes in remote-eval mode must trigger a fresh remote evaluation request"
+        )
+    }
+
+    @Test
+    fun test_setForcedFeatures_withRemoteEval_triggersRemoteRefresh() = runTest {
+        val client = CountingPostNetworkClient(MockResponse.successResponse)
+        val sdk = GBSDKBuilder(
+            testApiKey,
+            testHostURL,
+            attributes = mapOf("id" to GBString("1")),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = client,
+            remoteEval = true,
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler)).initialize()
+
+        val countAfterInit = client.postCount
+        sdk.setForcedFeatures(mapOf("featureForce" to GBNumber(112)))
+
+        assertTrue(
+            client.postCount > countAfterInit,
+            "setForcedFeatures in remote-eval mode must trigger a fresh remote evaluation request " +
+                "(forcedFeatures is part of the remote-eval payload)"
+        )
+    }
+
+    @Test
     fun test_savedGroupsFetchFailed_isRemoteTrue_callsRefreshHandlerWithFalse() = runTest {
         var handlerSuccess: Boolean? = null
         val sdk = buildSdkWithHandler(refreshHandler = { success, _ -> handlerSuccess = success })
@@ -748,7 +904,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun testSetInitialFeaturesTreats304AsSuccess() {
+    fun testSetInitialFeaturesTreats304AsSuccess() = runTest {
         val bundledFeatures: GBFeatures = mapOf("bundled-feature" to GBFeature())
         var refreshCalled = false
         var refreshSuccess: Boolean? = null
@@ -770,6 +926,9 @@ class GrowthBookSDKBuilderTests {
                 refreshCalled = true
                 refreshSuccess = success
             }
+            // Deterministic dispatcher: the fetch's 304 callback is applied on the test scheduler,
+            // so the assertions below observe a completed refresh without relying on wall-clock timing.
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
             .initialize()
 
         assertTrue(refreshCalled, "Refresh handler should be invoked on a 304 response")

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
@@ -77,6 +77,106 @@ open class MockNetworkClient(
     }
 }
 
+/**
+ * Mock client that counts POST (remote-eval) and GET requests so tests can assert which network
+ * path was taken — e.g. that an attribute change triggered a remote-eval POST, or that a retry in
+ * remote-eval mode issued a POST rather than a bare GET.
+ */
+open class CountingPostNetworkClient(
+    successResponse: String?,
+) : MockNetworkClient(successResponse, null) {
+
+    var postCount = 0
+        private set
+
+    var getCount = 0
+        private set
+
+    override fun consumeGETRequestWithNotModified(
+        request: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onNotModified: (() -> Unit)
+    ): Job {
+        getCount++
+        return super.consumeGETRequestWithNotModified(request, onSuccess, onError, onNotModified)
+    }
+
+    override fun consumePOSTRequest(
+        url: String,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        postCount++
+        super.consumePOSTRequest(url, bodyParams, onSuccess, onError)
+    }
+}
+
+/**
+ * Mock client that records the last POST body it was handed, so a test can assert the exact
+ * on-the-wire shape of the remote-eval payload (native JSON values for attributes, forcedFeatures
+ * as an array of [key, value] pairs). Still invokes onSuccess so the fetch flow completes.
+ */
+open class CapturingPostNetworkClient(
+    successResponse: String?,
+) : MockNetworkClient(successResponse, null) {
+
+    var lastBodyParams: Map<String, Any>? = null
+        private set
+
+    override fun consumePOSTRequest(
+        url: String,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        lastBodyParams = bodyParams
+        super.consumePOSTRequest(url, bodyParams, onSuccess, onError)
+    }
+}
+
+/**
+ * Mock client that captures each POST's success callback instead of invoking it, so a test can
+ * drive remote-eval responses in an arbitrary order (e.g. an older request completing after a
+ * newer one) and assert the out-of-order guard.
+ */
+open class DeferredPostNetworkClient : MockNetworkClient(null, null) {
+
+    val pendingPosts = mutableListOf<(String) -> Unit>()
+
+    override fun consumePOSTRequest(
+        url: String,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ) {
+        pendingPosts.add(onSuccess)
+    }
+}
+
+/**
+ * Mock dispatcher that throws synchronously while enqueuing (as a misbehaving custom
+ * NetworkDispatcher might). Used to assert the view model reports this as a fetch failure instead of
+ * swallowing it or rethrowing it into the caller.
+ */
+open class SynchronouslyThrowingNetworkClient : MockNetworkClient(null, null) {
+
+    override fun consumeGETRequestWithNotModified(
+        request: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onNotModified: (() -> Unit)
+    ): Job = throw RuntimeException("dispatcher failed to enqueue GET")
+
+    override fun consumePOSTRequest(
+        url: String,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ): Unit = throw RuntimeException("dispatcher failed to enqueue POST")
+}
+
 class MockResponse {
     companion object {
 

--- a/NetworkDispatcherKtor/build.gradle.kts
+++ b/NetworkDispatcherKtor/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.14"
+version = "1.0.15"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
+++ b/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
@@ -26,7 +26,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.core.use
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
@@ -314,35 +313,36 @@ class GBNetworkDispatcherKtor(
         onError: (Throwable) -> Unit
     ) {
         CoroutineScope(PlatformDependentIODispatcher).launch {
-            client.use { okHttpClient ->
-                try {
-                    val response = okHttpClient.post(url) {
-                        headers {
-                            append("Content-Type", "application/json")
-                            append("Accept", "application/json")
-                        }
-                        contentType(ContentType.Application.Json)
-                        setBody(bodyParams.toJsonElement())
-                        if (enableLogging) {
-                            println("body = $body")
-                        }
+            // Do NOT wrap in `client.use { }`: `client` is the shared, long-lived instance reused
+            // for every GET/POST/SSE. `.use` closes it after the first POST, breaking all later
+            // requests and the SSE stream. Matches the GET path, which also reuses `client`.
+            try {
+                val response = client.post(url) {
+                    headers {
+                        append("Content-Type", "application/json")
+                        append("Accept", "application/json")
                     }
-                    if (response.status.value in 200..299) {
-                        onSuccess(response.body())
-                    } else {
-                        onError(
-                            Exception(
-                                "Response not successful status code is : ${response.status.value} " +
-                                    "and description : ${response.status.description}"
-                            )
-                        )
-                    }
-                } catch (e: Exception) {
+                    contentType(ContentType.Application.Json)
+                    setBody(bodyParams.toJsonElement())
                     if (enableLogging) {
-                        println("exception $e")
+                        println("body = $body")
                     }
-                    onError(e)
                 }
+                if (response.status.value in 200..299) {
+                    onSuccess(response.body())
+                } else {
+                    onError(
+                        Exception(
+                            "Response not successful status code is : ${response.status.value} " +
+                                "and description : ${response.status.description}"
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                if (enableLogging) {
+                    println("exception $e")
+                }
+                onError(e)
             }
         }
     }
@@ -368,6 +368,10 @@ internal fun Map<*, *>.toJsonElement(): JsonElement {
         val key = it.key as? String ?: return@forEach
         val value = it.value ?: return@forEach
         map[key] = when (value) {
+            // Pass already-serialized JsonElement through untouched. Must precede the Map/List
+            // branches: JsonObject is a Map and JsonArray is a List, so those branches would
+            // otherwise re-encode their JsonPrimitive contents via toString() and double-quote them.
+            is JsonElement -> value
             is Map<*, *> -> (value).toJsonElement()
             is List<*> -> value.toJsonElement()
             is Boolean -> JsonPrimitive(value)
@@ -383,6 +387,7 @@ internal fun List<*>.toJsonElement(): JsonElement {
     this.forEach {
         val value = it ?: return@forEach
         when (value) {
+            is JsonElement -> list.add(value)
             is Map<*, *> -> list.add((value).toJsonElement())
             is List<*> -> list.add(value.toJsonElement())
             is Boolean -> list.add(JsonPrimitive(value))

--- a/NetworkDispatcherOkHttp/build.gradle.kts
+++ b/NetworkDispatcherOkHttp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.8"
+version = "1.0.9"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
+++ b/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
@@ -336,6 +336,10 @@ internal fun Map<*, *>.toJsonElement(): JsonElement {
         val key = it.key as? String ?: return@forEach
         val value = it.value ?: return@forEach
         map[key] = when (value) {
+            // Pass already-serialized JsonElement through untouched. Must precede the Map/List
+            // branches: JsonObject is a Map and JsonArray is a List, so those branches would
+            // otherwise re-encode their JsonPrimitive contents via toString() and double-quote them.
+            is JsonElement -> value
             is Map<*, *> -> (value).toJsonElement()
             is List<*> -> value.toJsonElement()
             is Boolean -> JsonPrimitive(value)
@@ -351,6 +355,7 @@ internal fun List<*>.toJsonElement(): JsonElement {
     this.forEach {
         val value = it ?: return@forEach
         when (value) {
+            is JsonElement -> list.add(value)
             is Map<*, *> -> list.add((value).toJsonElement())
             is List<*> -> list.add(value.toJsonElement())
             is Boolean -> list.add(JsonPrimitive(value))

--- a/README.md
+++ b/README.md
@@ -230,6 +230,23 @@ and returns a feature value typed with specified type.
   fun setAttributes(attributes: Map<String, GBValue>) {}
   ```
 
+- The updateAttributes method shallow-merges into the current attributes instead of replacing them
+  (parity with the TypeScript SDK's `updateAttributes`): new keys are added, existing keys are
+  overwritten, and untouched keys are preserved. The merge is one level deep — nested `GBJson`/
+  `GBArray` values are replaced wholesale. A key mapped to `GBNull` keeps the key with a null value
+  (it is **not** removed); to remove a key, rebuild the map with `setAttributes`.
+
+  ```kotlin
+  fun updateAttributes(attributes: Map<String, GBValue>) {}
+  ```
+
+  Example:
+  ```kotlin
+  sdk.setAttributes(mapOf("id" to GBString("1")))
+  sdk.updateAttributes(mapOf("plan" to GBString("pro")))
+  // evaluation now sees both "id" and "plan"
+  ```
+
 - The setAttributeOverrides method replaces the Map of attribute overrides used for Sticky Bucketing.
 
   ```kotlin
@@ -241,6 +258,7 @@ and returns a feature value typed with specified type.
 
   ```kotlin
   suspend fun setAttributesSync(attributes: Map<String, GBValue>) {}
+  suspend fun updateAttributesSync(attributes: Map<String, GBValue>) {}
   suspend fun setAttributeOverridesSync(overrides: Map<String, GBValue>) {}
   ```
 
@@ -306,7 +324,8 @@ You must enable Remote Evaluation in your SDK Connection settings. Cloud custome
 GrowthBook Proxy Server or custom remote evaluation backend.
 
 To use Remote Evaluation, set the `remoteEval = true` property to your SDK instance. A new evaluation API call will be
-made any time a user attribute or other dependency changes.
+made any time a user attribute or other dependency changes — specifically on `setAttributes` / `setAttributesSync` /
+`updateAttributes` / `updateAttributesSync`, `setAttributeOverrides`, `setForcedFeatures`, and `setForcedVariations`.
 
 > If you would like to implement Sticky Bucketing while using Remote Evaluation, you must configure your remote evaluation
 > backend to support Sticky Bucketing. You will not need to provide a StickyBucketService instance to the client side SDK.


### PR DESCRIPTION
## Summary

Adds an _updateAttributes_ merge API and hardens remote-evaluation correctness and thread-safety. Also resolves the outstanding remote-eval retry.

Public API is additive only - new fluent methods, no changed/removed signatures, binary-compatible.

## What changed
  
### New API (**Added**)
- `GrowthBookSDK.updateAttributes()` / `updateAttributesSync()` - shallow-merge user attributes into the current map (new keys added, existing overwritten, untouched preserved). A `GBNull` value keeps the key with a null value. Use `setAttributes()` to fully replace.

### Remote-eval correctness (**Fixed**)
- `setAttributes()`, `setAttributesSync()` and `setForcedFeatures()` now trigger a fresh remote evaluation (previously they didn't, so remote-eval consumers kept stale results);
- `suspendFeature()`'s internal retry now goes through the remote-eval _POST_ instead of a bare _GET_, so a retry can no longer momentarily surface non-personalized (unevaluated) features;
- Out-of-order remote-eval responses are discarded via a `generation` guard: after rapid attribute/forced-feature changes, a slower earlier request completing after a newer one can no longer overwrite the current evaluation.
- A custom `NetworkDispatcher` that throws synchronously while starting a request is now reported through the refresh handler as a failure, instead of being swallowed or propagating out of `initialize()`/ `setAttributes()`.

### Thread-safety / correctness (**Fixed**)
- `updateAttributes` merges atomically inside `GBContext` (CAS loop), so concurrent updates can't lose each other's keys.
- `forcedFeatures` and `attributeOverrides` are now published in the _atomic_ `EvalSnapshot`; `feature()`/`run()` read a single consistent snapshot of all evaluation inputs.

### Internal cleanup
- Unified the network layer on one `performNetworkRound` core; `fetchFromNetwork` (always-fresh, fire-and-forget) and `runNetworkRound` (coalesced, timeout-bounded) are thin wrappers.
- Single source of truth for remote-eval mode (dropped a redundant per-call flag threaded through four methods).

## Behavior changes
- Attribute / forced-feature / forced-variation / override changes now always trigger a fresh remote evaluation in remote-eval mode.
- A synchronous dispatcher enqueue failure is now surfaced as a fetch failure rather than thrown to the caller (relevant to custom `NetworkDispatcher` implementations).