### PR TITLE
feat!: add contextual bandit support & narrow SDK-owned model constructors

### DIFF
--- a/CHANGELOG-GrowthBookExt.md
+++ b/CHANGELOG-GrowthBookExt.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.0] - 2026-08-26
+
+No changes to `GrowthBookExt` itself. The major bump propagates the breaking changes in
+`GrowthBook` 8.0.0, which this artifact exposes as an `api` dependency — upgrading here pulls the
+new core in transitively. See the [core changelog](CHANGELOG.md#800---2026-08-26).
+
+---
+
 ## [1.0.0] - 2026-08-25
 
 Initial release of `GrowthBookExt` — a pure-Kotlin companion module with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,74 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [8.0.0] - Unreleased
+
+### Added
+- **Contextual bandits.** The SDK now understands contextual bandit rules and their definitions in the features payload
+  (`contextualBandits` / `encryptedContextualBandits`), matching the reference TS SDK against shared spec version 0.8.0.
+  A bandit rule carries its variations under `contextualVariations`; at evaluation the SDK routes the user into the
+  first context (leaf) whose condition matches and buckets by that leaf's weights. All weight maths stays server-side.
+    - New exposure metadata on `GBExperimentResult`: `leafId`, `variationWeights`, `banditVersion`, populated only for
+      users actually enrolled in the experiment. `leafId == -1` means no leaf matched and the rule's aggregate weights
+      were used.
+    - Fallbacks mirror the reference SDK: a dangling `contextualBanditRef` keeps the rule's aggregate weights and emits
+      no metadata; empty or non-matching contexts fall back to aggregate (or equal) weights with the `-1` sentinel.
+    - Sticky bucketing recognises bandit rules — identifier attributes are now derived from `contextualVariations` as
+      well as `variations`. Previously sticky bucketing silently did nothing on a bandit-driven feature.
+- `GBSDKBuilder.setInitialPayload(json)` seeds the SDK with a bundled **raw API payload** rather than just features:
+  saved groups and contextual bandit definitions are seeded too, including their encrypted variants. Bandit rules are
+  inert without their definitions, so offline-first setups covering a bandit-driven feature need this over
+  `setInitialFeatures`. A payload that cannot be parsed is ignored instead of failing initialization.
+
+### Changed
+- `GBUtils.isIncludedInRollout` aligned with the reference SDK: `coverage == 0` now excludes everyone, and an empty or
+  missing hash attribute value excludes the user, instead of both being treated as "included".
+- A payload that cannot be decrypted no longer throws. `getFeaturesFromEncryptedFeatures`,
+  `getSavedGroupFromEncryptedSavedGroup` and `getBanditsFromEncryptedBandits` now return `null` for a malformed blob or
+  a rotated key (previously only a JSON-parse failure was handled, while the split/base64/AES steps threw), so one bad
+  field no longer discards the rest of the payload — matching the reference SDK's per-field handling. Consequence for
+  `GrowthBookSDK.setEncryptedFeatures`: a payload it cannot decrypt is now ignored instead of throwing at the call site.
+
+### Fixed
+- Features, saved groups and contextual bandit definitions from a fetched payload are published to the context in a
+  single atomic update. Previously each was a separate write, so an evaluation on another thread could observe new
+  features paired with the previous generation's bandit definitions (routing by stale weights, or falling back to
+  aggregate weights for a rule whose bandit had just arrived).
+
+### Breaking changes
+This release narrows which types application code may **construct**. Reading, passing around and pattern-matching them
+is unaffected — only creating instances is now the SDK's job.
+
+- Constructors of SDK-owned types are `internal`, and their `copy()` with them (`@ConsistentCopyVisibility`):
+  `GBContext`, `GBOptions`, `StackContext`, `GBFeaturesDiff`, `GBFeatureChange`, `FeaturesDataModel`,
+  `GBContextualBandit`, `GBBanditContext`, and every `SerializableGB*` wire type. Build a context through
+  `GBSDKBuilder`; the other types only ever arrive from the SDK. This is what lets future payload fields be added to
+  them without another major release. Note that Kotlin enforces `internal` at compile time; for Java callers it is a
+  declaration of intent rather than a hard lock, and such use is unsupported.
+- Types application code legitimately constructs — `GBFeature`, `GBFeatureRule`, `GBExperiment`, `GBExperimentResult`,
+  `GBFeatureResult` — keep public constructors, but gained fields for contextual bandits. Adding a constructor
+  parameter changes the JVM signature, so code compiled against 7.x must be recompiled against 8.0.0.
+- `GBContext.plugins` moved from a mutable property into the constructor as a `val`. Set plugins with
+  `GBSDKBuilder.setPlugins()`, as before; assigning after construction was already a silent no-op and is now impossible.
+- Because `GBContext` can no longer be constructed by application code, the public `GrowthBookSDK(gbContext, ...)`
+  constructor is unreachable in practice. Use `GBSDKBuilder`.
+- The internal fetch-result callbacks `featuresFetchedSuccessfully` / `savedGroupsFetchedSuccessfully` on
+  `GrowthBookSDK` are replaced by a single `payloadFetchedSuccessfully(features, savedGroups, contextualBandits,
+  isRemote)`, which is what makes the payload land atomically (see *Fixed*). They were never part of the documented
+  API — `FeaturesFlowDelegate` is internal — but they were reachable from the JVM, hence the note.
+
+### Known limitations
+- GrowthBook's querystring variation override is not implemented in this SDK, so the corresponding shared spec case
+  (`querystring force overrides CB routing`) is skipped rather than ported. Use `setForcedVariations` instead.
+
+### Companion artifacts
+- `GrowthBookTest` **2.0.0** — no source changes, but it builds `GBExperimentResult` internally, so the 1.0.0 artifact
+  is not binary-compatible with this release and must be upgraded alongside it.
+- `GrowthBookExt` **2.0.0** — no source changes; the major bump propagates this release through its `api` dependency.
+- `Core`, `GrowthBookKotlinxSerialization`, `NetworkDispatcherKtor` and `NetworkDispatcherOkHttp` are unaffected and
+  keep their current versions.
+
+---
 ## [7.9.0] - 2026-09-03
 
 ### Added

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.9.0"
+version = "8.0.0"
 
 val generateSdkMeta by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated/sdk-meta/commonMain/kotlin")

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -3,11 +3,17 @@ package com.sdk.growthbook
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import com.sdk.growthbook.logger.GB
+import com.sdk.growthbook.model.EvalSnapshot
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.GBOptions
 import com.sdk.growthbook.plugin.tracking.GrowthBookPlugin
+import com.sdk.growthbook.features.FeaturePayloadDecoder
+import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.network.NetworkDispatcher
+import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
+import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.sandbox.CachingLayer
 import com.sdk.growthbook.sandbox.GBCachingLayer
@@ -17,6 +23,7 @@ import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
 import com.sdk.growthbook.utils.GBCacheRefreshHandler
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBFeaturesChangeHandler
+import kotlinx.serialization.json.Json
 
 /**
  * SDKBuilder - Root Class for SDK Initializers for GrowthBook SDK
@@ -117,6 +124,7 @@ class GBSDKBuilder(
     private var featureUsageCallback: GBFeatureUsageCallback? = null
     private var plugins: List<GrowthBookPlugin>? = null
     private var initialFeatures: GBFeatures? = null
+    private var initialPayloadJson: String? = null
     private var cacheMaxAge: Long? = null
     private var refreshInterval: Long? = null
     private var staleTtl: Long? = null
@@ -127,6 +135,10 @@ class GBSDKBuilder(
     // StandardTestDispatcher) to drive the async pipeline synchronously.
     private var coroutineContext: CoroutineContext = PlatformDependentIODispatcher
     private var customCachingLayer: GBCachingLayer? = null
+
+    // Matches the parser the network path uses, so a bundled snapshot is accepted on exactly the
+    // same terms as a live response (unknown//future payload fields ignored rather than fatal).
+    private val seedJsonParser = Json { isLenient = true; ignoreUnknownKeys = true }
 
     /**
      * Override the dispatcher used to process fetched payloads. Intended for tests that need
@@ -162,6 +174,28 @@ class GBSDKBuilder(
      */
     fun setInitialFeatures(features: GBFeatures): GBSDKBuilder {
         this.initialFeatures = features
+        return this
+    }
+
+    /**
+     * Seed the SDK with a bundled fallback payload in its raw API form — the exact JSON body the
+     * features endpoint returns, e.g. snapshotted into your assets at build time.
+     *
+     * Use this instead of [setInitialFeatures] when the payload carries more than features:
+     * `savedGroups` and `contextualBandits` are seeded too, and the encrypted variants
+     * (`encryptedFeatures` / `encryptedSavedGroups` / `encryptedContextualBandits`) are decrypted
+     * with the builder's encryption key. Contextual bandit rules in particular are inert without
+     * their definitions, so a bundled payload for a bandit-driven feature must go through here.
+     *
+     * Like [setInitialFeatures], this is only a seed: the normal cache/network refresh still runs on
+     * top and overwrites it as fresher data arrives (network > disk cache > seed > code defaults).
+     * A payload that cannot be parsed is ignored (logged when logging is enabled) rather than
+     * failing initialization — the seed is a fallback, not a hard dependency.
+     *
+     * If both this and [setInitialFeatures] are set, the explicit features win over the payload's.
+     */
+    fun setInitialPayload(json: String): GBSDKBuilder {
+        this.initialPayloadJson = json
         return this
     }
 
@@ -378,7 +412,7 @@ class GBSDKBuilder(
             )
         }
 
-        initialFeatures?.let { gbContext.features = it }
+        seedInitialState(gbContext)
 
         val gbOptions = GBOptions(apiHost, streamingHost)
 
@@ -414,11 +448,8 @@ class GBSDKBuilder(
             // honoured regardless of whether it was set before or after the sticky-bucket setter.
             stickyBucketService = stickyBucketService
                 ?: stickyBucketServiceFactory?.invoke(resolveCachingLayer()),
-        ).also {
-            // Assigned rather than passed: keeping it out of GBContext's primary constructor
-            // preserves that constructor's signature for already-compiled consumers.
-            it.plugins = plugins
-        }
+            plugins = plugins,
+        )
 
     private inner class WaitForCallCaseHelper(
         gbContext: GBContext,
@@ -445,7 +476,7 @@ class GBSDKBuilder(
                 handleWaitForCallCallback = null
                 growthBookSDK = null
             }
-            initialFeatures?.let { gbContext.features = it }
+            seedInitialState(gbContext)
 
             val gbOptions = GBOptions(apiHost, streamingHost)
             growthBookSDK = GrowthBookSDK(
@@ -463,6 +494,35 @@ class GBSDKBuilder(
                 cachingLayer = customCachingLayer
             )
         }
+    }
+
+    /**
+     * Applies the bundled seed to [gbContext] before the SDK starts its own fetch: first the raw
+     * payload from [setInitialPayload] (decrypted if needed), then the explicit features from
+     * [setInitialFeatures], which therefore take precedence. A seed that fails to parse is skipped —
+     * the SDK then simply starts empty and waits for cache/network, as it would without a seed.
+     */
+    private fun seedInitialState(gbContext: GBContext) {
+        initialPayloadJson?.let { json ->
+            val decoded = runCatching {
+                val model = seedJsonParser
+                    .decodeFromString(SerializableFeaturesDataModel.serializer(), json)
+                    .gbDeserialize()
+                FeaturePayloadDecoder(encryptionKey).decode(model)
+            }.getOrElse { error ->
+                if (enableLogging) {
+                    GB.error("GBSDKBuilder: setInitialPayload could not be parsed, ignoring seed", error)
+                }
+                null
+            }
+
+            decoded?.features?.let { gbContext.features = it }
+            decoded?.savedGroups?.let { groups ->
+                gbContext.savedGroups = groups.mapValues { (_, value) -> GBValue.from(value) }
+            }
+            decoded?.contextualBandits?.let { gbContext.contextualBandits = it }
+        }
+        initialFeatures?.let { gbContext.features = it }
     }
 
     private fun resolveCachingLayer(): CachingLayer =

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -36,6 +36,7 @@ import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.plugin.tracking.PluginRegistry
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.utils.GBFeaturesChangeHandler
 import com.sdk.growthbook.sandbox.CachingImpl
