### PR TITLE
add configurable fetchTimeoutMillis to bound feature fetches on both dispatchers

### DIFF
--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.0] - 2026-09-08
+
+### Added
+- `fetchTimeoutMillis` constructor parameter (default 30 000 ms): a per-request total time
+  budget for feature GET and POST requests. The default client's request/socket timeouts are
+  infinite because the same client carries the SSE stream, so a stalled feature fetch could
+  previously hang forever. The bound is applied per request, so SSE is unaffected. Pass `null`
+  to opt out and keep the injected client's own configuration. On a custom client without the
+  `HttpTimeout` plugin the request bound is inert; only the socket timeout is applied by
+  engines that support it
+
+---
 ## [1.2.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG-NetworkDispatcherOkhttp.md
+++ b/CHANGELOG-NetworkDispatcherOkhttp.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.0] - 2026-09-08
+
+### Added
+- `fetchTimeoutMillis` constructor parameter (default 30 000 ms): a whole-call ceiling
+  (`callTimeout`) and matching `readTimeout` for feature GET and POST requests. Previously the
+  bare `OkHttpClient()` default applied a silent 10 s per-read timeout to the fetch — too
+  tight for a large payload on a slow network, and invisible to the caller. Applied via a
+  derived client that shares the injected client's pool and dispatcher; SSE keeps its own
+  streaming-tuned connection. Pass `null` to opt out and keep the injected client's own
+  configuration
+
+---
 ## [1.1.1] - 2026-09-03
 
 ### Fixed

--- a/NetworkDispatcherKtor/build.gradle.kts
+++ b/NetworkDispatcherKtor/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.2.0"
+version = "1.3.0"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherKtor/src/androidUnitTest/kotlin/com/sdk/growthbook/GBNetworkDispatcherKtorTimeoutTest.kt
+++ b/NetworkDispatcherKtor/src/androidUnitTest/kotlin/com/sdk/growthbook/GBNetworkDispatcherKtorTimeoutTest.kt
@@ -1,0 +1,139 @@
+package com.sdk.growthbook
+
+import com.sdk.growthbook.network.GBNetworkDispatcherKtor
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.HttpTimeoutConfig.Companion.INFINITE_TIMEOUT_MS
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val FEATURES_URL = "http://example.com/api/features/my-key"
+private const val RESPONSE_BODY = """{"features":{}}"""
+
+/**
+ * Covers `fetchTimeoutMillis`: the default client's request/socket timeouts are infinite for
+ * the SSE stream's sake, so without the per-request bound a stalled feature fetch hangs forever.
+ */
+class GBNetworkDispatcherKtorTimeoutTest {
+
+    /** Engine that stalls for [stallMillis] before responding — a hung CDN in miniature. */
+    private fun stalledEngine(stallMillis: Long): MockEngine = MockEngine {
+        delay(stallMillis)
+        respond(
+            content = ByteReadChannel(RESPONSE_BODY),
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+    }
+
+    /** Client with the same infinite `HttpTimeout` config as `createDefaultHttpClient()`. */
+    private fun clientWith(engine: MockEngine): HttpClient =
+        HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { isLenient = true; ignoreUnknownKeys = true })
+            }
+            install(HttpTimeout) {
+                socketTimeoutMillis = INFINITE_TIMEOUT_MS
+                requestTimeoutMillis = INFINITE_TIMEOUT_MS
+            }
+        }
+
+    @Test
+    fun `stalled fetch fails at fetchTimeout despite the client's infinite timeouts`() {
+        var error: Throwable? = null
+        val dispatcher = GBNetworkDispatcherKtor(
+            client = clientWith(stalledEngine(stallMillis = 60_000)),
+            fetchTimeoutMillis = 200,
+        )
+
+        val job = dispatcher.consumeGETRequest(
+            request = FEATURES_URL,
+            onSuccess = {},
+            onError = { error = it },
+        )
+        runBlocking { job.join() }
+
+        assertTrue(
+            "expected HttpRequestTimeoutException, got $error",
+            error is HttpRequestTimeoutException
+        )
+    }
+
+    @Test
+    fun `fetch slower than the old OkHttp-style tight default still succeeds within fetchTimeout`() {
+        var error: Throwable? = null
+        var body: String? = null
+        val dispatcher = GBNetworkDispatcherKtor(
+            client = clientWith(stalledEngine(stallMillis = 300)),
+            fetchTimeoutMillis = 10_000,
+        )
+
+        val job = dispatcher.consumeGETRequest(
+            request = FEATURES_URL,
+            onSuccess = { body = it },
+            onError = { error = it },
+        )
+        runBlocking { job.join() }
+
+        assertNull(error)
+        assertTrue(body == RESPONSE_BODY)
+    }
+
+    @Test
+    fun `null fetchTimeout opts out and leaves the client's own configuration`() {
+        var error: Throwable? = null
+        var succeeded = false
+        val dispatcher = GBNetworkDispatcherKtor(
+            client = clientWith(stalledEngine(stallMillis = 700)),
+            fetchTimeoutMillis = null,
+        )
+
+        val job = dispatcher.consumeGETRequest(
+            request = FEATURES_URL,
+            onSuccess = { succeeded = true },
+            onError = { error = it },
+        )
+        runBlocking { job.join() }
+
+        assertNull(error)
+        assertTrue(succeeded)
+    }
+
+    @Test
+    fun `stalled remote-eval POST is bounded too`() {
+        var error: Throwable? = null
+        val latch = CountDownLatch(1)
+        val dispatcher = GBNetworkDispatcherKtor(
+            client = clientWith(stalledEngine(stallMillis = 60_000)),
+            fetchTimeoutMillis = 200,
+        )
+
+        dispatcher.consumePOSTRequest(
+            url = FEATURES_URL,
+            bodyParams = mapOf("attributes" to emptyMap<String, Any>()),
+            onSuccess = { latch.countDown() },
+            onError = { error = it; latch.countDown() },
+        )
+
+        assertTrue("POST never called back", latch.await(5, TimeUnit.SECONDS))
+        assertTrue(
+            "expected HttpRequestTimeoutException, got $error",
+            error is HttpRequestTimeoutException
+        )
+    }
+}

