### PR TITLE
Report fetch duration and payload size per fetch

### DIFF
--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -17,6 +17,7 @@ import com.sdk.growthbook.stickybucket.GBStickyBucketServiceImp
 import com.sdk.growthbook.utils.GBCacheRefreshHandler
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBFeaturesChangeHandler
+import com.sdk.growthbook.utils.GBFetchStatsHandler
 
 /**
  * SDKBuilder - Root Class for SDK Initializers for GrowthBook SDK
@@ -109,6 +110,7 @@ class GBSDKBuilder(
 
     private var refreshHandler: GBCacheRefreshHandler? = null
     private var featuresChangeHandler: GBFeaturesChangeHandler? = null
+    private var fetchStatsHandler: GBFetchStatsHandler? = null
     private var stickyBucketService: GBStickyBucketService? = null
     // Deferred builder for the default sticky-bucket service. The caching layer is resolved
     // lazily at initialize() time (via resolveCachingLayer()) rather than when the setter is
@@ -148,6 +150,19 @@ class GBSDKBuilder(
 
     fun setFeaturesChangeHandler(featuresChangeHandler: GBFeaturesChangeHandler): GBSDKBuilder {
         this.featuresChangeHandler = featuresChangeHandler
+        return this
+    }
+
+    /**
+     * Set Fetch Stats Handler - Will be called once per feature fetch with how long it took and
+     * how large the payload was. Use it to measure what users actually experience on first
+     * launch; the edge completes a response before the device has received it, so fetch duration
+     * cannot be measured server-side.
+     *
+     * Invoked on the network callback's thread, before the payload is parsed.
+     */
+    fun setFetchStatsHandler(fetchStatsHandler: GBFetchStatsHandler): GBSDKBuilder {
+        this.fetchStatsHandler = fetchStatsHandler
         return this
     }
 
@@ -293,7 +308,8 @@ class GBSDKBuilder(
             cacheMaxAge = cacheMaxAge,
             coroutineContext = coroutineContext,
             featuresChangeHandler = featuresChangeHandler,
-            cachingLayer = customCachingLayer
+            cachingLayer = customCachingLayer,
+            fetchStatsHandler = fetchStatsHandler
         )
     }
 
