### PR TITLE
Seed the SDK from a raw payload, encrypted or plain

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -2,12 +2,18 @@ package com.sdk.growthbook
 
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.serialization.json.Json
 import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.GBValue
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBOptions
+import com.sdk.growthbook.features.DecodedPayload
+import com.sdk.growthbook.features.FeaturePayloadDecoder
+import com.sdk.growthbook.kotlinx.serialization.from
 import com.sdk.growthbook.plugin.tracking.GrowthBookPlugin
 import com.sdk.growthbook.network.NetworkDispatcher
+import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
+import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.sandbox.CachingImpl
 import com.sdk.growthbook.sandbox.CachingLayer
 import com.sdk.growthbook.sandbox.GBCachingLayer
@@ -117,6 +123,7 @@ class GBSDKBuilder(
     private var featureUsageCallback: GBFeatureUsageCallback? = null
     private var plugins: List<GrowthBookPlugin>? = null
     private var initialFeatures: GBFeatures? = null
+    private var initialPayload: String? = null
     private var cacheMaxAge: Long? = null
 
     // Dispatcher used to process fetched payloads. Defaults to the platform IO dispatcher in
@@ -156,9 +163,26 @@ class GBSDKBuilder(
      * Features are applied immediately so flags are available from the first millisecond,
      * and the normal cache/network refresh still runs on top — overwriting the seed as
      * fresher data arrives. Effective precedence: network > disk cache > seed > code defaults.
+     *
+     * Takes an already-decoded feature map; see [setInitialPayload] to seed straight from a
+     * payload as the API returns it.
      */
     fun setInitialFeatures(features: GBFeatures): GBSDKBuilder {
         this.initialFeatures = features
+        return this
+    }
+
+    /**
+     * Seed the SDK from a raw feature payload, byte for byte as the API returns it — encrypted
+     * or plain, and including saved groups. Decryption uses the same `encryptionKey` as network
+     * payloads, so an encrypted snapshot can be bundled without decrypting it at build time and
+     * shipping plaintext definitions inside the app.
+     *
+     * Seeding semantics match [setInitialFeatures], which wins if both are set. A payload that
+     * cannot be parsed or decrypted is logged and ignored rather than failing initialization.
+     */
+    fun setInitialPayload(payload: String): GBSDKBuilder {
+        this.initialPayload = payload
         return this
     }
 
@@ -280,7 +304,7 @@ class GBSDKBuilder(
             )
         }
 
-        initialFeatures?.let { gbContext.features = it }
+        applySeed(gbContext)
 
         val gbOptions = GBOptions(apiHost, streamingHost)
 
@@ -344,7 +368,7 @@ class GBSDKBuilder(
                 handleWaitForCallCallback = null
                 growthBookSDK = null
             }
-            initialFeatures?.let { gbContext.features = it }
+            applySeed(gbContext)
 
             val gbOptions = GBOptions(apiHost, streamingHost)
             growthBookSDK = GrowthBookSDK(
@@ -363,4 +387,30 @@ class GBSDKBuilder(
 
     private fun resolveCachingLayer(): CachingLayer =
         customCachingLayer?.let { GBCachingLayerAdapter(it) } ?: CachingImpl.getLayer()
+
+    /** Applies the raw payload seed first, so an explicit [setInitialFeatures] map wins. */
+    private fun applySeed(gbContext: GBContext) {
+        initialPayload?.let(::decodeSeed)?.let { seed ->
+            seed.features?.let { gbContext.features = it }
+            seed.savedGroups?.let { groups ->
+                gbContext.savedGroups = groups.mapValues { GBValue.from(it.value) }
+            }
+        }
+        initialFeatures?.let { gbContext.features = it }
+    }
+
+    // A seed is a fallback by definition, so a bad one must not stop the SDK from starting.
+    private fun decodeSeed(payload: String): DecodedPayload? =
+        runCatching {
+            FeaturePayloadDecoder(encryptionKey).decode(
+                Json { isLenient = true; ignoreUnknownKeys = true }
+                    .decodeFromString(SerializableFeaturesDataModel.serializer(), payload)
+                    .gbDeserialize()
+            )
+        }.onFailure {
+            GB.error(
+                errorMessage = "GBSDKBuilder: seeded payload could not be decoded, ignoring it",
+                throwable = it
+            )
+        }.getOrNull()
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -399,18 +399,22 @@ class GBSDKBuilder(
         initialFeatures?.let { gbContext.features = it }
     }
 
+    private val seedJsonParser = Json { isLenient = true; ignoreUnknownKeys = true }
+
     // A seed is a fallback by definition, so a bad one must not stop the SDK from starting.
     private fun decodeSeed(payload: String): DecodedPayload? =
         runCatching {
             FeaturePayloadDecoder(encryptionKey).decode(
-                Json { isLenient = true; ignoreUnknownKeys = true }
+                seedJsonParser
                     .decodeFromString(SerializableFeaturesDataModel.serializer(), payload)
                     .gbDeserialize()
             )
         }.onFailure {
-            GB.error(
-                errorMessage = "GBSDKBuilder: seeded payload could not be decoded, ignoring it",
-                throwable = it
-            )
+            if (enableLogging) {
+                GB.error(
+                    errorMessage = "GBSDKBuilder: seeded payload could not be decoded, ignoring it",
+                    throwable = it
+                )
+            }
         }.getOrNull()
 }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/SeedFromPayloadTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/SeedFromPayloadTests.kt
@@ -4,8 +4,12 @@ import com.sdk.growthbook.GBSDKBuilder
 import com.sdk.growthbook.GrowthBookSDK
 import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBExperimentResult
+import com.sdk.growthbook.sandbox.CachingJvm
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.encryptToFeaturesDataModel
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -21,6 +25,17 @@ class SeedFromPayloadTests {
     private val encKey = "Ns04T5n9+59rl2x3SlNHtQ=="
     private val encBlob =
         "vMSg2Bj/IurObDsWVmvkUg==.L6qtQkIzKDoE2Dix6IAKDcVel8PHUnzJ7JjmLjFZFQDqidRIoCxKmvxvUj2kTuHFTQ3/NJ3D6XhxhXXv2+dsXpw5woQf0eAgqrcxHrbtFORs18tRXRZza7zqgzwvcznx"
+
+    @Rule
+    @JvmField
+    var tempFolder = TemporaryFolder()
+
+    // Cache reads happen even when writes are disabled, so point them at an empty dir per test;
+    // otherwise a payload left by an earlier run could overwrite the seed under assertion.
+    @BeforeTest
+    fun setUp() {
+        CachingJvm.baseDir = tempFolder.newFolder()
+    }
 
     // Caching stays off so the assertions see the seed alone, not a cache read racing it.
     private fun seed(

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/SeedFromPayloadTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/SeedFromPayloadTests.kt
@@ -1,0 +1,96 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.GrowthBookSDK
+import com.sdk.growthbook.model.GBExperiment
+import com.sdk.growthbook.model.GBExperimentResult
+import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.encryptToFeaturesDataModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers [GBSDKBuilder.setInitialPayload]: a build-time snapshot bundled exactly as the API
+ * returns it, so an encrypted payload need not be decrypted into the app bundle.
+ */
+class SeedFromPayloadTests {
+
+    // Same fixture as FeaturePayloadDecoderTest; the blob decrypts to a "testfeature1" flag.
+    private val encKey = "Ns04T5n9+59rl2x3SlNHtQ=="
+    private val encBlob =
+        "vMSg2Bj/IurObDsWVmvkUg==.L6qtQkIzKDoE2Dix6IAKDcVel8PHUnzJ7JjmLjFZFQDqidRIoCxKmvxvUj2kTuHFTQ3/NJ3D6XhxhXXv2+dsXpw5woQf0eAgqrcxHrbtFORs18tRXRZza7zqgzwvcznx"
+
+    // Caching stays off so the assertions see the seed alone, not a cache read racing it.
+    private fun seed(
+        payload: String,
+        encryptionKey: String? = null,
+        initialFeatures: GBFeatures? = null,
+    ): GrowthBookSDK = GBSDKBuilder(
+        "test-key",
+        "https://cdn.growthbook.io",
+        attributes = emptyMap(),
+        encryptionKey = encryptionKey,
+        trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+        networkDispatcher = MockNetworkClient(null, null),
+        cachingEnabled = false,
+    )
+        .setInitialPayload(payload)
+        .apply { initialFeatures?.let { setInitialFeatures(it) } }
+        .initialize()
+
+    @Test
+    fun encryptedPayload_isDecryptedAndSeeded() {
+        val sdk = seed(
+            payload = """{"status":200,"features":{},"encryptedFeatures":"$encBlob"}""",
+            encryptionKey = encKey,
+        )
+
+        assertTrue(sdk.getFeatures().containsKey("testfeature1"))
+    }
+
+    @Test
+    fun plainPayload_isSeeded() {
+        val sdk = seed("""{"status":200,"features":{"f1":{"defaultValue":true}}}""")
+
+        assertTrue(sdk.getFeatures().containsKey("f1"))
+    }
+
+    @Test
+    fun savedGroupsInPayload_areSeeded() {
+        val sdk = seed(
+            """{"features":{"f1":{"defaultValue":true}},"savedGroups":{"admins":["a","b"]}}"""
+        )
+
+        assertEquals(setOf("admins"), sdk.getGBContext().savedGroups?.keys)
+    }
+
+    @Test
+    fun explicitInitialFeatures_winOverPayload() {
+        val sdk = seed(
+            payload = """{"features":{"fromPayload":{"defaultValue":true}}}""",
+            initialFeatures = encryptToFeaturesDataModel("""{"fromMap":{"defaultValue":true}}""")!!,
+        )
+
+        assertTrue(sdk.getFeatures().containsKey("fromMap"))
+        assertFalse(sdk.getFeatures().containsKey("fromPayload"))
+    }
+
+    @Test
+    fun undecryptablePayload_isIgnoredAndInitializationSucceeds() {
+        val sdk = seed(
+            payload = """{"encryptedFeatures":"$encBlob"}""",
+            encryptionKey = "AAAAAAAAAAAAAAAAAAAAAA==",
+        )
+
+        assertTrue(sdk.getFeatures().isEmpty())
+    }
+
+    @Test
+    fun malformedPayload_isIgnoredAndInitializationSucceeds() {
+        val sdk = seed("not json at all")
+
+        assertTrue(sdk.getFeatures().isEmpty())
+    }
+}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If you are accessing features the first time there will be no features right aft
     .setQAMode(true) // Enable / Disable QA Mode
     .setForcedVariations(<HashMap>) // Pass Forced Variations
     .setInitialFeatures(<GBFeatures>) // Seed bundled fallback features (see below)
+    .setInitialPayload(<String>) // Seed a bundled raw API payload (see below)
     .setCacheMaxAge(<Long>) // Cache freshness window in ms (see below)
 .initialize()
 ```
@@ -109,6 +110,30 @@ var sdkInstance: GrowthBookSDK = GBSDKBuilder(
 ```
 
 The seeded features are applied immediately. The normal cache/network refresh still runs on top and overwrites the seed as fresher data arrives. Effective precedence: **network > disk cache > seed > code defaults**.
+
+#### Bundled fallback payload (`setInitialPayload`)
+
+`setInitialFeatures` takes an already-decoded feature map, so bundling a snapshot means decrypting it at build time —
+shipping plaintext feature definitions inside the app even when payload encryption is on. When the snapshot is encrypted,
+or carries more than features (saved groups, or encrypted variants of either), seed the **raw API payload** instead: the
+exact JSON body the features endpoint returns, snapshotted into your assets at build time.
+
+```kotlin
+var sdkInstance: GrowthBookSDK = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    hostURL = <GrowthBook_URL>,
+    attributes = hashMapOf(),
+    trackingCallback = { _, _ -> },
+    encryptionKey = <String?>, // used to decrypt the seed's encrypted* fields too
+    networkDispatcher = GBNetworkDispatcherKtor(),
+)
+    .setInitialPayload(readBundledJsonFromAssets())
+    .initialize()
+```
+
+Like `setInitialFeatures`, this is only a seed and the same precedence applies. A payload that cannot be parsed or
+decrypted is logged and ignored rather than failing initialization. If both setters are used, the explicit features win
+over the payload's.
 
 > **Upgrading from 6.x:** Persistent caching is now implemented on every target — Android, Apple (iOS/macOS) and the JVM (on disk), and JS and wasmJs (browser `localStorage`). The legacy `FeatureCache.txt` → `FeatureCache_<clientKey>.txt` migration applies to Android only, so this upgrade note does not apply to the other targets.
 


### PR DESCRIPTION
### Features and Changes

`setInitialFeatures` takes a decoded `GBFeatures` map, so bundling a build-time snapshot meant decrypting at build time and shipping plaintext definitions inside the app. That defeats the point for anyone using payload encryption, so the bundled-seed path was effectively unavailable to them.

`setInitialPayload` takes the payload as the API returns it and runs it through the same parse and decrypt path the network uses, so an encrypted snapshot can be embedded verbatim and decrypted on device. It also seeds saved groups, which the map-based setter can't carry, and without them a bundled payload mis-evaluates any rule targeting a saved group.

Precedence is unchanged and `setInitialFeatures` still wins if both are set. A payload that won't parse or decrypt is logged and skipped rather than failing `initialize()`.

### Testing

- [x] Encrypted payload with a matching `encryptionKey` -> features available before any fetch
- [x] Plain payload -> features available before any fetch
- [x] Payload carrying `savedGroups` -> groups seeded onto the context
- [x] Both setters used -> `setInitialFeatures` wins
- [x] Wrong key or malformed JSON -> seed skipped and `initialize()` still returns
