### PR TITLE
perf: Replace BigInteger FNV-1a with wrapping 32-bit integer hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [7.8.1] - 2026-09-02
+
+### Changed
+- The FNV-1a hash behind bucketing (`GBUtils.hash`, hash versions 1 and 2) is now computed with
+  plain `Int` arithmetic instead of arbitrary-precision `BigInteger`. `Int` multiplication wraps at
+  32 bits, which is exactly the modulo 2^32 the algorithm calls for, so the explicit `mod(2^32)`
+  step is gone; the accumulator is widened to an unsigned `Long` once at the end. The old code
+  allocated an `FNV` instance per hash (twice per hash-v2 call), computed `BigInteger(2).pow(32)` in
+  its constructor, and created roughly three `BigInteger` objects per character; the new code
+  allocates nothing. **Hash output is bit-identical for every input** — no user is re-bucketed, and
+  hashing stays byte-compatible with the reference (TypeScript) SDK for all ASCII and Latin-1
+  inputs, as before
+
+### Removed
+- `com.ionspin.kotlin:bignum` is no longer a dependency of the `:GrowthBook` module, since the hash
+  rewrite above was its only consumer. It was declared `implementation`, so it never appeared on
+  consumers' compile classpath and no consumer code can fail to compile. It does disappear from the
+  published POM's `runtime` scope: if your build resolves `bignum` at an older version and was
+  silently being upgraded to `0.3.9` through us, it will now resolve to your declared version.
+  Declare it explicitly if you depend on it
+
+---
 ## [7.8.0] - 2026-08-25
 
 ### Added

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -70,7 +70,6 @@ kotlin {
 
                 implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
                 implementation(libs.kotlinx.coroutines.core)
-                implementation("com.ionspin.kotlin:bignum:0.3.9") // used in hash calculation
                 implementation(libs.cryptography.core) // encryption/decryption
 
                 implementation(libs.kotlinx.serialization.json)

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "7.8.0"
+version = "7.8.1"
 
 val generateSdkMeta by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated/sdk-meta/commonMain/kotlin")

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -1,6 +1,5 @@
 package com.sdk.growthbook.utils
 
-import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.sdk.growthbook.evaluators.EvaluationContext
 import com.sdk.growthbook.evaluators.UserContext
 import com.sdk.growthbook.features.FeaturesDataModel
@@ -23,27 +22,35 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+// FNV-1a offset basis. Unsigned 0x811c9dc5 does not fit in a signed Int
+// (high bit set); -0x7ee3623b is the same 32-bit pattern.
+private const val FNV_OFFSET_BASIS = -0x7ee3623b
+private const val FNV_PRIME = 0x01000193
+
 /**
- * Fowler-Noll-Vo hash - 32 bit
+ * Fowler-Noll-Vo FNV-1a, 32-bit.
+ *
+ * For each UTF-16 code unit: XOR the low 8 bits into [hash], then multiply
+ * by [FNV_PRIME]. Kotlin `Int` multiply wraps at 32 bits — that wrap *is*
+ * the FNV modulo 2^32.
+ *
+ * Only the low byte of each code unit is mixed in (`code and 0xFF`). That
+ * is this SDK's historical behaviour; ASCII ids/keys are identical either
+ * way. Code units > 255 (e.g. `'€'`) hash differently than a full-char XOR.
+ *
+ * Returns an unsigned value in 0..2^32-1 so remainders and hash-v2's
+ * decimal stringify do not see a negative `Int`.
  */
-internal class FNV {
-
-    private val INIT32 = BigInteger(0x811c9dc5)
-    private val PRIME32 = BigInteger(0x01000193)
-    private val MOD32 = BigInteger(2).pow(32)
-
-    /**
-     * Fowler-Noll-Vo hash - 32 bit
-     * Returns BigInteger
-     */
-    fun fnv1a32(data: String): BigInteger {
-        var hash: BigInteger = INIT32
-        for (b in data) {
-            hash = hash.xor(BigInteger(b.code and 0xff))
-            hash = hash.multiply(PRIME32).mod(MOD32)
-        }
-        return hash
+private fun fnv1a32(data: String): Long {
+    var hash = FNV_OFFSET_BASIS
+    val length = data.length
+    var i = 0
+    while (i < length) {
+        hash = hash xor (data[i].code and 0xFF)
+        hash *= FNV_PRIME
+        i++
     }
+    return hash.toLong() and 0xFFFFFFFFL
 }
 
 /**
@@ -81,29 +88,19 @@ internal class GBUtils {
         }
 
         /**
-         * Method for hash stings to float for hash version #1
+         * Hash version 1: fnv1a32(value + seed) % 1000 / 1000
          */
         private fun hashV1(stringValue: String, seed: String?): Float {
-            val bigInt: BigInteger = FNV().fnv1a32(stringValue + seed)
-            val thousand = BigInteger(1000)
-            val remainder = bigInt.remainder(thousand)
-
-            val remainderAsFloat = remainder.toString().toFloat()
-            return remainderAsFloat / 1000f
+            return (fnv1a32(stringValue + seed) % 1000L).toFloat() / 1000f
         }
 
         /**
-         * Method for hash stings to float for hash version #2
+         * Hash version 2: hash the unsigned decimal of the first FNV pass, then
+         * % 10000 / 10000. [fnv1a32] returns 0..2^32-1 so [Long.toString] has no sign.
          */
         private fun hashV2(stringValue: String, seed: String?): Float {
-            val first: BigInteger = FNV().fnv1a32(seed + stringValue)
-            val second: BigInteger = FNV().fnv1a32(first.toString())
-
-            val tenThousand = BigInteger(10000)
-            val remainder = second.remainder(tenThousand)
-
-            val remainderAsFloat = remainder.toString().toFloat()
-            return remainderAsFloat / 10000f
+            val first = fnv1a32(seed + stringValue)
+            return (fnv1a32(first.toString()) % 10000L).toFloat() / 10000f
         }
 
         /**

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBUtils.kt
@@ -88,15 +88,14 @@ internal class GBUtils {
         }
 
         /**
-         * Hash version 1: fnv1a32(value + seed) % 1000 / 1000
+         * Method for hash stings to float for hash version #1
          */
         private fun hashV1(stringValue: String, seed: String?): Float {
             return (fnv1a32(stringValue + seed) % 1000L).toFloat() / 1000f
         }
 
         /**
-         * Hash version 2: hash the unsigned decimal of the first FNV pass, then
-         * % 10000 / 10000. [fnv1a32] returns 0..2^32-1 so [Long.toString] has no sign.
+         * Method for hash stings to float for hash version #2
          */
         private fun hashV2(stringValue: String, seed: String?): Float {
             val first = fnv1a32(seed + stringValue)


### PR DESCRIPTION
## Summary

This PR replaces the FNV-1a hash used for experiment and feature bucketing. It was implemented with arbitrary-precision `BigInteger` even though the algorithm is 32-bit; hashing now uses wrapping `Int` arithmetic instead.

## Why it was slow

Per character, the old path allocated several `BigInteger`s and did a software multiply **plus a software division** (`.mod(2^32)`). `FNV()` was constructed on every call — twice for hash version 2 — and `MOD32 = BigInteger(2).pow(32)` ran in that constructor. After the loop, the remainder was converted with `remainder.toString().toFloat()`.

Node/V8 can JIT some of that away, but still on Node it was already slower than the [JS SDK](https://github.com/growthbook/growthbook/tree/main/packages/sdk-js) (~119 µs vs ~28 µs). On Hermes (no JIT) a single experiment eval was **~6.2 ms**. In Java, the use of BigInteger is also very expensive, see https://github.com/growthbook/growthbook-sdk-java/issues/44

## Compatibility

This is not a new hash version and not a new bucketing rule. Hash versions **1** and **2** are unchanged:

- v1: `fnv1a32(value + seed) % 1000 / 1000`
- v2: `fnv1a32(fnv1a32(seed + value).toString()) % 10000 / 10000`, where `.toString()` is still the **unsigned** decimal of the 32-bit value

Wrapping `Int` multiply is the same as `BigInteger.multiply.mod(2^32)` for this 32-bit range, so the float `n` that `chooseVariation` / `inRange` / coverage see is the same. Users stay in the same experiment variations, rollouts, namespaces, and filters. Sticky-bucket keys are not derived from this hash.

Only the low byte of each UTF-16 code unit is mixed in (`code and 0xFF`) — the same as this SDK historically. ASCII ids/keys (what we actually hash) are unaffected. Official GrowthBook `cases.json` hash vectors (`GBUtilsTests.testHash`) plus experiment/feature evaluation tests all passed. A pre-timing parity check against the JS SDK on the same feature snapshot matched on every op (`isOn` / `isOff` / `getFeatureValue` × stress, baseline, experiment).

## Performance
The bottleneck is experiment evaluation — that is the path that hashes. Benchmarks call that path against a fixed, deterministic feature set. On hermes, feature evaluation with experiment rule went from *~6.2ms - ~320µs*.

## Test plan

- [x] `GBUtilsTests.testHash` — all `cases.json` hash vectors (v1, v2, unknown version → null)
- [x] Experiment / feature evaluation tests that assign via hash (including namespace, coverage, sticky bucket)
- [x] On ourside confirm a known set of 500 user+experiment pairs still lands in the same variation as 7.8.0
- [x] Re-run the Node / Hermes eval benchmark: experiment path be sub-milliseconds on JS runtimes.