### PR TITLE
feat: reactive feature streams (featuresStateFlow / featureFlow) + refreshCacheSuspend (8.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [8.0.0] - Unreleased
+## [8.1.0] - Unreleased
+
+### Added
+- Reactive feature-observation API. `GrowthBookSDK.featuresStateFlow: StateFlow<GBFeatures>` exposes
+  the current feature map as a coroutine flow, and `GrowthBookSDK.featureFlow(id): Flow<GBFeatureResult>`
+  streams a single feature's evaluated result (de-duplicated via `distinctUntilChanged`). Both derive
+  from a single observable state snapshot on the context, so they can never diverge from the evaluated
+  state under concurrent writers. `featuresStateFlow` emits on every feature change — network fetch,
+  disk cache, `setInitialFeatures` seed, `setEncryptedFeatures`, and SSE. `featureFlow(id)`
+  re-evaluates on any change that can affect the result — feature definitions **and** attributes,
+  attribute overrides, forced features and saved groups — and its reactive re-evaluations use a fully
+  silent evaluation: they fire **neither** the `featureUsageCallback` **nor** the experiment
+  `trackingCallback`, do not notify registered `GrowthBookPlugin`s (so the built-in tracking plugin
+  sends nothing), and do not touch the tracking-dedup state. Observing a feature via the flow
+  therefore inflates neither usage analytics nor experiment exposures — only explicit `feature()`
+  access reports usage and fires exposures. Both are `@HiddenFromObjC` (Kotlin `Flow` has no native Objective-C
+  representation); Apple consumers read `getFeatures()` or bridge via SKIE.
+- `GrowthBookSDK.refreshCacheSuspend(): Boolean` — coroutine variant of `refreshCache()` that awaits
+  the network round and returns `true` on success. A 304 Not Modified counts as success only when a
+  payload has already been loaded (cached payload stays valid); a 304 before any payload exists returns
+  `false`, as does a failed round. In remote-eval mode it issues the personalized remote-eval POST
+  (same path as `suspendFeature()`), so it never surfaces non-personalized definitions.
+
+---
+## [8.0.0] - 2026-09-09
 
 ### Added
 - **Contextual bandits.** The SDK now understands contextual bandit rules and their definitions in the features payload

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "8.0.0"
+version = "8.1.0"
 
 val generateSdkMeta by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated/sdk-meta/commonMain/kotlin")

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GrowthBookSDK.kt
@@ -45,6 +45,14 @@ import com.sdk.growthbook.sandbox.GBCachingLayer
 import com.sdk.growthbook.sandbox.GBCachingLayerAdapter
 import com.sdk.growthbook.utils.GBUtils.Companion.refreshStickyBuckets
 import com.sdk.growthbook.model.diffFeatures
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
@@ -135,6 +143,28 @@ class GrowthBookSDK internal constructor(
     private var hasFeaturesPayload: Boolean = gbContext.features.isNotEmpty()
     var pluginRegistry: PluginRegistry? = null
 
+    // Scope backing the reactive StateFlows ([featuresStateFlow]). Independent of the payload
+    // pipeline scope (own SupervisorJob) and cancelled in [close].
+    private val reactiveScope: CoroutineScope = CoroutineScope(coroutineContext + SupervisorJob())
+
+    /**
+     * Reactive stream of the full feature map. Emits the current snapshot on
+     * subscription and a new value every time features are replaced — from a network
+     * fetch, disk cache, [GBSDKBuilder.setInitialFeatures] seed, [setEncryptedFeatures], or SSE
+     * auto-refresh. Backed by a [StateFlow], so [StateFlow.value] is always the
+     * currently loaded map (the same value [getFeatures] returns).
+     *
+     * Hidden from Objective-C/Swift: Kotlin Flow has no native ObjC representation.
+     * Apple consumers should read [getFeatures] or bridge the flow via SKIE.
+     */
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
+    val featuresStateFlow: StateFlow<GBFeatures> =
+        gbContext.snapshotFlow
+            .map { it.features }
+            .distinctUntilChanged()
+            .stateIn(reactiveScope, SharingStarted.Eagerly, gbContext.evalSnapshot().features)
+
     /**
      * JAVA Consumers preset Features
      * SDK will not call API to fetch Features List
@@ -188,6 +218,60 @@ class GrowthBookSDK internal constructor(
             featuresViewModel.revalidate()
         }
     }
+
+    /**
+     * Suspend variant of [refreshCache]: awaits the coalesced network refresh
+     * (payload applied + sticky buckets refreshed) and reports whether features
+     * are usable afterwards.
+     *
+     * @return true if the refresh succeeded. A 304 Not Modified counts as success only when a feature
+     * payload has already been loaded (the cached payload stays valid); a 304 received before any
+     * payload exists returns false, mirroring [featuresNotModified]. Returns false when the network
+     * round failed.
+     *
+     * In remote-eval mode the underlying refresh issues the personalized remote-eval
+     * POST (see [FeaturesViewModel.awaitRefresh]), the same path [suspendFeature] uses,
+     * so it does not surface non-personalized definitions. A round repeatedly superseded by newer
+     * remote-eval generations is re-joined up to [MAX_SUPERSEDED_ROUNDS] times before returning.
+     */
+    suspend fun refreshCacheSuspend(): Boolean {
+        var superseded = 0
+        while (true) {
+            return when (featuresViewModel.awaitRefresh()) {
+                FetchResult.Success -> true
+                // A 304 only means "usable" if a payload was already loaded. A 304 received before
+                // any payload exists is treated as a failure (mirrors featuresNotModified()), so the
+                // caller retries instead of being told empty features are ready.
+                FetchResult.NotModified -> hasFeaturesPayload
+                FetchResult.Failed -> false
+                FetchResult.Superseded ->
+                    if (++superseded > MAX_SUPERSEDED_ROUNDS) hasFeaturesPayload
+                    else continue
+            }
+        }
+    }
+
+    /**
+     * Reactive stream of a single feature's evaluated [GBFeatureResult]. Re-evaluates whenever any
+     * evaluation input changes — features, attributes, attribute overrides, forced features/variations
+     * or saved groups (it observes the full state snapshot, not just the feature map) — and only
+     * forwards distinct results.
+     *
+     * The reactive re-evaluations pass through a fully silent evaluation: they fire neither the
+     * `featureUsageCallback` nor the experiment `trackingCallback`, do not notify registered
+     * [com.sdk.growthbook.plugin.tracking.GrowthBookPlugin]s (so the built-in tracking plugin sends
+     * nothing), and do not touch the shared tracking-dedup state — observing a feature via the flow
+     * inflates neither usage analytics nor experiment exposures. Only explicit [feature] access
+     * reports usage and fires exposures.
+     *
+     * Hidden from Objective-C/Swift for the same reason as [featuresStateFlow].
+     */
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
+    fun featureFlow(id: String): Flow<GBFeatureResult> =
+        gbContext.snapshotFlow
+            .map { evaluateFeature(id, true) }
+            .distinctUntilChanged()
 
     /**
      * Get Context - Holding the complete data regarding cached features & attributes etc.
@@ -263,6 +347,7 @@ class GrowthBookSDK internal constructor(
     fun close() {
         pluginRegistry?.closeAll()
         featuresViewModel.close()
+        reactiveScope.cancel()
     }
 
     /**
@@ -400,6 +485,7 @@ class GrowthBookSDK internal constructor(
             maxAttempts = MAX_RETRY_ATTEMPTS,
         )
         var attempt = 0
+        var superseded = 0
 
         while (true) {
             when (remoteSourceFeaturesFetchResult) {
@@ -415,7 +501,10 @@ class GrowthBookSDK internal constructor(
                     // A superseded round is not a failure (nothing went wrong, its payload was just
                     // discarded by a newer generation): re-join the latest generation without burning
                     // a retry attempt or applying backoff.
-                    if (featuresViewModel.awaitRefresh() == FetchResult.Superseded) continue
+                    if (featuresViewModel.awaitRefresh() == FetchResult.Superseded) {
+                        if (++superseded > MAX_SUPERSEDED_ROUNDS) return feature(id)
+                        else continue
+                    }
                     if (remoteSourceFeaturesFetchResult != FeaturesFetchResult.Failed) continue
                     val delaysMs = backOff.delayFor(attempt)
                     if (gbContext.enableLogging) {
@@ -442,13 +531,17 @@ class GrowthBookSDK internal constructor(
     override fun feature(id: String): GBFeatureResult {
         // Single atomic snapshot for every evaluation input (attributes, forced features/variations,
         // attribute overrides, sticky docs), so a concurrent setter can't yield a torn mix.
-        val snapshot = gbContext.evalSnapshot()
-        val evalContext = createEvaluationContext(snapshot)
-        val evaluator = GBFeatureEvaluator(evalContext, snapshot.forcedFeatures)
-        val result = evaluator.evaluateFeature(featureKey = id, attributeOverrides = snapshot.attributeOverrides)
+        val result = evaluateFeature(id, false)
         // Newly-generated sticky assignments are merged into the context per-key during evaluation
         // (see EvaluationContext.onStickyAssignmentChanged) — no whole-map write-back needed here.
         return result
+    }
+
+    private fun evaluateFeature(id: String, silent: Boolean): GBFeatureResult {
+        val snapshot = gbContext.evalSnapshot()
+        val evalContext = createEvaluationContext(snapshot, silent)
+        val evaluator = GBFeatureEvaluator(evalContext, snapshot.forcedFeatures)
+        return evaluator.evaluateFeature(featureKey = id, attributeOverrides = snapshot.attributeOverrides)
     }
 
     /**
@@ -768,8 +861,27 @@ class GrowthBookSDK internal constructor(
         NoResultYet, Success, Failed
     }
 
-    private fun createEvaluationContext(snapshot: EvalSnapshot = gbContext.evalSnapshot()) =
-        createEvaluationContext(gbContext, gbExperimentHelper, snapshot, pluginRegistry)
+    private fun createEvaluationContext(
+        snapshot: EvalSnapshot = gbContext.evalSnapshot(),
+        silent: Boolean = false
+    ) = createEvaluationContext(
+        gbContext,
+        // A silent (reactive) evaluation must not touch the shared tracking-dedup state:
+        // GBExperimentHelper.isTracked() marks the experiment as tracked as a side effect, which
+        // would suppress the real exposure on a later feature()/run() call. Give silent evals a
+        // throwaway helper so the shared one stays clean (paired with the no-op trackingCallback
+        // below, which keeps the silent pass from firing anything).
+        if (silent) GBExperimentHelper() else gbExperimentHelper,
+        snapshot,
+        // Plugins are muted for a silent evaluation too, not just the callbacks: the evaluators fire
+        // pluginRegistry.fireFeatureEvaluated/fireExperimentViewed right next to onFeatureUsage /
+        // trackingCallback, so leaving the registry in place would let the built-in tracking plugin
+        // POST an exposure for every reactive re-evaluation. Worse than the callback case: the
+        // exposure fire is gated by GBExperimentHelper.isTracked(), and the throwaway helper above is
+        // empty on every pass, so the dedup would never suppress anything.
+        if (silent) null else pluginRegistry,
+        silent
+    )
 
     //@ThreadLocal
     internal companion object {
@@ -779,6 +891,7 @@ class GrowthBookSDK internal constructor(
         private const val INITIAL_RETRY_DELAY_MILLIS = 1000L
         private const val MAX_RETRY_DELAY_MILLIS = 60_000L
         private const val MAX_RETRY_ATTEMPTS = 5
+        private const val MAX_SUPERSEDED_ROUNDS = 5
 
         private fun createEvaluationContext(
             gbContext: GBContext,
@@ -788,7 +901,8 @@ class GrowthBookSDK internal constructor(
             // snapshot, so the evaluation can never observe a torn mix (e.g. new features with stale
             // sticky docs, or new attributes with old overrides). Callers pass the snapshot they read.
             snapshot: EvalSnapshot,
-            pluginRegistry: PluginRegistry?
+            pluginRegistry: PluginRegistry?,
+            silent: Boolean
         ): EvaluationContext {
             return EvaluationContext(
                 enabled = gbContext.enabled,
@@ -796,9 +910,9 @@ class GrowthBookSDK internal constructor(
                 savedGroups = snapshot.savedGroups,
                 gbExperimentHelper = gbExperimentHelper,
                 loggingEnabled = gbContext.enableLogging,
-                onFeatureUsage = gbContext.onFeatureUsage,
+                onFeatureUsage = if (silent) null else gbContext.onFeatureUsage,
                 forcedVariations = snapshot.forcedVariations,
-                trackingCallback = gbContext.trackingCallback,
+                trackingCallback = if (silent) { _, _ -> } else gbContext.trackingCallback,
                 stickyBucketService = gbContext.stickyBucketService,
                 userContext = UserContext(
                     qaMode = gbContext.qaMode,
@@ -812,7 +926,7 @@ class GrowthBookSDK internal constructor(
                     gbContext.mergeStickyAssignmentDoc(key, doc)
                 },
                 stackContext = StackContext(null, mutableSetOf()),
-                pluginRegistry = pluginRegistry,
+                pluginRegistry = if (silent) null else pluginRegistry,
                 contextualBandits = snapshot.contextualBandits
             )
         }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBContext.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalAtomicApi::class)
-
 package com.sdk.growthbook.model
 
 import com.sdk.growthbook.GBTrackingCallback
@@ -8,8 +6,10 @@ import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBStickyAssignmentsDocument
 import com.sdk.growthbook.utils.GBStickyAttributeKey
 import com.sdk.growthbook.stickybucket.GBStickyBucketService
-import kotlin.concurrent.atomics.AtomicReference
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 internal typealias FeatureUsageFuncCallback = (String, GBFeatureResult) -> Unit
 internal typealias StickyBucketAssignmentDocsType = Map<GBStickyAttributeKey, GBStickyAssignmentsDocument>
@@ -19,7 +19,7 @@ internal typealias StickyBucketAssignmentDocsType = Map<GBStickyAttributeKey, GB
  *
  * These fields are written by the background payload pipeline (network fetch + sticky-bucket refresh)
  * and read synchronously by feature()/run(). They are published together as a single immutable value
- * behind an AtomicReference, so any reader observes a fully consistent set — there is no window where,
+ * behind a MutableStateFlow, so any reader observes a fully consistent set — there is no window where,
  * e.g., new [features] are visible while [stickyBucketAssignmentDocs] are still stale.
  */
 internal data class EvalSnapshot(
@@ -38,10 +38,12 @@ internal data class EvalSnapshot(
  * Defines the GrowthBook context.
  *
  * The cross-thread-shared evaluation inputs (features, attributes, forced variations, sticky-bucket
- * state, saved groups) are kept in a single [EvalSnapshot] behind an [AtomicReference]. Reads return
- * the current snapshot; writes atomically swap in a copy with the changed field (CAS loop, so
- * concurrent writers never lose each other's updates). For a consistent multi-field read during
- * evaluation, use [evalSnapshot] rather than reading the individual properties one by one.
+ * state, saved groups) are kept in a single [EvalSnapshot] behind a
+ * [kotlinx.coroutines.flow.MutableStateFlow]. Reads return the current snapshot; writes atomically
+ * swap in a copy with the changed field (via [kotlinx.coroutines.flow.update]'s CAS loop, so
+ * concurrent writers never lose each other's updates) and publish it to observers. For a consistent
+ * multi-field read during evaluation, use [evalSnapshot] rather than reading the individual
+ * properties one by one.
  *
  * SDK-owned: assembled by [com.sdk.growthbook.GBSDKBuilder], never by consumer code — which is why
  * the constructor is internal. The type itself stays public because [com.sdk.growthbook.GrowthBookSDK.getGBContext]
@@ -134,7 +136,7 @@ class GBContext internal constructor(
 ) {
 
     // Single source of truth for all cross-thread-shared evaluation inputs.
-    private val state = AtomicReference(
+    private val state = MutableStateFlow(
         EvalSnapshot(
             attributes = attributes,
             forcedVariations = forcedVariations,
@@ -143,39 +145,38 @@ class GBContext internal constructor(
             savedGroups = savedGroups
         )
     )
+    // Single observable source of truth for evaluation inputs. Reactive consumers (featuresStateFlow,
+    // featureFlow) derive from this snapshot, so they react to ANY input change — features, attributes,
+    // overrides, forced values, saved groups — and can never diverge from the committed state.
+    internal val snapshotFlow: StateFlow<EvalSnapshot> = state.asStateFlow()
 
     /**
      * Atomically read the full evaluation-input snapshot. Evaluation must use this (one read) instead
      * of reading the individual properties separately, so it operates on a single consistent state.
      */
-    internal fun evalSnapshot(): EvalSnapshot = state.load()
+    internal fun evalSnapshot(): EvalSnapshot = state.value
 
-    private fun mutate(transform: (EvalSnapshot) -> EvalSnapshot) {
-        while (true) {
-            val current = state.load()
-            if (state.compareAndSet(current, transform(current))) return
-        }
-    }
+    private fun mutate(transform: (EvalSnapshot) -> EvalSnapshot) = state.update(transform)
 
     /**
      * Map of user attributes that are used to assign variations
      */
     internal var attributes: Map<String, GBValue>
-        get() = state.load().attributes
+        get() = state.value.attributes
         set(value) = mutate { it.copy(attributes = value) }
 
     /**
      * Force specific experiments to always assign a specific variation (used for QA)
      */
     var forcedVariations: Map<String, Number>
-        get() = state.load().forcedVariations
+        get() = state.value.forcedVariations
         set(value) = mutate { it.copy(forcedVariations = value) }
 
     /**
      * Map of Sticky Bucket documents
      */
     var stickyBucketAssignmentDocs: StickyBucketAssignmentDocsType?
-        get() = state.load().stickyBucketAssignmentDocs
+        get() = state.value.stickyBucketAssignmentDocs
         set(value) = mutate { it.copy(stickyBucketAssignmentDocs = value) }
 
     /**
@@ -252,7 +253,7 @@ class GBContext internal constructor(
      * no happens-before guarantee).
      */
     internal var forcedFeatures: Map<String, GBValue>
-        get() = state.load().forcedFeatures
+        get() = state.value.forcedFeatures
         set(value) = mutate { it.copy(forcedFeatures = value) }
 
     /**
@@ -260,27 +261,27 @@ class GBContext internal constructor(
      * evaluation inputs (previously a plain field on GrowthBookSDK with no happens-before guarantee).
      */
     internal var attributeOverrides: Map<String, GBValue>
-        get() = state.load().attributeOverrides
+        get() = state.value.attributeOverrides
         set(value) = mutate { it.copy(attributeOverrides = value) }
 
     /**
      * List of user's attributes keys
      */
     var stickyBucketIdentifierAttributes: List<String>?
-        get() = state.load().stickyBucketIdentifierAttributes
+        get() = state.value.stickyBucketIdentifierAttributes
         set(value) = mutate { it.copy(stickyBucketIdentifierAttributes = value) }
 
     /**
      * Saved groups used by feature/experiment conditions
      */
     var savedGroups: Map<String, GBValue>?
-        get() = state.load().savedGroups
+        get() = state.value.savedGroups
         set(value) = mutate { it.copy(savedGroups = value) }
 
     // Keys are unique identifiers for the features and the values are Feature objects.
     // Feature definitions - To be pulled from API / Cache.
     internal var features: GBFeatures
-        get() = state.load().features
+        get() = state.value.features
         set(value) = mutate { it.copy(features = value) }
 
     /**
@@ -290,7 +291,7 @@ class GBContext internal constructor(
      * pipeline, read atomically via [evalSnapshot] during evaluation.
      */
     internal var contextualBandits: Map<String, GBContextualBandit>?
-        get() = state.load().contextualBandits
+        get() = state.value.contextualBandits
         set(value) = mutate { it.copy(contextualBandits = value) }
 }
 

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKReactiveTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/GrowthBookSDKReactiveTests.kt
@@ -1,0 +1,330 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.model.GBExperiment
+import com.sdk.growthbook.model.GBExperimentResult
+import com.sdk.growthbook.model.GBFeatureResult
+import com.sdk.growthbook.model.GBString
+import com.sdk.growthbook.model.GBValue
+import com.sdk.growthbook.plugin.tracking.GrowthBookPlugin
+import com.sdk.growthbook.utils.encryptToFeaturesDataModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GrowthBookSDKReactiveTests {
+    private val apiKey = "key"
+    private val hostURL = "https://example.com"
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun builder(client: MockNetworkClient, scheduler: TestCoroutineScheduler) =
+        GBSDKBuilder(
+            apiKey = apiKey,
+            apiHost = hostURL,
+            attributes = HashMap<String, GBValue>(),
+            trackingCallback = { _, _ -> },
+            networkDispatcher = client,
+            cachingEnabled = false,
+        ).setCoroutineContext(UnconfinedTestDispatcher(scheduler))
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featuresStateFlowReflectsFetchedPayload() = runTest {
+        val sdk = builder(
+            MockNetworkClient(MockResponse.successResponse, null),
+            testScheduler
+        ).initialize()
+        runCurrent()
+
+        val features = sdk.featuresStateFlow.value
+        assertTrue(features.contains("onboarding"))
+        assertTrue(features.contains("qrscanpayment"))
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featuresStateFlowKeepsSeedOnNetworkFailure() = runTest {
+        val seed = encryptToFeaturesDataModel("""{"seedflag":{"defaultValue":true}}""")
+        val sdk = builder(
+            client = MockNetworkClient(
+                successResponse = null,
+                error = RuntimeException("boom")
+            ), scheduler = testScheduler
+        )
+            .setInitialFeatures(seed!!)
+            .initialize()
+        runCurrent()
+
+        assertTrue(sdk.featuresStateFlow.value.contains("seedflag"))
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featuresStateFlowNetworkOverridesSeed() = runTest {
+        val seed = encryptToFeaturesDataModel("""{"seedflag":{"defaultValue":true}}""")!!
+        val sdk = builder(MockNetworkClient(MockResponse.successResponse, null), testScheduler)
+            .setInitialFeatures(seed)
+            .initialize()
+        runCurrent()
+
+        val features = sdk.featuresStateFlow.value
+        assertTrue(features.containsKey("onboarding"))
+        assertFalse(features.containsKey("seedflag"))
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun setEncryptedFeaturesEmitsToFlow() = runTest {
+        val sdk = builder(MockNetworkClient(null, null), testScheduler).initialize()
+        runCurrent()
+        assertFalse(sdk.featuresStateFlow.value.containsKey("testfeature1"))
+
+        sdk.setEncryptedFeatures(
+            "vMSg2Bj/IurObDsWVmvkUg==.L6qtQkIzKDoE2Dix6IAKDcVel8PHUnzJ7JjmLjFZFQDqidRIoCxKmvxvUj2kTuHFTQ3/NJ3D6XhxhXXv2+dsXpw5woQf0eAgqrcxHrbtFORs18tRXRZza7zqgzwvcznx",
+            "Ns04T5n9+59rl2x3SlNHtQ==",
+            null,
+        )
+        runCurrent()
+
+        assertTrue(sdk.featuresStateFlow.value.containsKey("testfeature1"))
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featureFlowEmitsAndDedupesIdenticalPayload() = runTest {
+        val sdk = builder(MockNetworkClient(MockResponse.successResponse, null), testScheduler)
+            .initialize()
+        runCurrent()
+
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch {
+            sdk.featureFlow("editprofile").collect { emissions.add(it.on) }
+        }
+        runCurrent()
+        val afterFirst = emissions.size
+        assertTrue(afterFirst >= 1)
+        sdk.refreshCacheSuspend()
+        runCurrent()
+        assertEquals(afterFirst, emissions.size, "identical payload must not re-emit")
+
+        job.cancel()
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun refreshCacheSuspendTrueOnSuccess() = runTest {
+        val sdk = builder(MockNetworkClient(MockResponse.successResponse, null), testScheduler)
+            .initialize()
+        runCurrent()
+        assertTrue(sdk.refreshCacheSuspend())
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun refreshCacheSuspendTrueOnNotModifiedWithLoadedPayload() = runTest {
+        // A seed makes hasFeaturesPayload true, so a subsequent 304 means the loaded payload is
+        // still valid and must be reported as success.
+        val seed = encryptToFeaturesDataModel("""{"seedflag":{"defaultValue":true}}""")!!
+        val sdk = builder(MockNetworkClient(null, null, notModified = true), testScheduler)
+            .setInitialFeatures(seed)
+            .initialize()
+        runCurrent()
+
+        assertTrue(
+            sdk.refreshCacheSuspend(),
+            "304 with a loaded payload must count as success"
+        )
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun refreshCacheSuspendFalseOnNotModifiedWithoutPayload() = runTest {
+        // No payload was ever loaded: a 304 cannot guarantee features are available, so it must be
+        // reported as a failure (mirrors featuresNotModified()) rather than a false success.
+        val sdk = builder(MockNetworkClient(null, null, notModified = true), testScheduler)
+            .initialize()
+        runCurrent()
+
+        assertFalse(
+            sdk.refreshCacheSuspend(),
+            "304 before any payload has loaded must not report success"
+        )
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun refreshCacheSuspendFalseOnFailure() = runTest {
+        val sdk = builder(MockNetworkClient(null, RuntimeException("boom")), testScheduler)
+            .initialize()
+        runCurrent()
+        assertFalse(sdk.refreshCacheSuspend())
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featureFlowReEmitsWhenAttributesChange() = runTest {
+        // "targeted" gates on attribute `country == "US"`. featureFlow must re-emit when attributes
+        // change even though the feature map itself is unchanged (regression guard for #4).
+        val features = encryptToFeaturesDataModel(
+            """{"targeted":{"defaultValue":false,"rules":[{"condition":{"country":"US"},"force":true}]}}"""
+        )!!
+        val sdk = builder(MockNetworkClient(null, null), testScheduler)
+            .setInitialFeatures(features)
+            .initialize()
+        runCurrent()
+
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch {
+            sdk.featureFlow("targeted").collect { emissions.add(it.on) }
+        }
+        runCurrent()
+        assertEquals(listOf(false), emissions, "initial emission evaluates with no matching attribute")
+
+        sdk.setAttributes(mapOf("country" to GBString("US")))
+        runCurrent()
+
+        assertEquals(
+            listOf(false, true),
+            emissions,
+            "featureFlow must re-evaluate and emit when attributes change the result"
+        )
+        job.cancel()
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featureFlowObservationDoesNotFireTrackingButFeatureDoes() = runTest {
+        // "expfeature" is backed by an experiment rule, so evaluating it buckets the user and would
+        // fire the experiment-exposure trackingCallback. featureFlow is a passive observer: its
+        // (silent) re-evaluations must NOT fire tracking, and must NOT poison the shared tracking
+        // dedup (otherwise the real exposure on feature() would be suppressed). An explicit feature()
+        // access must fire the exposure exactly once.
+        val features = encryptToFeaturesDataModel(
+            """{"expfeature":{"defaultValue":0,"rules":[{"key":"exp1","coverage":1,""" +
+                """"hashAttribute":"id","variations":[0,1],"weights":[0.5,0.5]}]}}"""
+        )!!
+        var trackCount = 0
+        val sdk = GBSDKBuilder(
+            apiKey = apiKey,
+            apiHost = hostURL,
+            attributes = hashMapOf<String, GBValue>("id" to GBString("user-1")),
+            trackingCallback = { _, _ -> trackCount++ },
+            networkDispatcher = MockNetworkClient(null, null),
+            cachingEnabled = false,
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .setInitialFeatures(features)
+            .initialize()
+        runCurrent()
+
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch {
+            sdk.featureFlow("expfeature").collect { emissions.add(it.on) }
+        }
+        runCurrent()
+
+        // Drive several reactive re-evaluations via unrelated state changes (id stays "user-1", so the
+        // assigned variation is unchanged) — none of these must fire an exposure.
+        sdk.setAttributes(mapOf("id" to GBString("user-1"), "extra" to GBString("a")))
+        runCurrent()
+        sdk.setForcedFeatures(emptyMap())
+        runCurrent()
+
+        assertTrue(emissions.isNotEmpty(), "featureFlow should have emitted at least once")
+        assertEquals(0, trackCount, "featureFlow observation must not fire experiment tracking")
+
+        // Explicit access fires the exposure once — proving the silent path did not poison the dedup.
+        sdk.feature("expfeature")
+        runCurrent()
+        assertEquals(1, trackCount, "explicit feature() access must fire the exposure exactly once")
+
+        job.cancel()
+        sdk.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun featureFlowObservationDoesNotFirePluginsButFeatureDoes() = runTest {
+        // Same contract as the trackingCallback test above, for the plugin path: the evaluators call
+        // pluginRegistry.fireFeatureEvaluated/fireExperimentViewed right next to onFeatureUsage and
+        // trackingCallback, so a silent (reactive) evaluation must mute the registry too. Otherwise
+        // the built-in tracking plugin POSTs an exposure for every featureFlow emission — and since
+        // the exposure fire is gated by GBExperimentHelper.isTracked() while a silent eval gets a
+        // fresh, empty helper, nothing would ever dedup it.
+        val features = encryptToFeaturesDataModel(
+            """{"expfeature":{"defaultValue":0,"rules":[{"key":"exp1","coverage":1,""" +
+                """"hashAttribute":"id","variations":[0,1],"weights":[0.5,0.5]}]}}"""
+        )!!
+        var evaluatedCount = 0
+        var viewedCount = 0
+        val plugin = object : GrowthBookPlugin {
+            override fun onFeatureEvaluated(
+                featureKey: String,
+                result: GBFeatureResult,
+                attributes: Map<String, GBValue>?
+            ) {
+                evaluatedCount++
+            }
+
+            override fun onExperimentViewed(
+                experiment: GBExperiment,
+                result: GBExperimentResult,
+                attributes: Map<String, GBValue>?
+            ) {
+                viewedCount++
+            }
+        }
+        val sdk = GBSDKBuilder(
+            apiKey = apiKey,
+            apiHost = hostURL,
+            attributes = hashMapOf<String, GBValue>("id" to GBString("user-1")),
+            trackingCallback = { _, _ -> },
+            networkDispatcher = MockNetworkClient(null, null),
+            cachingEnabled = false,
+        ).setCoroutineContext(UnconfinedTestDispatcher(testScheduler))
+            .setInitialFeatures(features)
+            .setPlugins(listOf(plugin))
+            .initialize()
+        runCurrent()
+
+        val emissions = mutableListOf<Boolean>()
+        val job = backgroundScope.launch {
+            sdk.featureFlow("expfeature").collect { emissions.add(it.on) }
+        }
+        runCurrent()
+
+        sdk.setAttributes(mapOf("id" to GBString("user-1"), "extra" to GBString("a")))
+        runCurrent()
+        sdk.setForcedFeatures(emptyMap())
+        runCurrent()
+
+        assertTrue(emissions.isNotEmpty(), "featureFlow should have emitted at least once")
+        assertEquals(0, evaluatedCount, "featureFlow observation must not fire onFeatureEvaluated")
+        assertEquals(0, viewedCount, "featureFlow observation must not fire onExperimentViewed")
+
+        // Explicit access still reaches the plugins, exactly once for the exposure.
+        sdk.feature("expfeature")
+        runCurrent()
+        assertEquals(1, evaluatedCount, "explicit feature() access must reach onFeatureEvaluated")
+        assertEquals(1, viewedCount, "explicit feature() access must fire the exposure exactly once")
+
+        job.cancel()
+        sdk.close()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ repositories {
 
 dependencies {
     // Add GrowthBook module:
-    implementation 'io.growthbook.sdk:GrowthBook:7.9.0'
+    implementation 'io.growthbook.sdk:GrowthBook:7.10.0'
 
     // Add Network Dispatcher you prefer:
     // 1) NetworkDispatcherKtor — supports Android, iOS, JVM, JS, Wasm
@@ -239,6 +239,42 @@ The poller is a coroutine (not a dedicated thread) on the SDK's background scope
 
 > **Mobile note:** the SDK cannot observe app lifecycle, so tie `startPolling()` / `stopPolling()` to your foreground/background transitions to avoid keeping the radio awake in the background. On mobile prefer SSE or the pull-on-access cache window (`setCacheMaxAge` / `setStaleTtl`); background polling is intended mainly for JVM/backend usage.
 
+#### Reactive feature updates (`featuresStateFlow` / `featureFlow`)
+
+Instead of polling `getFeatures()` yourself, you can observe features as a coroutine `Flow`. Both streams update on **every** feature change — network fetch, disk cache, `setInitialFeatures` seed, `setEncryptedFeatures`, and SSE.
+
+```kotlin
+// The whole feature map, as a StateFlow (current value always readable via .value):
+scope.launch {
+    sdk.featuresStateFlow.collect { features ->
+        // re-render, refresh derived state, etc.
+    }
+}
+
+// A single feature's evaluated result, de-duplicated:
+scope.launch {
+    sdk.featureFlow("new-checkout").collect { result ->
+        showNewCheckout(result.on)
+    }
+}
+```
+
+> **Reacts to every evaluation input:** `featureFlow(id)` re-evaluates whenever anything that can change the result changes — feature definitions **and** attributes, attribute overrides, forced features or saved groups — so it re-fires on its own after `setAttributes()` / `setAttributeOverrides()`.
+
+> **No analytics pollution:** the reactive re-evaluations pass through a fully silent evaluation — they fire **neither** the `featureUsageCallback` **nor** the experiment `trackingCallback`, so streaming a feature inflates neither usage analytics nor experiment exposures. Only explicit `feature(id)` access counts as usage and fires exposures.
+
+> **Apple/ObjC:** `featuresStateFlow` and `featureFlow(id)` are hidden from Objective-C/Swift (`@HiddenFromObjC`) because Kotlin `Flow` has no native ObjC representation. Apple consumers should read `getFeatures()` or bridge the flow with [SKIE](https://skie.touchlab.co/).
+
+You can also await a manual refresh instead of firing it and forgetting:
+
+```kotlin
+// Suspends until the network round completes; returns true on success. A 304 Not Modified counts
+// as success only once a payload is loaded (false if it arrives before any payload); false on a
+// failed round. In remote-eval mode it issues the personalized remote-eval POST (same path as
+// suspendFeature), so it never surfaces non-personalized definitions.
+val refreshed: Boolean = sdk.refreshCacheSuspend()
+```
+
 ## Usage
 
 - Initialization returns SDK instance - GrowthBookSDK
@@ -299,6 +335,22 @@ not of the requested type.
 
   ```kotlin
   fun refreshCache()
+  ```
+
+- refreshCacheSuspend is the coroutine variant of refreshCache: it awaits the network round and returns
+  `true` on success. A 304 Not Modified counts as success only once a payload has been loaded (the
+  cached payload stays valid); a 304 before any payload, or a failed round, returns `false`.
+
+  ```kotlin
+  suspend fun refreshCacheSuspend(): Boolean
+  ```
+
+- observe features reactively as a coroutine Flow (see the "Reactive feature updates" section above).
+  Both are hidden from Objective-C/Swift.
+
+  ```kotlin
+  val featuresStateFlow: StateFlow<GBFeatures>
+  fun featureFlow(id: String): Flow<GBFeatureResult>
   ```
 
 - use setRefreshHandler to set a callback that will be called whenever the cache is refreshed.


### PR DESCRIPTION
## Summary

Adds a coroutine-based reactive API for observing features, plus an awaitable cache refresh. Both streams derive from a single observable state snapshot on the context, so they can never diverge from the evaluated state under concurrent writers. Public API is additive only — new methods/properties, no changed or removed signatures, binary-compatible.

## New public API
  
- GrowthBookSDK.featuresStateFlow: StateFlow<GBFeatures> — the whole feature map as a StateFlow; .value is always the currently loaded map (same as `getFeatures()`). Emits on every feature change — network fetch, disk cache, setInitialFeatures seed, setEncryptedFeatures, and SSE.
- GrowthBookSDK.featureFlow(id): Flow<GBFeatureResult> — a single feature's evaluated result, de-duplicated via distinctUntilChanged. Re-evaluates on any input that can change the result — feature definitions and attributes, attribute overrides, forced features/variations, saved groups — so it re-fires on its own after setAttributes() / setAttributeOverrides().
- GrowthBookSDK.refreshCacheSuspend(): Boolean — coroutine variant of refreshCache() that awaits the network round and returns true on success. A 304 Not Modified counts as success only once a payload is loaded (false if it arrives before any payload); false on a failed round. In remote-eval mode it issues the personalized remote-eval POST (same path as `suspendFeature`), so it never surfaces non-personalized definitions.

## How it works

- GBContext`'s cross-thread evaluation snapshot moves from an `AtomicReference<EvalSnapshot> to a MutableStateFlow<EvalSnapshot>, exposed as an internal snapshotFlow. Both public streams derive from it, so a reactive observer sees exactly what feature() / run() would evaluate — no separate, drift-prone state.
- featuresStateFlow maps the snapshot to its feature map; featureFlow(id) maps each snapshot through a silent evaluation and forwards only distinct results.

## Silent evaluation (no analytics pollution)

featureFlow(id) re-evaluates on background state changes, so its re-evaluations pass through a fully silent evaluation: they fire neither the featureUsageCallback nor the experiment trackingCallback, do not notify registered GrowthBookPlugins (so the built-in tracking plugin sends nothing), and do not touch the shared tracking-dedup state. Observing a feature via the flow therefore inflates neither usage analytics nor experiment exposures — only explicit feature(id) access reports usage and fires exposures. (Sticky bucketing is left intact, so a flow result always matches what feature() would return.)

 ## Compatibility
- Additive on top of 8.0.0 — new methods and properties only, no changed or removed signatures. `featuresStateFlow` / `featureFlow(id)` are `@HiddenFromObjC`, since Kotlin `Flow` has no native Objective-C representation; Apple consumers read `getFeatures()` or bridge via SKIE. 
- Dropping `AtomicReference` also removes the file's `@OptIn(ExperimentalAtomicApi::class)`.