@@ -269,28 +270,6 @@ class GrowthBookSDK internal constructor(
     }
 
     /**
-     * Delegate that set to Context successfully fetched features
-     */
-    override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
-        // Compute the diff only for authoritative results (network / SSE / fresh cache), against the
-        // features currently applied. The non-authoritative cache pre-load that precedes a network
-        // refresh must not notify, otherwise the handler double-fires on a warm start (cache, then
-        // network); the subsequent authoritative result reports the real delta.
-        val diff = if (isRemote) {
-            featuresChangeHandler?.let { diffFeatures(gbContext.features, features) }
-        } else null
-
-        gbContext.features = features
-        hasFeaturesPayload = true
-        if (isRemote) {
-            remoteSourceFeaturesFetchResult = FeaturesFetchResult.Success
-            invokeRefreshHandler(true, null)
-        }
-
-        diff?.takeIf { it.hasChanges }?.let { featuresChangeHandler?.invoke(it) }
-    }
-
-    /**
      * Delegate that fire refreshHandler with success = true when a 304 response occurs.
      * Only treated as success when the SDK instance has a loaded feature payload.
      * Without prior state a 304 cannot guarantee features are available
@@ -356,9 +335,44 @@ class GrowthBookSDK internal constructor(
         }
     }
 
-    override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) {
-        gbContext.savedGroups = savedGroups.mapValues { GBValue.from(it.value) }
-        if (isRemote) {
+    /**
+     * Applies a successfully fetched payload: every field it carries lands in the context in a
+     * single atomic update, then the refresh/features-change handlers fire.
+     *
+     * One update rather than one per field because payload application runs on a background
+     * dispatcher: a feature() call from the app thread could otherwise land mid-way and evaluate new
+     * features against the previous generation's bandit definitions or saved groups.
+     */
+    override fun payloadFetchedSuccessfully(
+        features: GBFeatures?,
+        savedGroups: JsonObject?,
+        contextualBandits: Map<String, GBContextualBandit>?,
+        isRemote: Boolean,
+    ) {
+        // Compute the diff only for authoritative results (network / SSE / fresh cache), against the
+        // features currently applied. The non-authoritative cache pre-load that precedes a network
+        // refresh must not notify, otherwise the handler double-fires on a warm start (cache, then
+        // network); the subsequent authoritative result reports the real delta.
+        val diff = if (isRemote && features != null) {
+            featuresChangeHandler?.let { diffFeatures(gbContext.features, features) }
+        } else null
+
+        gbContext.applyPayload(
+            features = features,
+            savedGroups = savedGroups?.mapValues { GBValue.from(it.value) },
+            contextualBandits = contextualBandits
+        )
+
+        if (features != null) {
+            hasFeaturesPayload = true
+            if (isRemote) {
+                remoteSourceFeaturesFetchResult = FeaturesFetchResult.Success
+                invokeRefreshHandler(true, null)
+            }
+            diff?.takeIf { it.hasChanges }?.let { featuresChangeHandler?.invoke(it) }
+        }
+
+        if (savedGroups != null && isRemote) {
             invokeRefreshHandler(true, null)
         }
     }