--- a/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
+++ b/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
@@ -16,6 +16,7 @@ import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.plugins.compression.ContentEncoding
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
@@ -41,6 +42,7 @@ import kotlinx.serialization.json.JsonElement
  * Creates default Ktor HTTP client configured for:
  * - SSE consumption
  * - unlimited request/socket timeout for streaming connections
+ *   (feature GET / POST requests are bounded per request by `fetchTimeoutMillis` instead)
  * - JSON parsing with lenient mode & unknown key ignore
  */
 internal fun createDefaultHttpClient(): HttpClient =
@@ -83,8 +85,22 @@ class GBNetworkDispatcherKtor(
     private var enableLogging: Boolean = false,
     private val maxRetries: Int = 10,
     private val initialRetryDelayMs: Long = 1000L,
-    private val maxRetryDelayMs: Long = 30_000L
+    private val maxRetryDelayMs: Long = 30_000L,
+
+    /**
+     * Total time budget for a single feature GET or POST request, in milliseconds.
+     * The default client's timeouts are infinite because the same client carries the SSE
+     * stream, so without this bound a stalled feature fetch would hang forever.
+     * `null` disables the per-request bound and leaves whatever the [client] is configured
+     * with. Requires the `HttpTimeout` plugin (installed on the default client); on a custom
+     * client without it, only the socket timeout is applied by engines that support it.
+     */
+    private val fetchTimeoutMillis: Long? = DEFAULT_FETCH_TIMEOUT_MILLIS,
 ) : NetworkDispatcherWithNotModified, TrackingNetworkDispatcher {
+
+    companion object {
+        const val DEFAULT_FETCH_TIMEOUT_MILLIS: Long = 30_000L
+    }
 
     // Regex to match the desired URL pattern: "/api/features/<clientKey>"
     private val featuresPathPattern = Regex(".*/api/features/[^/]+")
@@ -167,14 +183,18 @@ class GBNetworkDispatcherKtor(
     }
 
     /**
-     * Supportive method for preparing GET request for consuming SSE connection
+     * Supportive method for preparing a GET request, shared by the feature fetch and the SSE
+     * connection. [bounded] applies [fetchTimeoutMillis] and must be false for SSE, whose
+     * connection is long-lived by design.
      */
     private suspend fun prepareGetRequest(
         url: String,
         headers: Map<String, String> = emptyMap(),
         queryParams: Map<String, String> = emptyMap(),
+        bounded: Boolean = true,
     ): HttpStatement =
         client.prepareGet(url) {
+            if (bounded) applyFetchTimeout()
             headers {
                 headers.forEach { (key, value) -> append(key, value) }
 
@@ -257,7 +277,7 @@ class GBNetworkDispatcherKtor(
             connectionJob?.cancel()
             connectionJob = scope.launch(PlatformDependentIODispatcher) {
                 try {
-                    prepareGetRequest(url).execute { response ->
+                    prepareGetRequest(url, bounded = false).execute { response ->
                         val channel: ByteReadChannel = response.body()
                         channel.readSse(
                             onSseEvent = { sseEvent ->
@@ -330,6 +350,7 @@ class GBNetworkDispatcherKtor(
                     println("GrowthBook: POST $url (${payload.toString().length} chars)")
                 }
                 val response = client.post(url) {
+                    applyFetchTimeout()
                     headers {
                         append("Content-Type", "application/json")
                         append("Accept", "application/json")
@@ -384,6 +405,7 @@ class GBNetworkDispatcherKtor(
                     println("GrowthBook: POST $url (${serializedBody.length} chars)")
                 }
                 val response = client.post(url) {
+                    applyFetchTimeout()
                     headers {
                         append("Accept", "application/json")
                         headers.forEach { (key, value) ->
@@ -422,6 +444,19 @@ class GBNetworkDispatcherKtor(
 
     fun setLoggingEnabled(enabled: Boolean) {
         enableLogging = enabled
+    }
+
+    /**
+     * Bounds one GET/POST request by [fetchTimeoutMillis]. Per-request, so the client-level
+     * config — infinite on the default client, for the SSE stream's sake — stays untouched.
+     */
+    private fun HttpRequestBuilder.applyFetchTimeout() {
+        fetchTimeoutMillis?.let { millis ->
+            timeout {
+                requestTimeoutMillis = millis
+                socketTimeoutMillis = millis
+            }
+        }
     }
 
     /**

--- a/NetworkDispatcherOkHttp/build.gradle.kts
+++ b/NetworkDispatcherOkHttp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.1.1"
+version = "1.2.0"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherOkHttp/src/androidUnitTest/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttpTimeoutTest.kt
+++ b/NetworkDispatcherOkHttp/src/androidUnitTest/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttpTimeoutTest.kt
@@ -1,0 +1,122 @@
+package com.sdk.growthbook.network
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.InterruptedIOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val RESPONSE_BODY = """{"features":{}}"""
+
+/**
+ * Covers `fetchTimeoutMillis`: a bare `OkHttpClient()` carries a silent 10s per-read timeout —
+ * too tight for a large payload on a slow network and invisible to the caller. The knob replaces
+ * it with an explicit whole-call ceiling (and matching read timeout) on the fetch path only.
+ * The tests emulate the tight default with a 300ms read timeout so they stay fast.
+ */
+class GBNetworkDispatcherOkHttpTimeoutTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun featuresUrl() = server.url("/api/features/my-key").toString()
+
+    private fun stalledResponse(stallMillis: Long): MockResponse =
+        MockResponse()
+            .setBody(RESPONSE_BODY)
+            .setHeadersDelay(stallMillis, TimeUnit.MILLISECONDS)
+
+    private fun getSync(
+        dispatcher: GBNetworkDispatcherOkHttp,
+        onSuccess: (String) -> Unit = {},
+        onError: (Throwable) -> Unit = {},
+    ) {
+        val latch = CountDownLatch(1)
+        dispatcher.consumeGETRequest(
+            request = featuresUrl(),
+            onSuccess = { onSuccess(it); latch.countDown() },
+            onError = { onError(it); latch.countDown() },
+        )
+        assertTrue("GET never called back", latch.await(10, TimeUnit.SECONDS))
+    }
+
+    private fun tightClient() = OkHttpClient.Builder()
+        .readTimeout(300, TimeUnit.MILLISECONDS)
+        .build()
+
+    @Test
+    fun `fetchTimeout relaxes the client's tight read timeout`() {
+        server.enqueue(stalledResponse(stallMillis = 800))
+        var error: Throwable? = null
+        var body: String? = null
+
+        val dispatcher = GBNetworkDispatcherOkHttp(
+            client = tightClient(),
+            fetchTimeoutMillis = 10_000,
+        )
+        getSync(dispatcher, onSuccess = { body = it }, onError = { error = it })
+
+        assertNull("read timeout should have been raised to fetchTimeout, got $error", error)
+        assertTrue(body == RESPONSE_BODY)
+    }
+
+    @Test
+    fun `stalled fetch fails at fetchTimeout`() {
+        server.enqueue(stalledResponse(stallMillis = 3_000))
+        var error: Throwable? = null
+
+        val dispatcher = GBNetworkDispatcherOkHttp(fetchTimeoutMillis = 300)
+        getSync(dispatcher, onError = { error = it })
+
+        // callTimeout and readTimeout both surface as InterruptedIOException subtypes.
+        assertTrue("expected a timeout, got $error", error is InterruptedIOException)
+    }
+
+    @Test
+    fun `null fetchTimeout respects the caller's client configuration`() {
+        server.enqueue(stalledResponse(stallMillis = 800))
+        var error: Throwable? = null
+
+        val dispatcher = GBNetworkDispatcherOkHttp(
+            client = tightClient(),
+            fetchTimeoutMillis = null,
+        )
+        getSync(dispatcher, onError = { error = it })
+
+        assertTrue("expected the client's own 300ms read timeout, got $error", error is InterruptedIOException)
+    }
+
+    @Test
+    fun `stalled remote-eval POST is bounded too`() {
+        server.enqueue(stalledResponse(stallMillis = 3_000))
+        var error: Throwable? = null
+        val latch = CountDownLatch(1)
+
+        val dispatcher = GBNetworkDispatcherOkHttp(fetchTimeoutMillis = 300)
+        dispatcher.consumePOSTRequest(
+            url = featuresUrl(),
+            bodyParams = mapOf("attributes" to emptyMap<String, Any>()),
+            onSuccess = { latch.countDown() },
+            onError = { error = it; latch.countDown() },
+        )
+
+        assertTrue("POST never called back", latch.await(10, TimeUnit.SECONDS))
+        assertTrue("expected a timeout, got $error", error is InterruptedIOException)
+    }
+}

--- a/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
+++ b/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
@@ -54,10 +54,34 @@ class GBNetworkDispatcherOkHttp(
     private val initialRetryDelayMs: Long = 1000L,
     private val maxRetryDelayMs: Long = 30_000L,
 
+    /**
+     * Total time budget for a single feature GET or POST request, in milliseconds. Applied as
+     * OkHttp's callTimeout (whole-call ceiling) and readTimeout. Without it, OkHttp's default
+     * 10s per-read timeout governs the fetch — too tight for a large payload on a slow
+     * network, and invisible to the caller. `null` leaves the [client]'s own configuration.
+     * SSE is unaffected: it uses its own connection with streaming-appropriate timeouts.
+     */
+    private val fetchTimeoutMillis: Long? = DEFAULT_FETCH_TIMEOUT_MILLIS,
+
     ) : NetworkDispatcherWithNotModified, TrackingNetworkDispatcher {
+
+    companion object {
+        const val DEFAULT_FETCH_TIMEOUT_MILLIS: Long = 30_000L
+    }
 
     // Regex to match the desired URL pattern: "/api/features/<clientKey>"
     private val featuresPathPattern = Regex(".*/api/features/[^/]+")
+
+    // Client for feature GET/POST: shares [client]'s pool and dispatcher, adds the bounded
+    // total deadline. Lazy so a `null` opt-out costs nothing.
+    private val fetchClient: OkHttpClient by lazy {
+        fetchTimeoutMillis?.let { millis ->
+            client.newBuilder()
+                .callTimeout(millis, TimeUnit.MILLISECONDS)
+                .readTimeout(millis, TimeUnit.MILLISECONDS)
+                .build()
+        } ?: client
+    }
 
     // Thread-safe LRU cache with max 100 entries to prevent unbounded growth
     private val eTagCache = OkHttpLruETagCache(maxSize = 100)
@@ -101,7 +125,7 @@ class GBNetworkDispatcherOkHttp(
                     .post(requestBody)
                     .build()
 
-                client.newCall(postRequest).enqueue(object : Callback {
+                fetchClient.newCall(postRequest).enqueue(object : Callback {
                     override fun onFailure(call: Call, e: IOException) {
                         onError(e)
                     }
@@ -151,7 +175,7 @@ class GBNetworkDispatcherOkHttp(
                     }
                 }
                 .build()
-            client.newCall(getRequest).enqueue(object : Callback {
+            fetchClient.newCall(getRequest).enqueue(object : Callback {
                 override fun onFailure(call: Call, e: IOException) {
                     onError(e)
                 }
@@ -361,7 +385,7 @@ class GBNetworkDispatcherOkHttp(
                     }
                     .post(requestBody)
                     .build()
-                client.newCall(postRequest).enqueue(object : Callback {
+                fetchClient.newCall(postRequest).enqueue(object : Callback {
                     override fun onFailure(call: Call, e: IOException) {
                         onError(e)
                     }


### PR DESCRIPTION
## Summary

Adds a `fetchTimeoutMillis` constructor parameter (default 30s, `null` opts out) to both network dispatchers, bounding feature GET/POST requests without touching SSE. This is the root-cause fix behind the payload-timeout reports that motivated #258/#259: today a feature fetch is either unbounded or silently 10s, and neither is configurable.

## Root cause

- **Ktor**: `createDefaultHttpClient()` sets `requestTimeoutMillis = socketTimeoutMillis = INFINITE_TIMEOUT_MS` for the SSE stream's sake — and the same client serves the feature GET, so a stalled CDN response hangs forever ([GBNetworkDispatcherKtor.kt:58-62](https://github.com/growthbook/growthbook-kotlin/blob/main/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt#L58-L62)).
- **OkHttp**: the default `OkHttpClient()` applies a 10s per-read timeout to the fetch — too tight for time-to-first-byte on a large payload (customers carry 1MB+, see #226) over a slow network, and invisible to the caller.
- The existing `maxRetries`/`initialRetryDelayMs`/`maxRetryDelayMs` params are SSE-reconnect only; there is no GET-timeout knob on either dispatcher short of replacing the whole client (which on Ktor silently drops the gzip/timeout/SSE plugin stack).

## Behavioral change

- Ktor: feature GET/POST now bounded per request via `timeout {}` (30s default) instead of infinite; SSE unchanged. On a custom client without the `HttpTimeout` plugin the request bound is inert (documented).
- OkHttp: feature GET/POST run on a derived client (`newBuilder()` — same pool/dispatcher) with `callTimeout` and `readTimeout` set to `fetchTimeoutMillis`; SSE keeps its own streaming-tuned client. Net effect: the silent 10s read timeout becomes an explicit, configurable 30s whole-call ceiling.
- `fetchTimeoutMillis = null` defers entirely to the injected client's own configuration.

## Test plan

- [x] `:NetworkDispatcherKtor:testDebugUnitTest` — green; new `GBNetworkDispatcherKtorTimeoutTest` covers stalled-fetch timeout despite infinite client config, slow-but-ok fetch, `null` opt-out, bounded remote-eval POST
- [x] `:NetworkDispatcherOkHttp:testDebugUnitTest` — green; new `GBNetworkDispatcherOkHttpTimeoutTest` covers raising a tight client read timeout, stalled-fetch timeout, `null` opt-out respecting the caller's client, bounded POST

Versions: NetworkDispatcherKtor 1.2.0 → 1.3.0, NetworkDispatcherOkHttp 1.1.1 → 1.2.0, changelog entries included.