@@ -356,7 +372,8 @@ class GBSDKBuilder(
                 cacheMaxAge = cacheMaxAge,
                 coroutineContext = coroutineContext,
                 featuresChangeHandler = featuresChangeHandler,
-                cachingLayer = customCachingLayer
+                cachingLayer = customCachingLayer,
+                fetchStatsHandler = fetchStatsHandler
             )
         }
     }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -160,6 +160,11 @@ class GBSDKBuilder(
      * cannot be measured server-side.
      *
      * Invoked on the network callback's thread, before the payload is parsed.
+     *
+     * Scope: feature GET fetches only. Remote evaluation (`remoteEval = true`) goes through a
+     * POST that is not reported — a server-side evaluation and a CDN GET have very different
+     * latency profiles, so folding them into one stream would corrupt both averages. Reporting
+     * for remote eval (with a source discriminator) is a possible follow-up.
      */
     fun setFetchStatsHandler(fetchStatsHandler: GBFetchStatsHandler): GBSDKBuilder {
         this.fetchStatsHandler = fetchStatsHandler

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -10,6 +10,7 @@ import com.sdk.growthbook.utils.Constants
 import com.sdk.growthbook.utils.GBCacheRefreshHandler
 import com.sdk.growthbook.utils.GBError
 import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.GBFetchStatsHandler
 import com.sdk.growthbook.utils.GBRemoteEvalParams
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.getFeaturesFromEncryptedFeatures
@@ -79,7 +80,9 @@ class GrowthBookSDK internal constructor(
     // Internal seam only: the public way to plug a cache is GBSDKBuilder.setCachingLayer().
     // Adding this to the public constructor would break binary compatibility,
     // so the public constructor below preserves the pre-7.4.0 signature and delegates here.
-    cachingLayer: GBCachingLayer?
+    cachingLayer: GBCachingLayer?,
+    // Internal seam only, same reasoning: set via GBSDKBuilder.setFetchStatsHandler().
+    private val fetchStatsHandler: GBFetchStatsHandler? = null
     ) : FeaturesFlowDelegate, IGrowthBookSDK {
 
     /**
@@ -126,7 +129,7 @@ class GrowthBookSDK internal constructor(
     internal var featuresViewModel: FeaturesViewModel = FeaturesViewModel(
         delegate = this,
         dataSource = FeaturesDataSource(
-            networkDispatcher, gbContext, gbOptions
+            networkDispatcher, gbContext, gbOptions, onFetchStats = fetchStatsHandler
         ),
         encryptionKey = gbContext.encryptionKey,
         cachingEnabled = cachingEnabled,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -11,9 +11,12 @@ import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.FeatureRefreshStrategy
 import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.GBFetchStats
+import com.sdk.growthbook.utils.GBFetchStatsHandler
 import com.sdk.growthbook.utils.GBRemoteEvalParams
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
+import kotlin.time.TimeSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.transform
 import kotlinx.serialization.json.Json
@@ -27,7 +30,8 @@ internal class FeaturesDataSource(
     private val dispatcher: NetworkDispatcher,
     private val gbContext: GBContext,
     private val gbOptions: GBOptions,
-    val sseController: SSEConnectionController = SSEConnectionController()
+    val sseController: SSEConnectionController = SSEConnectionController(),
+    private val onFetchStats: GBFetchStatsHandler? = null,
 ) {
 
     private val jsonParser: Json
@@ -52,34 +56,45 @@ internal class FeaturesDataSource(
         failure: (Throwable?) -> Unit,
         onNotModified: (() -> Unit)
     ) {
+        val startedAt = TimeSource.Monotonic.markNow()
+        // Reported before parsing, so the duration is the fetch and not the SDK's own decode work.
+        fun report(ok: Boolean, bytes: Int?) = onFetchStats?.invoke(
+            GBFetchStats(
+                success = ok,
+                durationMillis = startedAt.elapsedNow().inWholeMilliseconds,
+                payloadBytes = bytes,
+            )
+        )
+
+        val onSuccess: (String) -> Unit = { rawContent ->
+            report(ok = true, bytes = rawContent.encodeToByteArray().size)
+            val result = jsonParser.decodeFromString(
+                deserializer = SerializableFeaturesDataModel.serializer(),
+                string = rawContent
+            )
+            success.invoke(result.gbDeserialize())
+        }
+        val onError: (Throwable) -> Unit = { apiTimeError ->
+            report(ok = false, bytes = null)
+            apiTimeError.also(failure)
+        }
+
         if (dispatcher is NetworkDispatcherWithNotModified) {
             dispatcher.consumeGETRequestWithNotModified(
                 request = getEndpoint(),
-                onSuccess = { rawContent ->
-                    val result = jsonParser.decodeFromString(
-                        deserializer = SerializableFeaturesDataModel.serializer(),
-                        string = rawContent
-                    )
-                    success.invoke(result.gbDeserialize())
-                },
-                onError = { apiTimeError ->
-                    apiTimeError.also(failure)
-                },
-                onNotModified = onNotModified
+                onSuccess = onSuccess,
+                onError = onError,
+                onNotModified = {
+                    report(ok = true, bytes = 0)
+                    onNotModified()
+                }
             )
         } else {
             dispatcher.consumeGETRequest(
                 request = getEndpoint(),
-                onSuccess = { rawContent ->
-                    val result = jsonParser.decodeFromString(
-                        deserializer = SerializableFeaturesDataModel.serializer(),
-                        string = rawContent
-                    )
-                    success.invoke(result.gbDeserialize())
-                },
-                onError = { apiTimeError ->
-                    apiTimeError.also(failure)
-                })
+                onSuccess = onSuccess,
+                onError = onError
+            )
         }
     }
 

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -11,6 +11,7 @@ import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
 import com.sdk.growthbook.serializable_model.gbDeserialize
 import com.sdk.growthbook.utils.FeatureRefreshStrategy
 import com.sdk.growthbook.utils.GBFeatures
+import com.sdk.growthbook.utils.GBFetchOutcome
 import com.sdk.growthbook.utils.GBFetchStats
 import com.sdk.growthbook.utils.GBFetchStatsHandler
 import com.sdk.growthbook.utils.GBRemoteEvalParams
@@ -58,24 +59,42 @@ internal class FeaturesDataSource(
     ) {
         val startedAt = TimeSource.Monotonic.markNow()
         // Reported before parsing, so the duration is the fetch and not the SDK's own decode work.
-        fun report(ok: Boolean, bytes: Int?) = onFetchStats?.invoke(
-            GBFetchStats(
-                success = ok,
-                durationMillis = startedAt.elapsedNow().inWholeMilliseconds,
-                payloadBytes = bytes,
-            )
-        )
+        // A throwing handler must not take the fetch down with it — its payload is telemetry.
+        fun report(outcome: GBFetchOutcome, bytes: Int?) {
+            val handler = onFetchStats ?: return
+            try {
+                handler.invoke(
+                    GBFetchStats(
+                        outcome = outcome,
+                        durationMillis = startedAt.elapsedNow().inWholeMilliseconds,
+                        payloadBytes = bytes,
+                    )
+                )
+            } catch (t: Throwable) {
+                GB.warning("fetch stats handler failed: $t")
+            }
+        }
 
-        val onSuccess: (String) -> Unit = { rawContent ->
-            report(ok = true, bytes = rawContent.encodeToByteArray().size)
-            val result = jsonParser.decodeFromString(
-                deserializer = SerializableFeaturesDataModel.serializer(),
-                string = rawContent
-            )
+        val onSuccess: (String) -> Unit = onSuccess@{ rawContent ->
+            // encodeToByteArray() copies the whole payload — only measure when someone is listening.
+            if (onFetchStats != null) {
+                report(GBFetchOutcome.Success, bytes = rawContent.encodeToByteArray().size)
+            }
+            // A malformed body must reach `failure`, not escape the dispatcher's callback
+            // (the OkHttp dispatcher invokes onSuccess outside any try). Mirrors autoRefreshRaw().
+            val result = try {
+                jsonParser.decodeFromString(
+                    deserializer = SerializableFeaturesDataModel.serializer(),
+                    string = rawContent
+                )
+            } catch (e: Exception) {
+                failure(e)
+                return@onSuccess
+            }
             success.invoke(result.gbDeserialize())
         }
         val onError: (Throwable) -> Unit = { apiTimeError ->
-            report(ok = false, bytes = null)
+            report(GBFetchOutcome.Failed, bytes = null)
             apiTimeError.also(failure)
         }
 
@@ -85,7 +104,7 @@ internal class FeaturesDataSource(
                 onSuccess = onSuccess,
                 onError = onError,
                 onNotModified = {
-                    report(ok = true, bytes = 0)
+                    report(GBFetchOutcome.NotModified, bytes = 0)
                     onNotModified()
                 }
             )
@@ -172,11 +191,18 @@ internal class FeaturesDataSource(
         dispatcher.consumePOSTRequest(
             url = getEndpoint(FeatureRefreshStrategy.SERVER_SENT_REMOTE_FEATURE_EVAL),
             bodyParams = payload,
-            onSuccess = { rawContent ->
-                val featureDataModel = jsonParser.decodeFromString(
-                    deserializer = SerializableFeaturesDataModel.serializer(),
-                    string = rawContent
-                )
+            onSuccess = onSuccess@{ rawContent ->
+                // Same guarded decode as fetchFeatures: a malformed body must reach `failure`,
+                // not escape the dispatcher's callback.
+                val featureDataModel = try {
+                    jsonParser.decodeFromString(
+                        deserializer = SerializableFeaturesDataModel.serializer(),
+                        string = rawContent
+                    )
+                } catch (e: Exception) {
+                    failure(Resource.Error(e))
+                    return@onSuccess
+                }
                 success.invoke(
                     Resource.Success(
                         featureDataModel.gbDeserialize()

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
@@ -60,6 +60,26 @@ typealias GBCacheRefreshHandler = (Boolean, GBError?) -> Unit
 typealias GBFeaturesChangeHandler = (GBFeaturesDiff) -> Unit
 
 /**
+ * Timing and size of a single feature fetch. Reported before the payload is parsed, so the
+ * numbers describe the network round trip rather than the SDK's own work.
+ */
+data class GBFetchStats(
+    val success: Boolean,
+    val durationMillis: Long,
+    /**
+     * Payload size as received, after any transport decompression — the decoded size, not the
+     * compressed bytes on the wire. 0 for a 304, null when the fetch failed.
+     */
+    val payloadBytes: Int?,
+)
+
+/**
+ * Handler for per-fetch timing. Use it to track how long the initial feature fetch actually
+ * takes on real devices, which no server-side measurement can see.
+ */
+typealias GBFetchStatsHandler = (GBFetchStats) -> Unit
+
+/**
  * Triple Tuple for GrowthBook Namespaces
  * It has ID, StartRange & EndRange
  */

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/Constants.kt
@@ -60,11 +60,22 @@ typealias GBCacheRefreshHandler = (Boolean, GBError?) -> Unit
 typealias GBFeaturesChangeHandler = (GBFeaturesDiff) -> Unit
 
 /**
+ * How a single feature fetch ended. [NotModified] is its own outcome rather than a success
+ * with zero bytes: most fetches after the first are 304s, and anyone computing throughput
+ * from payloadBytes / durationMillis needs to be able to filter them out of the average.
+ */
+enum class GBFetchOutcome {
+    Success,
+    Failed,
+    NotModified,
+}
+
+/**
  * Timing and size of a single feature fetch. Reported before the payload is parsed, so the
  * numbers describe the network round trip rather than the SDK's own work.
  */
 data class GBFetchStats(
-    val success: Boolean,
+    val outcome: GBFetchOutcome,
     val durationMillis: Long,
     /**
      * Payload size as received, after any transport decompression — the decoded size, not the

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FetchStatsHandlerTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FetchStatsHandlerTests.kt
@@ -1,0 +1,140 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.model.GBExperiment
+import com.sdk.growthbook.model.GBExperimentResult
+import com.sdk.growthbook.network.NetworkDispatcher
+import com.sdk.growthbook.sandbox.CachingJvm
+import com.sdk.growthbook.utils.GBFetchStats
+import com.sdk.growthbook.utils.Resource
+import com.sdk.growthbook.utils.SSEConnectionController
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers [GBSDKBuilder.setFetchStatsHandler]: per-fetch duration and payload size, which only
+ * the client can measure because the edge completes a response before the device receives it.
+ */
+class FetchStatsHandlerTests {
+
+    private val payload = """{"status":200,"features":{"f1":{"defaultValue":true}}}"""
+
+    @Rule
+    @JvmField
+    var tempFolder = TemporaryFolder()
+
+    // Cache reads happen even when writes are disabled, so point them at an empty dir per test;
+    // otherwise a payload left by an earlier run could satisfy the fetch and report no stats.
+    @BeforeTest
+    fun setUp() {
+        CachingJvm.baseDir = tempFolder.newFolder()
+    }
+
+    /** Not a NetworkDispatcherWithNotModified, so the plain GET path is exercised too. */
+    private class PlainGetDispatcher(private val response: String) : NetworkDispatcher {
+        override fun consumeGETRequest(
+            request: String,
+            onSuccess: (String) -> Unit,
+            onError: (Throwable) -> Unit
+        ): Job {
+            onSuccess(response)
+            return Job()
+        }
+
+        override fun consumeSSEConnection(
+            url: String,
+            sseController: SSEConnectionController?
+        ): Flow<Resource<String>> = emptyFlow()
+
+        override fun consumePOSTRequest(
+            url: String,
+            bodyParams: Map<String, Any>,
+            onSuccess: (String) -> Unit,
+            onError: (Throwable) -> Unit
+        ) = Unit
+    }
+
+    private fun TestScope.statsFrom(dispatcher: NetworkDispatcher): List<GBFetchStats> {
+        val seen = mutableListOf<GBFetchStats>()
+        GBSDKBuilder(
+            "test-key",
+            "https://cdn.growthbook.io",
+            attributes = emptyMap(),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = dispatcher,
+            cachingEnabled = false,
+        )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .setFetchStatsHandler { seen.add(it) }
+            .initialize()
+        return seen
+    }
+
+    @Test
+    fun successfulFetch_reportsDurationAndDecodedSize() = runTest {
+        val stats = statsFrom(MockNetworkClient(payload, null))
+
+        assertEquals(1, stats.size)
+        assertTrue(stats[0].success)
+        assertEquals(payload.encodeToByteArray().size, stats[0].payloadBytes)
+        assertTrue(stats[0].durationMillis >= 0)
+    }
+
+    @Test
+    fun failedFetch_reportsFailureWithNoSize() = runTest {
+        val stats = statsFrom(MockNetworkClient(null, Exception("network down")))
+
+        assertEquals(1, stats.size)
+        assertFalse(stats[0].success)
+        assertNull(stats[0].payloadBytes)
+    }
+
+    @Test
+    fun notModified_reportsSuccessWithZeroSize() = runTest {
+        val stats = statsFrom(MockNetworkClient(null, null, notModified = true))
+
+        assertEquals(1, stats.size)
+        assertTrue(stats[0].success)
+        assertEquals(0, stats[0].payloadBytes)
+    }
+
+    @Test
+    fun plainGetDispatcher_isAlsoReported() = runTest {
+        val stats = statsFrom(PlainGetDispatcher(payload))
+
+        assertEquals(1, stats.size)
+        assertTrue(stats[0].success)
+        assertEquals(payload.encodeToByteArray().size, stats[0].payloadBytes)
+    }
+
+    @Test
+    fun noHandlerSet_fetchStillSucceeds() = runTest {
+        val sdk = GBSDKBuilder(
+            "test-key",
+            "https://cdn.growthbook.io",
+            attributes = emptyMap(),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(payload, null),
+            cachingEnabled = false,
+        )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .initialize()
+
+        assertNotNull(sdk.getFeatures()["f1"])
+    }
+}

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FetchStatsHandlerTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/FetchStatsHandlerTests.kt
@@ -5,6 +5,7 @@ import com.sdk.growthbook.model.GBExperiment
 import com.sdk.growthbook.model.GBExperimentResult
 import com.sdk.growthbook.network.NetworkDispatcher
 import com.sdk.growthbook.sandbox.CachingJvm
+import com.sdk.growthbook.utils.GBFetchOutcome
 import com.sdk.growthbook.utils.GBFetchStats
 import com.sdk.growthbook.utils.Resource
 import com.sdk.growthbook.utils.SSEConnectionController
@@ -19,7 +20,6 @@ import org.junit.rules.TemporaryFolder
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -89,7 +89,7 @@ class FetchStatsHandlerTests {
         val stats = statsFrom(MockNetworkClient(payload, null))
 
         assertEquals(1, stats.size)
-        assertTrue(stats[0].success)
+        assertEquals(GBFetchOutcome.Success, stats[0].outcome)
         assertEquals(payload.encodeToByteArray().size, stats[0].payloadBytes)
         assertTrue(stats[0].durationMillis >= 0)
     }
@@ -99,16 +99,16 @@ class FetchStatsHandlerTests {
         val stats = statsFrom(MockNetworkClient(null, Exception("network down")))
 
         assertEquals(1, stats.size)
-        assertFalse(stats[0].success)
+        assertEquals(GBFetchOutcome.Failed, stats[0].outcome)
         assertNull(stats[0].payloadBytes)
     }
 
     @Test
-    fun notModified_reportsSuccessWithZeroSize() = runTest {
+    fun notModified_reportsItsOwnOutcomeWithZeroSize() = runTest {
         val stats = statsFrom(MockNetworkClient(null, null, notModified = true))
 
         assertEquals(1, stats.size)
-        assertTrue(stats[0].success)
+        assertEquals(GBFetchOutcome.NotModified, stats[0].outcome)
         assertEquals(0, stats[0].payloadBytes)
     }
 
@@ -117,8 +117,51 @@ class FetchStatsHandlerTests {
         val stats = statsFrom(PlainGetDispatcher(payload))
 
         assertEquals(1, stats.size)
-        assertTrue(stats[0].success)
+        assertEquals(GBFetchOutcome.Success, stats[0].outcome)
         assertEquals(payload.encodeToByteArray().size, stats[0].payloadBytes)
+    }
+
+    @Test
+    fun throwingHandler_doesNotDropTheFeatures() = runTest {
+        val sdk = GBSDKBuilder(
+            "test-key",
+            "https://cdn.growthbook.io",
+            attributes = emptyMap(),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient(payload, null),
+            cachingEnabled = false,
+        )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .setFetchStatsHandler { throw IllegalStateException("analytics pipeline broke") }
+            .initialize()
+
+        assertNotNull(sdk.getFeatures()["f1"])
+    }
+
+    @Test
+    fun malformedBody_reportsSuccessStatsButFailsTheRefresh() = runTest {
+        val seen = mutableListOf<GBFetchStats>()
+        var refreshedOk: Boolean? = null
+        GBSDKBuilder(
+            "test-key",
+            "https://cdn.growthbook.io",
+            attributes = emptyMap(),
+            encryptionKey = null,
+            trackingCallback = { _: GBExperiment, _: GBExperimentResult? -> },
+            networkDispatcher = MockNetworkClient("not json at all", null),
+            cachingEnabled = false,
+        )
+            .setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .setFetchStatsHandler { seen.add(it) }
+            .setRefreshHandler { isRefreshed, _ -> refreshedOk = isRefreshed }
+            .initialize()
+
+        // Stats describe the network round trip, which did succeed; the decode failure
+        // then surfaces through the refresh handler instead of escaping the callback.
+        assertEquals(1, seen.size)
+        assertEquals(GBFetchOutcome.Success, seen[0].outcome)
+        assertEquals(false, refreshedOk)
     }
 
     @Test


### PR DESCRIPTION
### Features and Changes

`setRefreshHandler` only reports whether a fetch succeeded, so measuring how long the initial fetch takes on a real device means wrapping the network dispatcher yourself. It can't be measured server-side either: a CDN buffers a response this size and logs the request complete when the body is handed off, before the device has received it.

`setFetchStatsHandler` reports `GBFetchStats(success, durationMillis, payloadBytes)` once per fetch, measured around the GET and emitted before parsing so the duration covers the network round trip rather than our own decode work. With the payload size alongside it, that's the throughput figure that separates a slow network from a large payload.

`payloadBytes` is the decoded size after transport decompression rather than the compressed bytes on the wire, since only the HTTP client knows that and surfacing it would mean changing the public `NetworkDispatcher` interface. `GBCacheRefreshHandler` is untouched and the new constructor parameter sits on the internal constructor only, so binary compatibility holds.

### Testing

- [x] Successful fetch -> `success = true` with `payloadBytes` matching the response
- [x] Failed fetch -> `success = false` and `payloadBytes = null`
- [x] 304 -> `success = true` and `payloadBytes = 0`
- [x] Dispatcher without 304 support -> still reported
- [x] No handler set -> fetch unaffected