@@ -642,7 +656,7 @@ class GrowthBookSDK internal constructor(
 
     /**
      * Called after the full API payload is received, before features are applied to context.
-     * Awaits sticky bucket refresh so that context is consistent when featuresFetchedSuccessfully fires.
+     * Awaits sticky bucket refresh so that context is consistent when payloadFetchedSuccessfully fires.
      */
     override suspend fun onPayloadReady(model: FeaturesDataModel) {
         try {
@@ -795,7 +809,8 @@ class GrowthBookSDK internal constructor(
                     gbContext.mergeStickyAssignmentDoc(key, doc)
                 },
                 stackContext = StackContext(null, mutableSetOf()),
-                pluginRegistry = pluginRegistry
+                pluginRegistry = pluginRegistry,
+                contextualBandits = snapshot.contextualBandits
             )
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/EvaluationContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/EvaluationContext.kt
@@ -5,6 +5,7 @@ import com.sdk.growthbook.model.GBFeatureResult
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.GBTrackingCallback
 import com.sdk.growthbook.plugin.tracking.PluginRegistry
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.model.StickyBucketAssignmentDocsType
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
@@ -28,7 +29,8 @@ internal data class EvaluationContext(
     // docs map after evaluation, which could clobber a concurrent background refresh.
     val onStickyAssignmentChanged: ((GBStickyAttributeKey, GBStickyAssignmentsDocument) -> Unit)? = null,
     val stackContext: StackContext,
-    val pluginRegistry: PluginRegistry?
+    val pluginRegistry: PluginRegistry?,
+    val contextualBandits: Map<String, GBContextualBandit>? = null
 )
 
 internal data class UserContext(

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBExperimentEvaluator.kt
@@ -473,6 +473,10 @@ internal class GBExperimentEvaluator(
             if (experimentMeta.size > targetVariationIndex)
                 experimentMeta[targetVariationIndex] else null
 
+        // Bandit metadata is gated to enrolled users here. Kotlin has no unconditional experiment-eval
+        // hook (cf. TS onExperimentEval), so we don't need to strip exp.contextualBandit. If such a hook
+        // is ever added, revisit: exp would leak bandit metadata for non-enrolled users.
+        val cb = experiment.contextualBandit?.takeIf { hashUsed && inExperiment }
         return GBExperimentResult(
             inExperiment = inExperiment,
             variationId = targetVariationIndex,
@@ -487,7 +491,10 @@ internal class GBExperimentEvaluator(
             stickyBucketUsed = stickyBucketUsed ?: false,
             name = meta?.name,
             bucket = bucket,
-            passthrough = meta?.passthrough
+            passthrough = meta?.passthrough,
+            leafId = cb?.leafId,
+            variationWeights = cb?.variationWeights,
+            banditVersion = cb?.banditVersion
         )
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/evaluators/GBFeatureEvaluator.kt
@@ -2,7 +2,11 @@ package com.sdk.growthbook.evaluators
 
 import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.logger.GB
+import com.sdk.growthbook.model.CBContext
+import com.sdk.growthbook.model.CONTEXTUAL_BANDIT_FALLBACK_LEAF_ID
+import com.sdk.growthbook.model.GBBanditContext
 import com.sdk.growthbook.model.GBBoolean
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.model.GBFeature
@@ -13,7 +17,6 @@ import com.sdk.growthbook.model.GBNull
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBString
 import com.sdk.growthbook.model.GBValue
-import com.sdk.growthbook.utils.Constants
 import com.sdk.growthbook.utils.GBTrackData
 import com.sdk.growthbook.utils.GBUtils
 import com.sdk.growthbook.utils.GBUtils.Companion.getAttributes
@@ -243,31 +246,6 @@ internal class GBFeatureEvaluator(
                             }
                         }
 
-                        if (rule.range == null) {
-                            if (rule.coverage != null) {
-                                val key = rule.hashAttribute ?: Constants.ID_ATTRIBUTE_KEY
-                                val attributeValue =
-                                    getAttributes(
-                                        attributeOverrides = attributeOverrides,
-                                        attributes = evaluationContext.userContext.attributes
-                                    )[key]
-                                        .toHashValue()
-
-                                if (attributeValue.isNullOrEmpty()) {
-                                    continue@ruleLoop
-                                }
-                                val hashFNV = GBUtils.hash(
-                                    seed = rule.seed,
-                                    stringValue = attributeValue,
-                                    hashVersion = rule.hashVersion,
-                                ) ?: 0f
-                                if (hashFNV > rule.coverage) {
-                                    continue@ruleLoop
-                                }
-                            }
-                        }
-
-
                         return prepareResult(
                             ruleId = rule.id,
                             featureKey = featureKey,
@@ -276,7 +254,7 @@ internal class GBFeatureEvaluator(
                         )
                     } else {
 
-                        val variation = rule.variations
+                        val variation = rule.contextualVariations ?: rule.variations
                         if (variation != null) {
 
                             /**
@@ -302,6 +280,13 @@ internal class GBFeatureEvaluator(
                                 filters = rule.filters,
                                 condition = rule.condition,
                             )
+
+                            /**
+                             * Contextual bandit rule: route the user to a leaf and apply its weights.
+                             */
+                            if (rule.contextualBanditRef != null) {
+                                buildContextualBanditExperiment(exp, rule.contextualBanditRef, attributeOverrides)
+                            }
 
                             /**
                              * Only return a value if the user is part of the experiment
@@ -405,5 +390,81 @@ internal class GBFeatureEvaluator(
         }
 
         return gbFeatureResult
+    }
+
+    /**
+     * Contextual bandit: pick the first leaf whose condition matches the user and apply its weights
+     * to [experiment], recording which leaf/weights/version were used so the result can carry them.
+     * Fallbacks mirror the TS SDK: ref missing -> keep the rule's aggregate weights, no metadata;
+     * no leaf matches -> aggregate (or equal) weights with a sentinel leafId.
+     */
+    private fun buildContextualBanditExperiment(
+        experiment: GBExperiment,
+        contextualBanditRef: String,
+        attributeOverrides: Map<String, GBValue>
+    ) {
+        val cbDefinition: GBContextualBandit = evaluationContext.contextualBandits?.get(contextualBanditRef)
+            ?: run {
+                if (evaluationContext.loggingEnabled) {
+                    GB.log(
+                        "GBFeatureEvaluator: contextual bandit ref '$contextualBanditRef' not found in payload, " +
+                            "using aggregate weights"
+                    )
+                }
+                return
+            }
+
+        // Throwable, not Exception: on the JS/wasm targets a failure inside the condition evaluator
+        // can surface as a plain Throwable, which would otherwise escape and kill the evaluation.
+        val leaf = try {
+            getContextualBanditLeaf(cbDefinition, attributeOverrides)
+        } catch (e: Throwable) {
+            if (evaluationContext.loggingEnabled) {
+                GB.warning("GBFeatureEvaluator: contextual bandit leaf selection threw, using fallback weights")
+            }
+            null
+        }
+
+        if (leaf != null) {
+            // Only override when the leaf actually carries weights — a malformed leaf must not wipe
+            // the rule's aggregate weights (in TS the field is required, so the case cannot arise).
+            leaf.weights?.let { experiment.weights = it }
+            experiment.contextualBandit = CBContext(
+                leafId = leaf.leafId,
+                variationWeights = experiment.weights ?: GBUtils.getEqualWeights(experiment.variations.size),
+                banditVersion = cbDefinition.banditVersion
+            )
+        } else {
+            if (evaluationContext.loggingEnabled) {
+                GB.log(
+                    "GBFeatureEvaluator: contextual bandit '$contextualBanditRef' matched no leaf, " +
+                        "using fallback weights"
+                )
+            }
+            experiment.contextualBandit = CBContext(
+                leafId = CONTEXTUAL_BANDIT_FALLBACK_LEAF_ID,
+                variationWeights = experiment.weights ?: GBUtils.getEqualWeights(experiment.variations.size),
+                banditVersion = cbDefinition.banditVersion
+            )
+        }
+    }
+
+    private fun getContextualBanditLeaf(
+        cbDefinition: GBContextualBandit,
+        attributeOverrides: Map<String, GBValue>
+    ): GBBanditContext? {
+        return cbDefinition.contexts?.firstOrNull { ctx ->
+            val conditionObj = ctx.condition?.let {
+                GBValue.from(it)
+            } as? GBJson ?: GBJson(emptyMap())
+            GBConditionEvaluator().evalCondition(
+                attributes = getAttributes(
+                    attributes = evaluationContext.userContext.attributes,
+                    attributeOverrides = attributeOverrides
+                ),
+                conditionObj = conditionObj,
+                savedGroups = evaluationContext.savedGroups
+            )
+        }
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturePayloadDecoder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturePayloadDecoder.kt
@@ -1,9 +1,11 @@
 package com.sdk.growthbook.features
 
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.utils.Crypto
 import com.sdk.growthbook.utils.DefaultCrypto
 import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.getBanditsFromEncryptedBandits
 import com.sdk.growthbook.utils.getFeaturesFromEncryptedFeatures
 import com.sdk.growthbook.utils.getSavedGroupFromEncryptedSavedGroup
 import kotlinx.serialization.json.JsonObject
@@ -12,7 +14,8 @@ import kotlinx.serialization.json.JsonObject
 internal class FeaturePayloadDecoder(private val encryptionKey: String?) {
     fun decode(m: FeaturesDataModel) = DecodedPayload(
         features = decode(m.features, m.encryptedFeatures, ::getFeaturesFromEncryptedFeatures),
-        savedGroups = decode(m.savedGroups, m.encryptedSavedGroups, ::getSavedGroupFromEncryptedSavedGroup)
+        savedGroups = decode(m.savedGroups, m.encryptedSavedGroups, ::getSavedGroupFromEncryptedSavedGroup),
+        contextualBandits = decode(m.contextualBandits, m.encryptedContextualBandits, ::getBanditsFromEncryptedBandits)
     )
 
     private fun <T: Map<*, *>> decode(plain: T?, encrypted: String?, decrypt: (String, String, Crypto?) -> T?) : T? {
@@ -29,4 +32,8 @@ internal class FeaturePayloadDecoder(private val encryptionKey: String?) {
     }
 }
 
-internal data class DecodedPayload(val features: GBFeatures?, val savedGroups: JsonObject?)
+internal data class DecodedPayload(
+    val features: GBFeatures?,
+    val savedGroups: JsonObject?,
+    val contextualBandits: Map<String, GBContextualBandit>? = null
+)

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataModel.kt
@@ -1,18 +1,27 @@
 package com.sdk.growthbook.features
 
+import com.sdk.growthbook.model.GBContextualBandit
 import kotlinx.serialization.json.JsonObject
 import com.sdk.growthbook.model.gbSerialize
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
+import com.sdk.growthbook.serializable_model.gbDeserialize
 
 /**
- * Data Object for Feature API Response
+ * Data Object for Feature API Response.
+ *
+ * SDK-owned: instances come from the payload pipeline, never from consumer code, so the constructor
+ * (and `copy()` with it) is internal — new payload fields can then be added without breaking
+ * already-compiled consumers. Public only because it appears in an overridden delegate member.
  */
-data class FeaturesDataModel(
+@ConsistentCopyVisibility
+data class FeaturesDataModel internal constructor(
     val features: GBFeatures? = null,
     val encryptedFeatures: String? = null,
     val savedGroups: JsonObject? = null,
-    val encryptedSavedGroups: String? = null
+    val encryptedSavedGroups: String? = null,
+    val contextualBandits: Map<String, GBContextualBandit>? = null,
+    val encryptedContextualBandits: String? = null
 )
 
 internal fun FeaturesDataModel.gbSerialize() =
@@ -21,4 +30,6 @@ internal fun FeaturesDataModel.gbSerialize() =
         encryptedFeatures = encryptedFeatures,
         savedGroups = savedGroups,
         encryptedSavedGroups = encryptedSavedGroups,
+        contextualBandits = contextualBandits?.mapValues { it.value.gbSerialize() },
+        encryptedContextualBandits = encryptedContextualBandits
     )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesViewModel.kt
@@ -3,6 +3,7 @@
 package com.sdk.growthbook.features
 
 import com.sdk.growthbook.logger.GB
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.sandbox.CachingLayer
 import com.sdk.growthbook.sandbox.getData
@@ -49,11 +50,24 @@ private const val NETWORK_ROUND_TIMEOUT_MILLIS = 30_000L
  * Interface for Feature API Completion Events
  */
 internal interface FeaturesFlowDelegate {
-    fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean)
+    /**
+     * A successfully decoded payload, delivered whole rather than field by field: the implementer is
+     * expected to publish everything it carries in a single atomic update (see
+     * [com.sdk.growthbook.model.GBContext.applyPayload]), so an evaluation running concurrently can
+     * never observe one field from this payload paired with another from the previous one.
+     *
+     * A null argument means the field was absent from the payload — keep the current value.
+     */
+    fun payloadFetchedSuccessfully(
+        features: GBFeatures?,
+        savedGroups: JsonObject?,
+        contextualBandits: Map<String, GBContextualBandit>?,
+        isRemote: Boolean,
+    )
+
     suspend fun onPayloadReady(model: FeaturesDataModel)
     fun featuresFetchFailed(error: GBError, isRemote: Boolean)
     fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean)
-    fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean)
     fun featuresNotModified()
 }
 
@@ -599,6 +613,8 @@ internal class FeaturesViewModel(
                     encryptedFeatures = null,
                     savedGroups = decoded.savedGroups,
                     encryptedSavedGroups = null,
+                    contextualBandits = decoded.contextualBandits,
+                    encryptedContextualBandits = null,
                 )
             )
 
@@ -640,18 +656,14 @@ internal class FeaturesViewModel(
 
     private fun dispatch(outcome: FetchOutcome) = when (outcome) {
         is FetchOutcome.Ready -> {
-            outcome.payload.features?.let {
-                delegate.featuresFetchedSuccessfully(
-                    features = it,
-                    isRemote = outcome.authoritative
-                )
-            }
-            outcome.payload.savedGroups?.let {
-                delegate.savedGroupsFetchedSuccessfully(
-                    savedGroups = it,
-                    isRemote = outcome.authoritative
-                )
-            }
+            // One call, not three: the delegate applies the whole payload atomically, so a concurrent
+            // reader never observes new features paired with stale bandits/saved groups.
+            delegate.payloadFetchedSuccessfully(
+                features = outcome.payload.features,
+                savedGroups = outcome.payload.savedGroups,
+                contextualBandits = outcome.payload.contextualBandits,
+                isRemote = outcome.authoritative
+            )
         }
 
         is FetchOutcome.Failed -> {

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -31,6 +31,7 @@ internal data class EvalSnapshot(
     val stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
     val stickyBucketIdentifierAttributes: List<String>? = null,
     val savedGroups: Map<String, GBValue>? = null,
+    val contextualBandits: Map<String, GBContextualBandit>? = null
 )
 
 /**
@@ -41,8 +42,13 @@ internal data class EvalSnapshot(
  * the current snapshot; writes atomically swap in a copy with the changed field (CAS loop, so
  * concurrent writers never lose each other's updates). For a consistent multi-field read during
  * evaluation, use [evalSnapshot] rather than reading the individual properties one by one.
+ *
+ * SDK-owned: assembled by [com.sdk.growthbook.GBSDKBuilder], never by consumer code — which is why
+ * the constructor is internal. The type itself stays public because [com.sdk.growthbook.GrowthBookSDK.getGBContext]
+ * returns it for reading. With no external caller bound to the constructor's JVM signature, new
+ * options can be added here directly instead of being smuggled in as body properties.
  */
-class GBContext(
+class GBContext internal constructor(
 
     /**
      * Registered API Key for GrowthBook SDK
@@ -113,23 +119,19 @@ class GBContext(
      * Saved Groups let you target the same group of users across multiple features and experiments.
      */
     savedGroups: Map<String, GBValue>? = null,
-) {
 
     /**
      * Plugins registered with the GrowthBook. See
      * [GrowthBookPlugin] and
      * [com.sdk.growthbook.plugin.tracking.GrowthBookTrackingPlugin].
      *
-     * Set this before constructing [com.sdk.growthbook.GrowthBookSDK] — normally via
-     * [com.sdk.growthbook.GBSDKBuilder.setPlugins]. The SDK reads it once while initialising its
-     * plugin registry, so assigning afterwards has no effect (the reference JS SDK consumes
-     * `options.plugins` in its constructor the same way).
-     *
-     * Declared here rather than as a constructor parameter: adding a parameter to the public
-     * primary constructor changes its JVM signature, so bytecode compiled against an earlier
-     * release would fail with `NoSuchMethodError`. A property is purely additive.
+     * Normally set via [com.sdk.growthbook.GBSDKBuilder.setPlugins]. The SDK reads it once while
+     * initialising its plugin registry (the reference JS SDK consumes `options.plugins` in its
+     * constructor the same way); as a `val` here that read-once contract is structural rather than
+     * merely documented.
      */
-    var plugins: List<GrowthBookPlugin>? = null
+    val plugins: List<GrowthBookPlugin>? = null,
+) {
 
     // Single source of truth for all cross-thread-shared evaluation inputs.
     private val state = AtomicReference(
@@ -138,7 +140,7 @@ class GBContext(
             forcedVariations = forcedVariations,
             stickyBucketAssignmentDocs = stickyBucketAssignmentDocs,
             stickyBucketIdentifierAttributes = stickyBucketIdentifierAttributes,
-            savedGroups = savedGroups,
+            savedGroups = savedGroups
         )
     )
 
@@ -189,7 +191,8 @@ class GBContext(
         doc: GBStickyAssignmentsDocument,
     ) = mutate {
         it.copy(
-            stickyBucketAssignmentDocs = (it.stickyBucketAssignmentDocs ?: emptyMap()) + (key to doc)
+            stickyBucketAssignmentDocs = (it.stickyBucketAssignmentDocs
+                ?: emptyMap()) + (key to doc)
         )
     }
 
@@ -219,6 +222,28 @@ class GBContext(
      */
     internal fun mergeAttributes(attributes: Map<String, GBValue>) = mutate {
         it.copy(attributes = it.attributes + attributes)
+    }
+
+    /**
+     * Atomically publish a freshly decoded payload: [features], [savedGroups] and [contextualBandits]
+     * land in a single swap. Done as one write (not three separate setters) because payload
+     * application runs on a background dispatcher while feature()/run() read from the app thread — a
+     * reader landing between the writes would otherwise see new features paired with the previous
+     * generation's bandit definitions or saved groups.
+     *
+     * A null argument means "absent from this payload, keep the current value", matching the
+     * per-field dispatch it replaces.
+     */
+    internal fun applyPayload(
+        features: GBFeatures?,
+        savedGroups: Map<String, GBValue>?,
+        contextualBandits: Map<String, GBContextualBandit>?,
+    ) = mutate {
+        it.copy(
+            features = features ?: it.features,
+            savedGroups = savedGroups ?: it.savedGroups,
+            contextualBandits = contextualBandits ?: it.contextualBandits,
+        )
     }
 
     /**
@@ -257,12 +282,23 @@ class GBContext(
     internal var features: GBFeatures
         get() = state.load().features
         set(value) = mutate { it.copy(features = value) }
+
+    /**
+     * Contextual bandit definitions keyed by bandit ref, pulled from the payload alongside
+     * [features]. Internal-only: consumers never need the raw definitions — only the leaf metadata
+     * (leafId / weights / version) surfaced on the experiment result. Written by the payload
+     * pipeline, read atomically via [evalSnapshot] during evaluation.
+     */
+    internal var contextualBandits: Map<String, GBContextualBandit>?
+        get() = state.load().contextualBandits
+        set(value) = mutate { it.copy(contextualBandits = value) }
 }
 
 /**
  * Model consist already evaluated features
  */
-data class StackContext(
+@ConsistentCopyVisibility
+data class StackContext internal constructor(
 
     /**
      * Unique feature identifier

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContextualBandit.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContextualBandit.kt
@@ -1,0 +1,78 @@
+package com.sdk.growthbook.model
+
+import com.sdk.growthbook.serializable_model.SerializableGBBanditContext
+import com.sdk.growthbook.serializable_model.SerializableGBContextualBandit
+import com.sdk.growthbook.utils.GBCondition
+
+/**
+ * A contextual bandit definition, as delivered in the feature payload and keyed by bandit ref.
+ *
+ * The per-variation weights inside each context are recomputed server-side (Thompson sampling); the
+ * SDK does not learn or update them. At evaluation time it simply routes a user to the first matching
+ * context (leaf) and buckets by that leaf's weights using the ordinary experiment machinery.
+ */
+@ConsistentCopyVisibility
+data class GBContextualBandit internal constructor(
+
+    /**
+     * Monotonic marker of which weight generation this definition represents. Surfaced on the
+     * experiment result so tracking can attribute an exposure to the weights that produced it.
+     */
+    val banditVersion: Int? = null,
+
+    /**
+     * Ordered list of contexts (leaves). The first one whose [GBBanditContext.condition] passes for
+     * the user's attributes wins; if none match, the rule's aggregate weights are used instead.
+     */
+    val contexts: List<GBBanditContext>? = null
+)
+
+/**
+ * A single bandit context (leaf): a targeting condition plus its own per-variation weights.
+ */
+@ConsistentCopyVisibility
+data class GBBanditContext internal constructor(
+
+    /**
+     * Server-assigned id of this leaf, surfaced on the experiment result so an exposure can be
+     * attributed to the exact leaf the user was routed into.
+     */
+    val leafId: Int,
+
+    /**
+     * Targeting condition evaluated against the user's attributes to decide whether the user is
+     * routed into this leaf (same MongoDB-style condition format as feature/experiment targeting).
+     */
+    val condition: GBCondition? = null,
+
+    /**
+     * How to weight traffic between variations for users in this leaf. Must add to 1.
+     */
+    val weights: List<Float>? = null
+)
+
+/**
+ * Per-user resolved bandit context: the leaf the user was routed into plus the weights used.
+ * Attached transiently to a [com.sdk.growthbook.model.GBExperiment] during evaluation and surfaced
+ * on the experiment result for tracking. Not part of the payload.
+ */
+internal data class CBContext(
+    val leafId: Int,
+    val variationWeights: List<Float>,
+    val banditVersion: Int? = null
+)
+
+internal const val CONTEXTUAL_BANDIT_FALLBACK_LEAF_ID = -1
+
+internal fun GBContextualBandit.gbSerialize(): SerializableGBContextualBandit =
+    SerializableGBContextualBandit(
+        banditVersion = banditVersion,
+        contexts = contexts?.map { it.gbSerialize() }
+    )
+
+internal fun GBBanditContext.gbSerialize(): SerializableGBBanditContext =
+    SerializableGBBanditContext(
+        leafId = leafId,
+        condition = condition,
+        weights = weights
+    )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBExperiment.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBExperiment.kt
@@ -149,6 +149,10 @@ data class GBExperiment(
             return parsed
         }
 
+
+    /** Set during evaluation when this experiment came from a contextual bandit rule. Transient. */
+    internal var contextualBandit: CBContext? = null
+
     internal fun gbSerialize() =
         SerializableGBExperiment(
             key = key,
@@ -239,7 +243,23 @@ data class GBExperimentResult(
     /**
      * If sticky bucketing was used to assign a variation
      */
-    val stickyBucketUsed: Boolean? = null
+    val stickyBucketUsed: Boolean? = null,
+
+    /**
+     * Contextual bandit: id of the leaf the user was routed into. null if not a bandit or the user
+     * was not enrolled; -1 means no leaf matched and aggregate weights were used.
+     */
+    val leafId: Int? = null,
+
+    /**
+     * Contextual bandit: the per-variation weights used to bucket this user.
+     */
+    val variationWeights: List<Float>? = null,
+
+    /**
+     * Contextual bandit: which weight generation produced [variationWeights]
+     */
+    val banditVersion: Int? = null
 ) {
     internal fun gbSerialize() =
         SerializableGBExperimentResult(
@@ -255,6 +275,9 @@ data class GBExperimentResult(
             inExperiment = inExperiment,
             hashAttribute = hashAttribute,
             stickyBucketUsed = stickyBucketUsed,
+            leafId = leafId,
+            variationWeights = variationWeights,
+            banditVersion = banditVersion
         )
 }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBFeature.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBFeature.kt
@@ -160,7 +160,10 @@ data class GBFeatureRule(
     /**
      * Array of tracking calls to fire
      */
-    val tracks: ArrayList<GBTrackData>? = null
+    val tracks: ArrayList<GBTrackData>? = null,
+
+    val contextualBanditRef: String? = null,
+    val contextualVariations: List<GBValue>? = null
 ) {
     internal val conditionGB: GBJson? =
         condition?.toGBConditionJson()
@@ -195,6 +198,8 @@ data class GBFeatureRule(
                     tracks.map { it.gbSerialize() }
                 )
             },
+            contextualBanditRef = contextualBanditRef,
+            contextualVariations = contextualVariations?.map { it.gbSerialize() }
         )
 }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBFeaturesDiff.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBFeaturesDiff.kt
@@ -2,9 +2,13 @@ package com.sdk.growthbook.model
 
 import com.sdk.growthbook.utils.GBFeatures
 
-data class GBFeatureChange(val old: GBFeature, val new: GBFeature)
+/** SDK-owned: produced by [diffFeatures] and handed to the features-change handler, read-only. */
+@ConsistentCopyVisibility
+data class GBFeatureChange internal constructor(val old: GBFeature, val new: GBFeature)
 
-data class GBFeaturesDiff(
+/** SDK-owned: produced by [diffFeatures] and handed to the features-change handler, read-only. */
+@ConsistentCopyVisibility
+data class GBFeaturesDiff internal constructor(
     val added: GBFeatures,
     val removed: GBFeatures,
     val changed: Map<String, GBFeatureChange>

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBOptions.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBOptions.kt
@@ -1,6 +1,12 @@
 package com.sdk.growthbook.model
 
-data class GBOptions(
+/**
+ * SDK-owned: built by [com.sdk.growthbook.GBSDKBuilder], never by consumers. The constructor is
+ * internal (and `copy()` with it) so new options can be added without breaking already-compiled
+ * consumers — see the API-stability note in CLAUDE.md.
+ */
+@ConsistentCopyVisibility
+data class GBOptions internal constructor(
     val apiHost: String,
     val streamingHost: String?,
 )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableFeaturesDataModel.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableFeaturesDataModel.kt
@@ -13,6 +13,8 @@ internal data class SerializableFeaturesDataModel(
     val encryptedFeatures: String? = null,
     val savedGroups: JsonObject? = null,
     val encryptedSavedGroups: String? = null,
+    val contextualBandits: Map<String, SerializableGBContextualBandit>? = null,
+    val encryptedContextualBandits: String? = null,
     val cachedAt: Long? = null
 )
 
@@ -22,4 +24,6 @@ internal fun SerializableFeaturesDataModel.gbDeserialize() =
         encryptedFeatures = encryptedFeatures,
         savedGroups = savedGroups,
         encryptedSavedGroups = encryptedSavedGroups,
+        contextualBandits = contextualBandits?.mapValues { it.value.gbDeserialize() },
+        encryptedContextualBandits = encryptedContextualBandits,
     )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBContextualBandit.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBContextualBandit.kt
@@ -1,0 +1,62 @@
+package com.sdk.growthbook.serializable_model
+
+import com.sdk.growthbook.model.GBBanditContext
+import com.sdk.growthbook.model.GBContextualBandit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Wire (JSON) shape of a contextual bandit definition, keyed by bandit ref in the payload.
+ * The per-variation [SerializableGBBanditContext.weights] are recomputed server-side; the SDK
+ * only routes a user to the first matching context (leaf) and buckets by that leaf's weights.
+ */
+@Serializable
+@ConsistentCopyVisibility
+data class SerializableGBContextualBandit internal constructor(
+
+    /**
+     * Monotonic marker of which weight generation this definition represents.
+     */
+    val banditVersion: Int? = null,
+
+    /**
+     * Ordered list of contexts (leaves); the first whose condition passes wins.
+     */
+    val contexts: List<SerializableGBBanditContext>? = null
+)
+
+/**
+ * A single bandit context (leaf): a targeting condition plus its own variation weights.
+ */
+@Serializable
+@ConsistentCopyVisibility
+data class SerializableGBBanditContext internal constructor(
+
+    /**
+     * Server-assigned id of this leaf (used for tracking which leaf a user landed in).
+     */
+    val leafId: Int,
+
+    /**
+     * Targeting condition evaluated against user attributes to route users into this leaf.
+     */
+    val condition: JsonElement? = null,
+
+    /**
+     * How to weight traffic between variations for users in this leaf. Must add to 1.
+     */
+    val weights: List<Float>? = null
+)
+
+internal fun SerializableGBContextualBandit.gbDeserialize(): GBContextualBandit =
+    GBContextualBandit(
+        banditVersion = banditVersion,
+        contexts = contexts?.map { it.gbDeserialize() }
+    )
+
+internal fun SerializableGBBanditContext.gbDeserialize(): GBBanditContext =
+    GBBanditContext(
+        leafId = leafId,
+        condition = condition,
+        weights = weights
+    )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBExperiment.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBExperiment.kt
@@ -17,7 +17,8 @@ import com.sdk.growthbook.kotlinx.serialization.from
     Defines a single experiment
  */
 @Serializable
-data class SerializableGBExperiment(
+@ConsistentCopyVisibility
+data class SerializableGBExperiment internal constructor(
 
     /**
      * The globally unique tracking key for the experiment

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBExperimentResult.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBExperimentResult.kt
@@ -11,7 +11,8 @@ import com.sdk.growthbook.kotlinx.serialization.from
  * The result of running an Experiment given a specific Context
  */
 @Serializable
-data class SerializableGBExperimentResult(
+@ConsistentCopyVisibility
+data class SerializableGBExperimentResult internal constructor(
 
     /**
      * Whether or not the user is part of the experiment
@@ -72,7 +73,23 @@ data class SerializableGBExperimentResult(
     /**
      * If sticky bucketing was used to assign a variation
      */
-    val stickyBucketUsed: Boolean? = null
+    val stickyBucketUsed: Boolean? = null,
+
+    /**
+     * Contextual bandit: id of the leaf the user was routed into. null if not a bandit or the user
+     * was not enrolled; -1 means no leaf matched and aggregate weights were used.
+     */
+    val leafId: Int? = null,
+
+    /**
+     * Contextual bandit: the per-variation weights used to bucket this user.
+     */
+    val variationWeights: List<Float>? = null,
+
+    /**
+     * Contextual bandit: which weight generation produced [variationWeights]
+     */
+    val banditVersion: Int? = null
 )
 
 internal fun SerializableGBExperimentResult.gbDeserialize() =
@@ -89,4 +106,7 @@ internal fun SerializableGBExperimentResult.gbDeserialize() =
         inExperiment = inExperiment,
         hashAttribute = hashAttribute,
         stickyBucketUsed = stickyBucketUsed,
+        leafId = leafId,
+        variationWeights = variationWeights,
+        banditVersion = banditVersion
     )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBFeature.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBFeature.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.json.JsonElement
 import com.sdk.growthbook.kotlinx.serialization.from
 
 @Serializable
-data class SerializableGBFeature(
+@ConsistentCopyVisibility
+data class SerializableGBFeature internal constructor(
 
     /**
      * The default value (should use null if not specified)

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBFeatureRule.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBFeatureRule.kt
@@ -18,7 +18,8 @@ import com.sdk.growthbook.kotlinx.serialization.from
  * Rule object consists of various definitions to apply to calculate feature value
  */
 @Serializable
-data class SerializableGBFeatureRule(
+@ConsistentCopyVisibility
+data class SerializableGBFeatureRule internal constructor(
     /**
      * Unique feature rule id
      */
@@ -139,7 +140,9 @@ data class SerializableGBFeatureRule(
     /**
      * Array of tracking calls to fire
      */
-    val tracks: ArrayList<SerializableGBTrackData>? = null
+    val tracks: ArrayList<SerializableGBTrackData>? = null,
+    val contextualBanditRef: String? = null,
+    val contextualVariations: List<JsonElement>? = null
 )
 
 internal fun SerializableGBFeatureRule.gbDeserialize() =
@@ -179,4 +182,6 @@ internal fun SerializableGBFeatureRule.gbDeserialize() =
         },
         disableStickyBucketing = disableStickyBucketing,
         variations = variations?.map { GBValue.from(it) },
+        contextualBanditRef = contextualBanditRef,
+        contextualVariations = contextualVariations?.map { GBValue.from(it) }
     )

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBTrackData.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/serializable_model/SerializableGBTrackData.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.Serializable
  * Used for remote feature evaluation to trigger the TrackingCallback. An object with 2 properties
  */
 @Serializable
-data class SerializableGBTrackData(
+@ConsistentCopyVisibility
+data class SerializableGBTrackData internal constructor(
 
     /**
      * experiment - Experiment

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Crypto.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Crypto.kt
@@ -1,5 +1,8 @@
 package com.sdk.growthbook.utils
 
+import com.sdk.growthbook.logger.GB
+import com.sdk.growthbook.model.GBContextualBandit
+import com.sdk.growthbook.serializable_model.SerializableGBContextualBandit
 import com.sdk.growthbook.serializable_model.SerializableGBFeature
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import dev.whyoleg.cryptography.CryptographyProvider
@@ -54,10 +57,14 @@ fun encryptToFeaturesDataModel(string: String): GBFeatures? {
     val jsonParser = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }
 
     return try {
-        val serializableGBFeatures: Map<String, SerializableGBFeature> = jsonParser.decodeFromString(
-            deserializer = MapSerializer(String.serializer(), SerializableGBFeature.serializer()),
-            string = string
-        )
+        val serializableGBFeatures: Map<String, SerializableGBFeature> =
+            jsonParser.decodeFromString(
+                deserializer = MapSerializer(
+                    String.serializer(),
+                    SerializableGBFeature.serializer()
+                ),
+                string = string
+            )
         serializableGBFeatures.mapValues { it.value.gbDeserialize() }
     } catch (e: Exception) {
         null
@@ -68,7 +75,7 @@ fun getFeaturesFromEncryptedFeatures(
     encryptedString: String,
     encryptionKey: String,
     subtleCrypto: Crypto? = null,
-): GBFeatures? {
+): GBFeatures? = try {
     val encryptedArrayData = encryptedString.split(".")
 
     val iv = decodeBase64(encryptedArrayData[0])
@@ -80,14 +87,22 @@ fun getFeaturesFromEncryptedFeatures(
     val encrypt: ByteArray = cryptoLocal.decrypt(stringToDecrypt, key, iv)
     val encryptString: String =
         encrypt.decodeToString()
-    return encryptToFeaturesDataModel(encryptString)
+    encryptToFeaturesDataModel(encryptString)
+} catch (t: Throwable) {
+    // Throwable, not Exception: a malformed payload (missing "." separator, non-base64 input) or a
+    // rotated key throws out of split/decodeBase64/decrypt, and on the JS/wasm targets a WebCrypto
+    // failure can surface as a plain Throwable. Returning null keeps the rest of the payload usable
+    // instead of failing the whole fetch — see the per-field handling in FeaturePayloadDecoder.
+    // Never log the blob or the key.
+    GB.error(errorMessage = "Crypto: failed to decrypt features", throwable = t)
+    null
 }
 
 fun getSavedGroupFromEncryptedSavedGroup(
     encryptedString: String,
     encryptionKey: String,
     subtleCrypto: Crypto? = null,
-): JsonObject? {
+): JsonObject? = try {
     val encryptedArrayData = encryptedString.split(".")
 
     val iv = decodeBase64(encryptedArrayData[0])
@@ -100,9 +115,34 @@ fun getSavedGroupFromEncryptedSavedGroup(
     val encryptString: String =
         encrypt.decodeToString()
 
-    return try {
-        Json.decodeFromString(JsonObject.serializer(), encryptString)
-    } catch (e : Exception) {
-        null
-    }
+    Json.decodeFromString(JsonObject.serializer(), encryptString)
+} catch (t: Throwable) {
+    GB.error(errorMessage = "Crypto: failed to decrypt saved groups", throwable = t)
+    null
+}
+
+fun getBanditsFromEncryptedBandits(
+    encryptedString: String,
+    encryptionKey: String,
+    subtleCrypto: Crypto? = null,
+): Map<String, GBContextualBandit>? = try {
+    val parts = encryptedString.split(".")
+
+    val iv = decodeBase64(parts[0])
+    val key = decodeBase64(encryptionKey)
+    val stringToDecrypt = decodeBase64(parts[1])
+
+    val cryptoLocal = subtleCrypto ?: DefaultCrypto()
+
+    val decrypted = cryptoLocal.decrypt(stringToDecrypt, key, iv).decodeToString()
+    val jsonParser = Json { isLenient = true; ignoreUnknownKeys = true }
+    jsonParser
+        .decodeFromString(
+            MapSerializer(String.serializer(), SerializableGBContextualBandit.serializer()),
+            decrypted
+        )
+        .mapValues { it.value.gbDeserialize() }
+} catch (t: Throwable) {
+    GB.error(errorMessage = "Crypto: failed to decrypt contextual bandits", throwable = t)
+    null
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -322,6 +322,7 @@ internal class GBUtils {
             hashVersion: Int?,
         ): Boolean {
             if (range == null && coverage == null) return true
+            if (range == null && coverage == 0f) return false
 
             val (_, hashValue) = getHashAttribute(
                 attr = hashAttribute,
@@ -329,6 +330,7 @@ internal class GBUtils {
                 attributes = attributes,
                 attributeOverrides = attributeOverrides,
             )
+            if (hashValue.isNullOrEmpty()) return false
 
             val hash = hash(
                 seed = seed,
@@ -415,7 +417,10 @@ internal class GBUtils {
             features.keys.forEach { id ->
                 val feature = features[id]
                 feature?.rules?.forEach { rule ->
-                    rule.variations?.let { _ ->
+                    // Contextual bandit rules carry their variations under `contextualVariations`
+                    // (so older SDKs skip them) — they still need their identifiers registered,
+                    // otherwise sticky bucket docs are never loaded for bandit-driven features.
+                    if (rule.variations != null || rule.contextualVariations != null) {
                         attributes.add(rule.hashAttribute ?: "id")
                         rule.fallbackAttribute?.let { fallbackAttribute ->
                             attributes.add(fallbackAttribute)

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/integration/VerifySDKReturnFeatureValues.kt
@@ -181,7 +181,7 @@ internal class VerifySDKReturnFeatureValues {
 
         delay(100) // cancel only after 100 millis of waiting
         job.cancel()
-        // or gbSdk.featuresFetchedSuccessfully(emptyMap(), true)
+        // or gbSdk.payloadFetchedSuccessfully(emptyMap(), null, null, true)
 
         coVerify { mockedFeaturesViewModel.awaitRefresh() }
     }
@@ -205,7 +205,12 @@ internal class VerifySDKReturnFeatureValues {
             // 2nd awaitRefresh(): the newer round lands, applies the FRESH features and reports success.
             coEvery { awaitRefresh() } returns FetchResult.Superseded andThenAnswer {
                 gbSdk.getGBContext().features = mapOf("flag" to GBFeature(GBBoolean(true)))
-                gbSdk.featuresFetchedSuccessfully(gbSdk.getGBContext().features, true)
+                gbSdk.payloadFetchedSuccessfully(
+                    features = gbSdk.getGBContext().features,
+                    savedGroups = null,
+                    contextualBandits = null,
+                    isRemote = true
+                )
                 FetchResult.Success
             }
         }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelPollingTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelPollingTests.kt
@@ -5,6 +5,7 @@ import com.sdk.growthbook.features.FeaturesDataSource
 import com.sdk.growthbook.features.FeaturesFlowDelegate
 import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.GBOptions
 import com.sdk.growthbook.sandbox.CachingLayer
 import com.sdk.growthbook.utils.GBError
@@ -45,11 +46,15 @@ class FeaturesViewModelPollingTests {
     private val testGbOptions = GBOptions("https://example.com", null)
 
     private object NoopDelegate : FeaturesFlowDelegate {
-        override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) = Unit
+        override fun payloadFetchedSuccessfully(
+            features: GBFeatures?,
+            savedGroups: JsonObject?,
+            contextualBandits: Map<String, GBContextualBandit>?,
+            isRemote: Boolean,
+        ) = Unit
         override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
         override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
         override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-        override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
         override fun featuresNotModified() = Unit
     }
 
@@ -308,13 +313,17 @@ class FeaturesViewModelPollingTests {
 
     private fun cacheAppliedRecordingDelegate(record: () -> Unit): FeaturesFlowDelegate =
         object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
                 if (!isRemote) record()
             }
             override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
 
@@ -430,13 +439,17 @@ class FeaturesViewModelPollingTests {
         // preserving the pre-existing 7.3.0 behaviour.
         var appliedFromCache = false
         val recordingDelegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
                 if (!isRemote) appliedFromCache = true
             }
             override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val client = CountingClient(response = null, error = Throwable("offline"))

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FeaturesViewModelTests.kt
@@ -10,6 +10,7 @@ import com.sdk.growthbook.features.FeaturesViewModel
 import com.sdk.growthbook.features.FetchResult
 import com.sdk.growthbook.model.GBBoolean
 import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.model.GBNumber
 import com.sdk.growthbook.model.GBOptions
 import kotlinx.coroutines.CompletableDeferred
@@ -331,13 +332,17 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         val client = DeferredPostNetworkClient()
         var appliedFeatures: GBFeatures? = null
         val delegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
                 appliedFeatures = features
             }
             override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val viewModel = FeaturesViewModel(
@@ -426,8 +431,13 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         val oldApplyGate = CompletableDeferred<Unit>()
         val appliedOrder = mutableListOf<String>()
         val delegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
-                features.keys.firstOrNull()?.let { appliedOrder.add(it) }
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
+                features?.keys?.firstOrNull()?.let { appliedOrder.add(it) }
             }
             override suspend fun onPayloadReady(model: FeaturesDataModel) {
                 // Hold the OLDER round inside its apply until the test releases the gate.
@@ -435,7 +445,6 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             }
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val viewModel = FeaturesViewModel(
@@ -484,7 +493,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         // then SUSPENDS mid-apply (inside onPayloadReady). A NEWER round bumps the generation DURING
         // that suspend (incrementAndFetch runs outside applyMutex). When the older round resumes it
         // must RE-VALIDATE the generation at the commit point and bail: it must NOT commit its now
-        // stale features (no featuresFetchedSuccessfully) and its awaiter must resolve as Superseded,
+        // stale features (no payloadFetchedSuccessfully) and its awaiter must resolve as Superseded,
         // not Success. Without the re-check the older round commits old_feature and reports Success
         // for a superseded round.
         //
@@ -494,8 +503,13 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         val oldApplyGate = CompletableDeferred<Unit>()
         val committed = mutableListOf<String>()
         val delegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
-                features.keys.firstOrNull()?.let { committed.add(it) }
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
+                features?.keys?.firstOrNull()?.let { committed.add(it) }
             }
             override suspend fun onPayloadReady(model: FeaturesDataModel) {
                 // Hold the OLDER round inside its apply until the test releases the gate.
@@ -503,7 +517,6 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             }
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val viewModel = FeaturesViewModel(
@@ -565,11 +578,15 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         // failure — not swallowed by the coroutine machinery, and not rethrown into the caller.
         var failed = false
         val delegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) = Unit
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) = Unit
             override suspend fun onPayloadReady(model: FeaturesDataModel) = Unit
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) { failed = true }
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val viewModel = FeaturesViewModel(
@@ -794,7 +811,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
 
         assertTrue(
             receivedFromCache,
-            "Expected featuresFetchedSuccessfully(isRemote=false) from cache"
+            "Expected payloadFetchedSuccessfully(isRemote=false) from cache"
         )
         assertTrue(hasFeatures)
     }
@@ -820,7 +837,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
 
         assertTrue(
             receivedFromCache,
-            "Expected featuresFetchedSuccessfully(isRemote=false) from encrypted cache"
+            "Expected payloadFetchedSuccessfully(isRemote=false) from encrypted cache"
         )
         assertTrue(hasFeatures)
     }
@@ -1016,10 +1033,14 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 featuresSeenByPayloadReady = model.features
             }
 
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) = Unit
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) = Unit
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
         val viewModel = FeaturesViewModel(
@@ -1142,7 +1163,12 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         // A delegate whose onPayloadReady actually suspends, mimicking sticky-bucket IO that
         // does not complete synchronously (real GBStickyBucketService reads from storage).
         val orderingDelegate = object : FeaturesFlowDelegate {
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
                 events += "featuresApplied"
             }
 
@@ -1157,7 +1183,6 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
             }
 
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
 
@@ -1195,7 +1220,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         assertEquals(
             listOf("stickyRefreshStart", "stickyRefreshDone", "featuresApplied"),
             events,
-            "featuresFetchedSuccessfully must fire strictly after onPayloadReady completes"
+            "payloadFetchedSuccessfully must fire strictly after onPayloadReady completes"
         )
     }
 
@@ -1260,13 +1285,17 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
                 )
             }
 
-            override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+            override fun payloadFetchedSuccessfully(
+                features: GBFeatures?,
+                savedGroups: JsonObject?,
+                contextualBandits: Map<String, GBContextualBandit>?,
+                isRemote: Boolean,
+            ) {
                 docsAtApplyTime = ctx.stickyBucketAssignmentDocs
             }
 
             override fun featuresFetchFailed(error: GBError, isRemote: Boolean) = Unit
             override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) = Unit
-            override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) = Unit
             override fun featuresNotModified() = Unit
         }
 
@@ -1287,7 +1316,7 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
 
         advanceUntilIdle()
 
-        // featuresFetchedSuccessfully fired only after the real refresh wrote the current user's docs.
+        // payloadFetchedSuccessfully fired only after the real refresh wrote the current user's docs.
         assertNotNull(
             docsAtApplyTime,
             "stickyBucketAssignmentDocs must be populated before features are applied",
@@ -1298,11 +1327,18 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
         )
     }
 
-    override fun featuresFetchedSuccessfully(features: GBFeatures, isRemote: Boolean) {
+    override fun payloadFetchedSuccessfully(
+        features: GBFeatures?,
+        savedGroups: JsonObject?,
+        contextualBandits: Map<String, GBContextualBandit>?,
+        isRemote: Boolean,
+    ) {
         isSuccess = true
         isError = false
-        hasFeatures = features.isNotEmpty()
-        if (!isRemote) receivedFromCache = true
+        if (features != null) {
+            hasFeatures = features.isNotEmpty()
+            if (!isRemote) receivedFromCache = true
+        }
     }
 
     override fun featuresNotModified() {
@@ -1319,11 +1355,6 @@ class FeaturesViewModelTests : FeaturesFlowDelegate {
     override fun savedGroupsFetchFailed(error: GBError, isRemote: Boolean) {
         isSuccess = false
         isError = true
-    }
-
-    override fun savedGroupsFetchedSuccessfully(savedGroups: JsonObject, isRemote: Boolean) {
-        isSuccess = true
-        isError = false
     }
 
     override suspend fun onPayloadReady(model: FeaturesDataModel) {

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextualBanditPayloadTest.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextualBanditPayloadTest.kt
@@ -1,0 +1,260 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.features.FeaturePayloadDecoder
+import com.sdk.growthbook.features.FeaturesDataModel
+import com.sdk.growthbook.features.gbSerialize
+import com.sdk.growthbook.integration.buildSDK
+import com.sdk.growthbook.model.GBFeatureSource
+import com.sdk.growthbook.model.GBString
+import com.sdk.growthbook.model.GBValue
+import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
+import com.sdk.growthbook.serializable_model.gbDeserialize
+import com.sdk.growthbook.utils.DefaultCrypto
+import com.sdk.growthbook.utils.decodeBase64
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.intellij.lang.annotations.Language
+import kotlin.coroutines.CoroutineContext
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Covers the contextual-bandit payload path end to end — decryption, cache round-trip, ingestion
+ * from the network and from a bundled seed. The shared spec cases in [GBContextualBanditTest] only
+ * exercise the evaluator directly, so none of this is reached by them.
+ */
+class GBContextualBanditPayloadTest {
+
+    private val encryptionKey = "Ns04T5n9+59rl2x3SlNHtQ=="
+
+    @Language("json")
+    private val banditsJson = """
+        {
+          "bandit_1": {
+            "banditVersion": 3,
+            "contexts": [
+              { "leafId": 7, "condition": { "country": "UA" }, "weights": [0.0, 1.0] },
+              { "leafId": 9, "condition": {}, "weights": [1.0, 0.0] }
+            ]
+          }
+        }
+    """.trimIndent()
+
+    /**
+     * A feature whose only rule is a contextual bandit. The leaf weights are 0/1, so the variation
+     * a user lands on is decided purely by which leaf matched — no dependence on hash luck.
+     */
+    @Language("json")
+    private val payloadJson = """
+        {
+          "status": 200,
+          "features": {
+            "cb_feature": {
+              "defaultValue": "default",
+              "rules": [
+                {
+                  "key": "cb_exp",
+                  "hashAttribute": "id",
+                  "coverage": 1,
+                  "weights": [0.5, 0.5],
+                  "contextualBanditRef": "bandit_1",
+                  "contextualVariations": ["control", "variant"]
+                }
+              ]
+            }
+          },
+          "contextualBandits": $banditsJson
+        }
+    """.trimIndent()
+
+    /**
+     * Builds an SDK whose ONLY source of data is [seed]: the network always fails and the disk cache
+     * is off. Caching must be disabled explicitly — it is keyed by API key alone, so a shared key
+     * would let a payload cached by an earlier test satisfy the assertions and the seed would never
+     * actually be exercised. The unique [key] keeps this test's cache file out of other suites too.
+     */
+    private fun seededSDK(
+        seed: String,
+        key: String,
+        attributes: Map<String, GBValue>,
+        encryptionKey: String = "",
+        dispatcher: CoroutineContext,
+    ) = GBSDKBuilder(
+        apiKey = key,
+        apiHost = "http://host.com",
+        attributes = attributes,
+        remoteEval = false,
+        encryptionKey = encryptionKey,
+        trackingCallback = { _, _ -> },
+        networkDispatcher = MockNetworkClient(null, Throwable("offline")),
+        cachingEnabled = false,
+    )
+        .setCoroutineContext(dispatcher)
+        .setInitialPayload(seed)
+        .initialize()
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun encrypt(plain: String): String {
+        val iv = ByteArray(16) { it.toByte() } // fixed IV: deterministic test vector, not production
+        val cipher = DefaultCrypto().encrypt(
+            inputText = plain.encodeToByteArray(),
+            key = decodeBase64(encryptionKey),
+            iv = iv,
+        )
+        return "${Base64.encode(iv)}.${Base64.encode(cipher)}"
+    }
+
+    @Test
+    fun encryptedContextualBandits_correctKey_decodes() {
+        val model = FeaturesDataModel(encryptedContextualBandits = encrypt(banditsJson))
+
+        val bandits = FeaturePayloadDecoder(encryptionKey).decode(model).contextualBandits
+
+        assertNotNull(bandits)
+        val definition = assertNotNull(bandits["bandit_1"])
+        assertEquals(3, definition.banditVersion)
+        assertEquals(listOf(7, 9), definition.contexts?.map { it.leafId })
+        assertEquals(listOf(0f, 1f), definition.contexts?.first()?.weights)
+    }
+
+    @Test
+    fun encryptedContextualBandits_wrongKey_yieldsNull() {
+        val model = FeaturesDataModel(encryptedContextualBandits = encrypt(banditsJson))
+
+        val bandits = runCatching {
+            FeaturePayloadDecoder("AAAAAAAAAAAAAAAAAAAAAA==").decode(model).contextualBandits
+        }.getOrNull()
+
+        assertNull(bandits)
+    }
+
+    /**
+     * The disk cache stores the serialized [FeaturesDataModel], so bandits have to survive both
+     * directions of that conversion — otherwise an offline start silently loses them and every
+     * bandit rule falls back to its marginal weights.
+     */
+    @Test
+    fun contextualBandits_surviveCacheSerializationRoundTrip() {
+        val json = Json { isLenient = true; ignoreUnknownKeys = true }
+        val original = json
+            .decodeFromString(SerializableFeaturesDataModel.serializer(), payloadJson)
+            .gbDeserialize()
+
+        val restored = json
+            .decodeFromString(
+                SerializableFeaturesDataModel.serializer(),
+                json.encodeToString(SerializableFeaturesDataModel.serializer(), original.gbSerialize()),
+            )
+            .gbDeserialize()
+
+        assertEquals(original.contextualBandits, restored.contextualBandits)
+        assertEquals(3, restored.contextualBandits?.get("bandit_1")?.banditVersion)
+    }
+
+    @Test
+    fun networkPayload_routesUserIntoMatchingLeaf() = runTest {
+        val sdk = buildSDK(
+            json = payloadJson,
+            attributes = mapOf("id" to GBString("u1"), "country" to GBString("UA")),
+        )
+
+        val result = sdk.feature("cb_feature")
+
+        assertEquals(GBString("variant"), result.gbValue)
+        assertEquals(7, result.experimentResult?.leafId)
+        assertEquals(3, result.experimentResult?.banditVersion)
+        assertEquals(listOf(0f, 1f), result.experimentResult?.variationWeights)
+    }
+
+    @Test
+    fun networkPayload_fallsThroughToCatchAllLeaf() = runTest {
+        val sdk = buildSDK(
+            json = payloadJson,
+            attributes = mapOf("id" to GBString("u1"), "country" to GBString("PL")),
+        )
+
+        val result = sdk.feature("cb_feature")
+
+        assertEquals(GBString("control"), result.gbValue)
+        assertEquals(9, result.experimentResult?.leafId)
+    }
+
+    /**
+     * Bundled-seed path: the network fails, so everything the SDK evaluates comes from
+     * [GBSDKBuilder.setInitialPayload]. Without bandit definitions in the seed the rule would fall
+     * back to its 50/50 marginal weights and carry no leaf metadata.
+     */
+    @Test
+    fun initialPayload_seedsContextualBanditsOffline() = runTest {
+        val sdk = seededSDK(
+            seed = payloadJson,
+            key = "seed_plain_key",
+            attributes = mapOf("id" to GBString("u1"), "country" to GBString("UA")),
+            dispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = sdk.feature("cb_feature")
+
+        assertEquals(GBString("variant"), result.gbValue)
+        assertEquals(7, result.experimentResult?.leafId)
+        assertEquals(3, result.experimentResult?.banditVersion)
+    }
+
+    @Test
+    fun initialPayload_seedsEncryptedContextualBandits() = runTest {
+        @Language("json")
+        val encryptedPayload = """
+            {
+              "features": {
+                "cb_feature": {
+                  "defaultValue": "default",
+                  "rules": [
+                    {
+                      "key": "cb_exp",
+                      "hashAttribute": "id",
+                      "coverage": 1,
+                      "contextualBanditRef": "bandit_1",
+                      "contextualVariations": ["control", "variant"]
+                    }
+                  ]
+                }
+              },
+              "encryptedContextualBandits": "${encrypt(banditsJson)}"
+            }
+        """.trimIndent()
+
+        val sdk = seededSDK(
+            seed = encryptedPayload,
+            key = "seed_encrypted_key",
+            attributes = mapOf("id" to GBString("u1"), "country" to GBString("UA")),
+            encryptionKey = encryptionKey,
+            dispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        val result = sdk.feature("cb_feature")
+
+        assertEquals(GBString("variant"), result.gbValue)
+        assertEquals(7, result.experimentResult?.leafId)
+    }
+
+    @Test
+    fun initialPayload_malformedJsonIsIgnoredRatherThanFatal() = runTest {
+        val sdk = seededSDK(
+            seed = "{ not json at all",
+            key = "seed_malformed_key",
+            attributes = mapOf("id" to GBString("u1")),
+            dispatcher = UnconfinedTestDispatcher(testScheduler),
+        )
+
+        // Seed skipped, network down: the SDK simply has no features, exactly as if no seed was set.
+        val result = sdk.feature("cb_feature")
+        assertNull(result.gbValue)
+        assertEquals(GBFeatureSource.unknownFeature, result.source)
+    }
+}

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextualBanditTest.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBContextualBanditTest.kt
@@ -1,0 +1,168 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.evaluators.GBFeatureEvaluator
+import com.sdk.growthbook.features.FeaturesDataModel
+import com.sdk.growthbook.kotlinx.serialization.from
+import com.sdk.growthbook.kotlinx.serialization.gbSerialize
+import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.GBFeature
+import com.sdk.growthbook.model.GBFeatureRule
+import com.sdk.growthbook.model.GBString
+import com.sdk.growthbook.model.GBValue
+import com.sdk.growthbook.serializable_model.gbDeserialize
+import com.sdk.growthbook.stickybucket.GBStickyBucketService
+import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
+import com.sdk.growthbook.utils.GBUtils
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GBContextualBanditTest {
+    private lateinit var cases: JsonArray
+
+    @BeforeTest
+    fun setUp() {
+        cases = GBTestHelper.getContextualBanditData()
+    }
+
+    @Test
+    fun testContextualBandits() {
+        val failed = ArrayList<String>()
+        var skipped = 0
+        for (item in cases) {
+            if (item !is JsonArray) continue
+
+            // Kotlin (mobile-first) has no querystring/URL-based experiment override; skip that case.
+            if (item[0].jsonPrimitive.content == "querystring force overrides CB routing") {
+                skipped++
+                continue
+            }
+
+            val testData = GBTestHelper.jsonParser
+                .decodeFromJsonElement(GBFeaturesTest.serializer(), item[1])
+            val attributes = testData.attributes.jsonObject.mapValues { GBValue.from(it.value) }
+
+            val evalContext = GBTestHelper.createTestScopeEvaluationContext(
+                features = testData.features?.mapValues { it.value.gbDeserialize() } ?: emptyMap(),
+                attributes = attributes,
+                savedGroups = testData.savedGroups?.jsonObject?.mapValues { GBValue.from(it.value) },
+                contextualBandits = testData.contextualBandits?.mapValues { it.value.gbDeserialize() },
+                forcedVariations = testData.forcedVariations
+                    ?.mapValues { it.value.jsonPrimitive.intOrNull ?: 0 } ?: emptyMap(),
+                qaMode = testData.qaMode,
+                enabled = testData.enabled,
+            )
+
+            val actual = GBFeatureEvaluator(evalContext).evaluateFeature(
+                item[2].jsonPrimitive.content,
+                attributes
+            )
+            val expected = GBTestHelper.jsonParser.decodeFromJsonElement(
+                BanditExpected.serializer(), item[3]
+            )
+            val actualExperimentResult = actual.experimentResult
+            val expectedExperimentResult = expected.experimentResult
+
+            val actualValue = actual.gbValue?.gbSerialize()
+            val ok = actualValue == expected.value
+                && actual.on == expected.on
+                && actual.source.toString() == expected.source
+                && actualExperimentResult?.variationId == expectedExperimentResult?.variationId
+                && actualExperimentResult?.leafId == expectedExperimentResult?.leafId
+                && actualExperimentResult?.banditVersion == expectedExperimentResult?.banditVersion
+                && actualExperimentResult?.variationWeights == expectedExperimentResult?.variationWeights
+
+            if (!ok) {
+                failed.add(
+                    "${item[0]}: expected leaf=${expectedExperimentResult?.leafId}, " +
+                        "variationId=${expectedExperimentResult?.variationId}, " +
+                        "BUT got leaf=${actualExperimentResult?.leafId}, " +
+                        "variationId=${actualExperimentResult?.variationId}")
+            }
+        }
+        println("CB TESTS: ${cases.size}, skipped(no URL override): $skipped, failed: ${failed.size}\n$failed")
+        assertTrue(failed.isEmpty())
+    }
+
+    /**
+     * A contextual bandit rule carries its variations under `contextualVariations` (so older SDKs
+     * skip it), but it is still an experiment rule and its identifiers must be registered for
+     * sticky bucketing — otherwise no assignment doc is ever loaded for the feature and sticky
+     * bucketing silently does nothing. Mirrors deriveStickyBucketIdentifierAttributes in the TS SDK.
+     */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun testStickyBucketIdentifiersDerivedFromContextualVariations() = runTest {
+        var requestedAttributes: Map<String, String> = emptyMap()
+        val service = object : GBStickyBucketService {
+            override val coroutineScope = TestScope(testScheduler)
+            override suspend fun getAssignments(
+                attributeName: String,
+                attributeValue: String
+            ): GBStickyAssignmentsDocument? = null
+
+            override suspend fun saveAssignments(doc: GBStickyAssignmentsDocument) = Unit
+
+            override suspend fun getAllAssignments(
+                attributes: Map<String, String>
+            ): Map<String, GBStickyAssignmentsDocument> {
+                requestedAttributes = attributes
+                return emptyMap()
+            }
+        }
+
+        val context = GBContext(
+            apiKey = "Key",
+            enabled = true,
+            attributes = mapOf("id" to GBString("u1"), "deviceId" to GBString("d1")),
+            forcedVariations = emptyMap(),
+            qaMode = false,
+            trackingCallback = { _, _ -> },
+            encryptionKey = null,
+            stickyBucketService = service,
+        )
+
+        val payload = FeaturesDataModel(
+            features = mapOf(
+                "cb_feature" to GBFeature(
+                    rules = listOf(
+                        GBFeatureRule(
+                            hashAttribute = "deviceId",
+                            contextualBanditRef = "bandit_1",
+                            contextualVariations = listOf(GBString("control"), GBString("variant")),
+                        )
+                    )
+                )
+            )
+        )
+
+        GBUtils.refreshStickyBuckets(
+            context = context,
+            data = payload,
+            attributeOverrides = emptyMap(),
+        )
+
+        assertEquals(listOf("deviceId"), context.stickyBucketIdentifierAttributes)
+        assertEquals(mapOf("deviceId" to "d1"), requestedAttributes)
+    }
+}
+
+/** Expected feature result for a bandit case; value is a [JsonElement] so object values decode. */
+@Serializable
+class BanditExpected(
+    val value: JsonElement = JsonObject(emptyMap()),
+    val on: Boolean = false,
+    val off: Boolean = false,
+    val source: String = "",
+    val experimentResult: GBExperimentResultTest? = null,
+)

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBTestHelper.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GBTestHelper.kt
@@ -3,11 +3,13 @@ package com.sdk.growthbook.tests
 import com.sdk.growthbook.evaluators.UserContext
 import com.sdk.growthbook.evaluators.EvaluationContext
 import com.sdk.growthbook.evaluators.GBExperimentHelper
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.model.GBFeatureResult
 import com.sdk.growthbook.model.StackContext
 import com.sdk.growthbook.model.StickyBucketAssignmentDocsType
+import com.sdk.growthbook.serializable_model.SerializableGBContextualBandit
 import com.sdk.growthbook.serializable_model.SerializableGBExperiment
 import com.sdk.growthbook.serializable_model.SerializableGBFeature
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
@@ -88,6 +90,11 @@ class GBTestHelper {
             return array
         }
 
+        fun getContextualBanditData(): JsonArray {
+            val array = testData.jsonObject["contextualBandit"] as JsonArray
+            return array
+        }
+
         internal fun createTestScopeEvaluationContext(
             features: GBFeatures,
             attributes: Map<String, GBValue>,
@@ -96,9 +103,12 @@ class GBTestHelper {
             stickyBucketService: GBStickyBucketService? = null,
             onFeatureUsage: ((String, GBFeatureResult) -> Unit)? = null,
             stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType? = null,
+            contextualBandits: Map<String, GBContextualBandit>? = null,
+            qaMode: Boolean = false,
+            enabled: Boolean = true
         ) =
             EvaluationContext(
-                enabled = true,
+                enabled = enabled,
                 features = features,
                 loggingEnabled = true,
                 savedGroups = savedGroups,
@@ -108,13 +118,13 @@ class GBTestHelper {
                 stickyBucketService = stickyBucketService,
                 gbExperimentHelper = GBExperimentHelper(),
                 userContext = UserContext(
-                    qaMode = false,
+                    qaMode = qaMode,
                     attributes = attributes,
                     stickyBucketAssignmentDocs = stickyBucketAssignmentDocs,
                 ),
                 stackContext = StackContext(null, mutableSetOf()),
-                pluginRegistry = null
-
+                pluginRegistry = null,
+                contextualBandits = contextualBandits
             )
     }
 }
@@ -137,6 +147,9 @@ class GBFeaturesTest(
     val savedGroups: JsonElement? = null,
     val attributes: JsonElement = JsonObject(HashMap()),
     val forcedVariations: JsonObject? = null,
+    val contextualBandits: Map<String, SerializableGBContextualBandit>? = null,
+    val qaMode: Boolean = false,
+    val enabled: Boolean = true
 )
 
 @Serializable
@@ -176,5 +189,8 @@ data class GBExperimentResultTest(
     // The id of the feature (if any) that the experiment came from
     val featureId: String? = null,
     // If sticky bucketing was used to assign a variation
-    val stickyBucketUsed: Boolean? = null
+    val stickyBucketUsed: Boolean? = null,
+    val leafId: Int? = null,
+    val variationWeights: List<Float>? = null,
+    val banditVersion: Int? = null
 )

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKBuilderTests.kt
@@ -3,6 +3,7 @@ package com.sdk.growthbook.tests
 import com.sdk.growthbook.GBSDKBuilder
 import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.model.GBBoolean
+import com.sdk.growthbook.model.GBContextualBandit
 import com.sdk.growthbook.utils.GBCacheRefreshHandler
 import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
@@ -657,14 +658,19 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_updatesSavedGroups() = runTest {
+    fun test_payloadFetchedSuccessfully_updatesSavedGroups() = runTest {
         val sdk = buildSdkWithHandler()
         val jsonGroups = buildJsonObject {
             put("premium", JsonPrimitive(true))
             put("beta", JsonPrimitive("yes"))
         }
 
-        sdk.savedGroupsFetchedSuccessfully(jsonGroups, isRemote = false)
+        sdk.payloadFetchedSuccessfully(
+            features = null,
+            savedGroups = jsonGroups,
+            contextualBandits = null,
+            isRemote = false
+        )
 
         val savedGroups = sdk.getGBContext().savedGroups
         assertNotNull(savedGroups)
@@ -673,7 +679,7 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_isRemoteTrue_callsRefreshHandlerWithTrue() = runTest {
+    fun test_payloadFetchedSuccessfully_isRemoteTrue_callsRefreshHandlerWithTrue() = runTest {
         var handlerSuccess: Boolean? = null
         var handlerError: GBError? = GBError(null)
         val sdk = buildSdkWithHandler(refreshHandler = { success, error ->
@@ -681,8 +687,10 @@ class GrowthBookSDKBuilderTests {
             handlerError = error
         })
 
-        sdk.savedGroupsFetchedSuccessfully(
-            buildJsonObject { put("g1", JsonPrimitive(1)) },
+        sdk.payloadFetchedSuccessfully(
+            features = null,
+            savedGroups = buildJsonObject { put("g1", JsonPrimitive(1)) },
+            contextualBandits = null,
             isRemote = true
         )
 
@@ -691,13 +699,15 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_isRemoteFalse_doesNotCallRefreshHandler() = runTest {
+    fun test_payloadFetchedSuccessfully_isRemoteFalse_doesNotCallRefreshHandler() = runTest {
         var handlerCallCount = 0
         val sdk = buildSdkWithHandler(refreshHandler = { _, _ -> handlerCallCount++ })
         val countAfterInit = handlerCallCount
 
-        sdk.savedGroupsFetchedSuccessfully(
-            buildJsonObject { put("g1", JsonPrimitive(1)) },
+        sdk.payloadFetchedSuccessfully(
+            features = null,
+            savedGroups = buildJsonObject { put("g1", JsonPrimitive(1)) },
+            contextualBandits = null,
             isRemote = false
         )
 
@@ -705,14 +715,64 @@ class GrowthBookSDKBuilderTests {
     }
 
     @Test
-    fun test_savedGroupsFetchedSuccessfully_withEmptyJson_setEmptySavedGroups() = runTest {
+    fun test_payloadFetchedSuccessfully_withEmptyJson_setEmptySavedGroups() = runTest {
         val sdk = buildSdkWithHandler()
 
-        sdk.savedGroupsFetchedSuccessfully(buildJsonObject { }, isRemote = false)
+        sdk.payloadFetchedSuccessfully(
+            features = null,
+            savedGroups = buildJsonObject { },
+            contextualBandits = null,
+            isRemote = false
+        )
 
         val savedGroups = sdk.getGBContext().savedGroups
         assertNotNull(savedGroups)
         assertTrue(savedGroups.isEmpty())
+    }
+
+    @Test
+    fun test_payloadFetchedSuccessfully_appliesEveryFieldInOneUpdate() = runTest {
+        val sdk = buildSdkWithHandler()
+        val features: GBFeatures = mapOf("feat" to GBFeature(defaultValue = GBBoolean(true)))
+        val bandits = mapOf("cb_1" to GBContextualBandit(banditVersion = 7))
+
+        sdk.payloadFetchedSuccessfully(
+            features = features,
+            savedGroups = buildJsonObject { put("premium", JsonPrimitive(true)) },
+            contextualBandits = bandits,
+            isRemote = true
+        )
+
+        // Read the snapshot once: all three fields must come from the same payload generation.
+        val snapshot = sdk.getGBContext().evalSnapshot()
+        assertTrue(snapshot.features.containsKey("feat"))
+        assertTrue(snapshot.savedGroups?.containsKey("premium") == true)
+        assertEquals(7, snapshot.contextualBandits?.get("cb_1")?.banditVersion)
+    }
+
+    @Test
+    fun test_payloadFetchedSuccessfully_withAbsentFields_keepsPreviousValues() = runTest {
+        val sdk = buildSdkWithHandler()
+        sdk.payloadFetchedSuccessfully(
+            features = mapOf("old" to GBFeature(defaultValue = GBBoolean(true))),
+            savedGroups = buildJsonObject { put("premium", JsonPrimitive(true)) },
+            contextualBandits = mapOf("cb_1" to GBContextualBandit(banditVersion = 1)),
+            isRemote = false
+        )
+
+        // A payload carrying only features must not drop the bandits/saved groups already applied.
+        sdk.payloadFetchedSuccessfully(
+            features = mapOf("new" to GBFeature(defaultValue = GBBoolean(true))),
+            savedGroups = null,
+            contextualBandits = null,
+            isRemote = false
+        )
+
+        val snapshot = sdk.getGBContext().evalSnapshot()
+        assertTrue(snapshot.features.containsKey("new"))
+        assertFalse(snapshot.features.containsKey("old"))
+        assertTrue(snapshot.savedGroups?.containsKey("premium") == true)
+        assertEquals(1, snapshot.contextualBandits?.get("cb_1")?.banditVersion)
     }
 
     @Test

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/MockNetworkClient.kt
@@ -272,7 +272,7 @@ class MockResponse {
         """.trimIndent()
 
         // Has encryptedFeatures (triggers the "else" branch in features handling when encryptionKey
-        // is empty) and plain savedGroups, so savedGroupsFetchedSuccessfully is called
+        // is empty) and plain savedGroups, so payloadFetchedSuccessfully is called
         val successResponseWithSavedGroups = """
             {
                 "status": 200,

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.1",
+  "specVersion": "0.8.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -3726,6 +3726,62 @@
       }
     ],
     [
+      "force rules - hashVersion 2 includes user",
+      {
+        "attributes": {
+          "id": "user2"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "force rules - hashVersion 2 excludes user that v1 would include",
+      {
+        "attributes": {
+          "id": "user3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5,
+                "hashVersion": 2
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 0,
+        "on": false,
+        "off": true,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
       "ignores empty rules",
       {
         "features": {
@@ -5116,6 +5172,541 @@
           "stickyBucketUsed": false
         },
         "ruleId": ""
+      }
+    ],
+    [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0, 1],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "multi-armed-bandit type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "multi-armed-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "standard type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "standard"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "unknown bandit fields on a non-CB rule are ignored",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "banditVersion": 9
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
       }
     ]
   ],
@@ -7172,6 +7763,3030 @@
           "urlWithParams": "http://www.example.com/home-new-new"
         }
       ]
+    ]
+  ],
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["c0", "c1", "c2"],
+                "weights": [0.34, 0.33, 0.33],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [0, 0, 1]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0.34, 0.33, 0.33]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["c0", "c1", "c2"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0, 0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0, 0, 1],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0, 0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.9374,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.8606,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.4818,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.0484,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "bandit-exp": 1
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?bandit-exp=1",
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "bandit-exp": 0
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control"],
+                "weights": [1],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 0.5,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "8",
+          "stickyBucketUsed": false,
+          "bucket": 0.011,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0]
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": 1,
+          "variationWeights": [1, 0]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "bandit-exp",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "bandit-feature",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.5305,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
     ]
   ]
 }

--- a/GrowthBookExt/build.gradle.kts
+++ b/GrowthBookExt/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.0"
+version = "2.0.0"
 
 kotlin {
     androidTarget {

--- a/GrowthBookTest/build.gradle.kts
+++ b/GrowthBookTest/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.0.0"
+version = "2.0.0"
 
 kotlin {
     androidTarget {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If you are accessing features the first time there will be no features right aft
     .setQAMode(true) // Enable / Disable QA Mode
     .setForcedVariations(<HashMap>) // Pass Forced Variations
     .setInitialFeatures(<GBFeatures>) // Seed bundled fallback features (see below)
+    .setInitialPayload(<String>) // Seed a bundled raw API payload (see below)
     .setCacheMaxAge(<Long>) // Cache freshness window in ms (see below)
 .initialize()
 ```
@@ -109,6 +110,32 @@ var sdkInstance: GrowthBookSDK = GBSDKBuilder(
 ```
 
 The seeded features are applied immediately. The normal cache/network refresh still runs on top and overwrites the seed as fresher data arrives. Effective precedence: **network > disk cache > seed > code defaults**.
+
+#### Bundled fallback payload (`setInitialPayload`)
+
+`setInitialFeatures` seeds features only. When the bundled snapshot carries more than that — saved groups, contextual
+bandit definitions, or encrypted variants of any of them — seed the **raw API payload** instead: the exact JSON body the
+features endpoint returns, snapshotted into your assets at build time.
+
+```kotlin
+var sdkInstance: GrowthBookSDK = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    hostURL = <GrowthBook_URL>,
+    attributes = hashMapOf(),
+    trackingCallback = { _, _ -> },
+    encryptionKey = <String?>, // used to decrypt the seed's encrypted* fields too
+    networkDispatcher = GBNetworkDispatcherKtor(),
+)
+    .setInitialPayload(readBundledJsonFromAssets())
+    .initialize()
+```
+
+This matters for contextual bandits in particular: a bandit rule is inert without its definitions, so a bundled payload
+for a bandit-driven feature must go through `setInitialPayload` — otherwise the rule falls back to its marginal weights
+until the network responds.
+
+Like `setInitialFeatures`, this is only a seed and the same precedence applies. A payload that cannot be parsed is
+ignored rather than failing initialization. If both setters are used, the explicit features win over the payload's.
 
 > **Upgrading from 6.x:** Persistent caching is now implemented on every target — Android, Apple (iOS/macOS) and the JVM (on disk), and JS and wasmJs (browser `localStorage`). The legacy `FeatureCache.txt` → `FeatureCache_<clientKey>.txt` migration applies to Android only, so this upgrade note does not apply to the other targets.
 
@@ -614,6 +641,49 @@ made any time a user attribute or other dependency changes — specifically on `
 
 > If you would like to implement Sticky Bucketing while using Remote Evaluation, you must configure your remote evaluation
 > backend to support Sticky Bucketing. You will not need to provide a StickyBucketService instance to the client side SDK.
+
+## Contextual Bandits
+
+A contextual bandit splits an experiment's audience into *contexts* (leaves) and gives each leaf its own variation
+weights, so traffic is allocated per segment instead of globally. The weight maths (Thompson sampling) runs
+server-side — the SDK neither learns nor updates anything. At evaluation time it simply picks the **first leaf whose
+condition matches** the user's attributes and buckets by that leaf's weights, using the ordinary experiment machinery.
+
+Nothing needs to be enabled in code. Bandit definitions arrive in the features payload (plain or encrypted, alongside
+`features` and `savedGroups`), and a bandit-driven rule is evaluated like any other experiment rule.
+
+What is new is the exposure metadata on `GBExperimentResult`, which lets your warehouse attribute an exposure to the
+exact leaf and weight generation that produced it:
+
+```kotlin
+val sdkInstance = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    hostURL = <GrowthBook_URL>,
+    attributes = mapOf("id" to GBString("user-123"), "country" to GBString("UA")),
+    trackingCallback = { experiment, result ->
+        analytics.track(
+            event = "experiment_viewed",
+            experimentId = experiment.key,
+            variationId = result.variationId,
+            leafId = result.leafId,                     // which context the user was routed into
+            variationWeights = result.variationWeights, // the weights actually used to bucket them
+            banditVersion = result.banditVersion,       // which weight generation produced them
+        )
+    },
+    networkDispatcher = GBNetworkDispatcherKtor(),
+).initialize()
+```
+
+The three fields are populated only for users actually enrolled in a bandit experiment; they are `null` for ordinary
+experiments and for users the rule excluded. A `leafId` of `-1` means no leaf condition matched and the rule's aggregate
+weights were used instead.
+
+Sticky bucketing works with bandit rules as it does with any experiment rule. For offline-first setups, seed the
+definitions with [`setInitialPayload`](#bundled-fallback-payload-setinitialpayload) — `setInitialFeatures` does not carry
+them.
+
+> **Note:** GrowthBook's querystring-based variation override (`?experiment-key=0`) is not implemented in this SDK, so it
+> does not apply to bandit rules either. Use `setForcedVariations` for the same effect.
 
 ## Sticky Bucketing
 


### PR DESCRIPTION
## What

Adds contextual bandit support to the Kotlin SDK, matching the reference TS SDK against shared spec version 0.8.0, and narrows the constructors of SDK-owned model types (the reason this is a major release).

## How contextual bandits work here
  
All weight maths stays server-side. The payload gains a top-level contextualBandits map (plus its encryptedContextualBandits twin); a bandit rule carries contextualBanditRef (the marker) and its variations under contextualVariations. At evaluation the SDK:

1. resolves the ref into a bandit definition,
2. routes the user into the first context (leaf) whose condition matches their attributes,
3. substitutes that leaf's weights into the experiment and buckets normally,
4. surfaces the exposure metadata on the result.

New fields on GBExperimentResult — leafId, variationWeights, banditVersion — populated only for users actually enrolled in the experiment (mirrors the TS hashUsed && inExperiment strip). leafId == -1 means no leaf matched and the rule's aggregate weights were used.

Fallbacks mirror the reference SDK: a dangling contextualBanditRef keeps the rule's aggregate weights and emits no metadata; empty or non-matching contexts fall back to aggregate (or equal) weights with the -1 sentinel; a leaf-selection throw is caught and degrades to the fallback.

## Also included

- `GBSDKBuilder.setInitialPayload(json)` — seeds a bundled raw API payload (features, saved groups, bandit definitions, encrypted variants) rather than just features. Bandit rules are inert without their definitions, so offline-first setups covering a bandit-driven feature need this over setInitialFeatures. An unparsable payload is ignored instead of failing init.
- Sticky bucketing recognises bandit rules — identifier attributes are now derived from contextualVariations as well as variations. Previously sticky bucketing silently did nothing on a bandit-driven feature.
- `GBUtils.isIncludedInRollout` aligned with the reference SDK — coverage == 0 now excludes everyone, and an empty/missing hash attribute value excludes the user; both were previously treated as "included". Behaviour change on existing rollout rules, hence called out here.
- Decrypt failures no longer throw — getFeaturesFromEncryptedFeatures, getSavedGroupFromEncryptedSavedGroup and getBanditsFromEncryptedBandits return null for a malformed blob or rotated key (previously only JSON-parse failures were handled, while the split/base64/AES steps threw). One bad field no longer discards the rest of the payload — same per-field isolation the TS SDK gets from wrapping each decrypt. Consequence: setEncryptedFeatures now ignores an undecryptable payload instead of throwing at the call site.
- Atomic payload publication — features, saved groups and bandit definitions land in the context in a single atomic update (`GBContext.applyPayload`). Previously three separate writes, so an evaluation on another thread could observe new features paired with the previous generation's bandit definitions. `FeaturesFlowDelegate`'s three per-field success callbacks are replaced by one payloadFetchedSuccessfully(...), which is what makes the single update structural rather than a convention.

## Breaking changes
  
Reading, passing around and pattern-matching these types is unaffected — only constructing them is now the SDK's job.
- Constructors of SDK-owned types are internal, with copy() (`@ConsistentCopyVisibility`): GBContext, GBOptions, StackContext, GBFeaturesDiff, GBFeatureChange, FeaturesDataModel, GBContextualBandit, GBBanditContext, and every SerializableGB* wire type. This is what lets future payload fields be added without another major.
- Types application code legitimately constructs — GBFeature, GBFeatureRule, GBExperiment, GBExperimentResult, GBFeatureResult — keep public constructors but gained bandit fields, so code compiled against 7.x must be recompiled.
- GBContext.plugins moved into the constructor as a val (set it via GBSDKBuilder.setPlugins(), as before; post-construction assignment was already a silent no-op).
- The internal featuresFetchedSuccessfully / savedGroupsFetchedSuccessfully callbacks on GrowthBookSDK are replaced by payloadFetchedSuccessfully. Never a documented API (`FeaturesFlowDelegate` is internal), but reachable from the JVM — hence the note.