### PR TITLE
feat: custom request headers for API and streaming hosts

### DIFF
--- a/CHANGELOG-NetworkDispatcherKtor.md
+++ b/CHANGELOG-NetworkDispatcherKtor.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.3.0] - 2026-09-08
+## [1.4.0] - Unreleased
+
+### Added
+- Honour the SDK's custom request headers (`apiHostRequestHeaders` /
+  `streamingHostRequestHeaders`): implemented the `headers`-carrying overloads of
+  `consumeGETRequest`, `consumeGETRequestWithNotModified`, `consumeSSEConnection` and
+  `consumePOSTRequest` added in `:Core` 1.7.0. On SSE the headers are re-sent on every reconnection
+  attempt. Requires `io.growthbook.sdk:Core:1.7.0`.
+
+### Changed
+- The SDK-managed `If-None-Match`, `Cache-Control`, `Content-Type` and `Accept` headers are now set
+  with `set()` instead of `append()`, so an SDK value replaces a consumer-supplied one rather than
+  adding a second, conflicting header value. Reserved names are also stripped from the consumer's
+  map before it is applied. Behaviour is unchanged when no custom headers are configured.
+
+---
+
+## [1.3.0] - 2026-09-09
 
 ### Added
 - `fetchTimeoutMillis` constructor parameter (default 30 000 ms): a per-request total time

--- a/CHANGELOG-NetworkDispatcherOkhttp.md
+++ b/CHANGELOG-NetworkDispatcherOkhttp.md
@@ -7,7 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.0] - 2026-09-08
+## [1.3.0] - Unreleased
+
+### Added
+- Honour the SDK's custom request headers (`apiHostRequestHeaders` /
+  `streamingHostRequestHeaders`): implemented the `headers`-carrying overloads of
+  `consumeGETRequest`, `consumeGETRequestWithNotModified`, `consumeSSEConnection` and
+  `consumePOSTRequest` added in `:Core` 1.7.0. The SSE request is built once and reused, so the
+  headers are re-sent on every reconnection attempt. Requires `io.growthbook.sdk:Core:1.7.0`.
+
+### Changed
+- The SDK-managed `Cache-Control`, `Content-Type` and `Accept` headers are now set with `header()`
+  instead of `addHeader()`, so an SDK value replaces a consumer-supplied one rather than adding a
+  second, conflicting header value. Reserved names are also stripped from the consumer's map before
+  it is applied. Behaviour is unchanged when no custom headers are configured.
+
+### Fixed
+- A request that cannot be assembled — a URL without a scheme, for example — is now reported through
+  `onError` instead of escaping the dispatcher's `CoroutineScope`. Previously
+  `consumeGETRequest`/`consumeGETRequestWithNotModified` threw before the call was enqueued, so no
+  callback ever fired and the uncaught exception crashed the app on Android. `consumePOSTRequest`
+  already guarded this.
+- The SSE request is now built inside the returned `Flow`, so the same failure is emitted as
+  `Resource.Error` rather than thrown synchronously out of `consumeSSEConnection` — which used to
+  propagate all the way out of the SDK's public `autoRefreshFeatures()`.
+
+---
+
+## [1.2.0] - 2026-09-09
 
 ### Added
 - `fetchTimeoutMillis` constructor parameter (default 30 000 ms): a whole-call ceiling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,86 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [8.0.0] - Unreleased
+## [8.1.0] - Unreleased
+
+### Added
+- `GBSDKBuilder.setApiHostRequestHeaders(Map<String, String>)` — custom headers added to every
+  request against the API host: the features `GET` and the remote-evaluation `POST`. Makes the SDK
+  usable in enterprise self-hosted setups where GrowthBook sits behind an authenticated
+  gateway/proxy. Matches the TypeScript SDK's `apiHostRequestHeaders`.
+- `GBSDKBuilder.setStreamingHostRequestHeaders(Map<String, String>)` — custom headers added to the
+  SSE streaming request. Matches the TypeScript SDK's `streamingHostRequestHeaders`.
+- `GBOptions.apiHostRequestHeaders` / `GBOptions.streamingHostRequestHeaders` — the resolved values,
+  readable from the options object the builder produces. Added as constructor parameters with
+  defaults, which is safe here because `GBOptions`' primary constructor has been `internal` since
+  8.0.0 — consumers configure these through the builder setters. `GBOptions.toString()` prints only
+  header *names*, never values, since a value may be a credential.
+- `GBInvalidOptionsException` (extends `IllegalArgumentException`) — thrown when host/header options
+  are invalid, with every problem found collected in `violations` so several misconfigurations
+  surface at once instead of one per restart. `apiHost` and `streamingHost` are validated at
+  `initialize()`; header maps are validated in their setters, so a reserved or unusable header name
+  — or a value HTTP cannot carry — is rejected at startup. A blank host means "not set" and is not
+  a violation.
+- `GBRequestHeaders` — new public helper in `:Core` (`io.growthbook.sdk:Core:1.7.0`) exposing the
+  set of SDK-managed (reserved) header names and a `sanitize()` pass. Useful when writing a custom
+  `NetworkDispatcher` that honours custom headers.
+- `NetworkDispatcher` / `NetworkDispatcherWithNotModified` gained `headers`-carrying overloads of
+  `consumeGETRequest`, `consumeGETRequestWithNotModified`, `consumeSSEConnection` and
+  `consumePOSTRequest`. Each has a default body that delegates to the header-less variant, so an
+  existing custom dispatcher keeps compiling and working unchanged — it simply ignores custom
+  headers until it overrides them. Both built-in dispatchers honour them
+  (`NetworkDispatcherKtor:1.4.0`, `NetworkDispatcherOkHttp:1.3.0` — an older dispatcher silently
+  drops the headers, so bump it alongside this release).
+
+### Breaking
+- **`initialize()` now throws on a malformed `apiHost` / `streamingHost`** instead of degrading.
+  A host with a non-`http(s)` scheme or no usable host part used to produce a URL the HTTP client
+  rejected, which surfaced as a fetch failure and left the SDK serving cached or default values; it
+  now fails fast with `GBInvalidOptionsException` at `initialize()`. An app that has been shipping
+  with such a value — a stray character from string-interpolated config, say — will start throwing
+  at startup on this upgrade rather than running degraded. A blank host still means "not set" and
+  is not a violation. Check `GBOptionsValidator`-style problems ahead of time by catching
+  `GBInvalidOptionsException` around `initialize()` and reading `violations`.
+
+### Changed
+- **SSE now falls back to `apiHost` when no `streamingHost` is configured**, matching the TypeScript
+  SDK's `getApiHosts()`. Previously the streaming URL fell through to `https://cdn.growthbook.io`,
+  so every self-hosted deployment without an explicit `streamingHost` opened its SSE connection
+  against GrowthBook Cloud while fetching features from its own `apiHost`. If you relied on the old
+  behaviour (features self-hosted, streaming from GrowthBook Cloud), set
+  `streamingHost = "https://cdn.growthbook.io"` explicitly.
+- Redundant trailing slashes on `apiHost` / `streamingHost` are now collapsed rather than only a
+  single one, as in the TypeScript SDK.
+- A host configured without a scheme (`cdn.example.com`) is now resolved against `https`, as in the
+  Java SDK. Previously it produced a URL every HTTP client rejects, surfacing as an opaque fetch
+  failure. A *blank* host is left scheme-less on purpose, so it still produces a relative URL the
+  client rejects — adding a scheme would turn an unset `apiHost` into a request against a host
+  literally named `api`.
+
+### Fixed
+- `GBNetworkDispatcherOkHttp` no longer lets a request-assembly failure escape its `CoroutineScope`.
+  A malformed URL made `consumeGETRequest`/`consumeGETRequestWithNotModified` throw before the call
+  was enqueued, so `onError` never fired — `initialize(onResult)` never completed and, on Android,
+  the uncaught exception crashed the app. The same failure on the SSE path is now emitted as
+  `Resource.Error` instead of propagating synchronously out of `autoRefreshFeatures()`.
+
+### Security
+- Custom header values may carry credentials: they are never logged, never included in a validation
+  error message (only header *names* are), and never exposed through diagnostics. Values HTTP cannot
+  carry (control characters, line breaks, non-ASCII) are rejected by the builder and dropped on the
+  request path rather than handed to the HTTP client, whose exception message would quote the value
+  back into the SDK's error log. CR/LF in a header value — the classic header-injection vector —
+  is therefore never sent. Surrounding whitespace is stripped, so a token read from a file or
+  environment variable with a trailing newline still works.
+- Consumer-supplied headers can never override the SDK-managed `If-None-Match` and `Cache-Control`
+  headers — overriding them would break ETag-based cache revalidation. They are rejected up front by
+  the builder and dropped again on the request path (defence in depth, for a `GBOptions` assembled
+  inside the SDK without the builder's validation). `User-Agent` is deliberately *not* reserved: the
+  SDK does not set it on these
+  requests, so consumers behind a gateway that requires a specific one can supply it.
+
+---
+## [8.0.0] - 2026-09-09
 
 ### Added
 - **Contextual bandits.** The SDK now understands contextual bandit rules and their definitions in the features payload

--- a/Core/build.gradle.kts
+++ b/Core/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.6.0"
+version = "1.7.0"
 
 kotlin {
     androidTarget {

--- a/Core/src/commonMain/kotlin/com/sdk/growthbook/network/GBRequestHeaders.kt
+++ b/Core/src/commonMain/kotlin/com/sdk/growthbook/network/GBRequestHeaders.kt
@@ -1,0 +1,84 @@
+package com.sdk.growthbook.network
+
+/**
+ * Helpers for the custom request headers a consumer can attach to API and streaming requests
+ * (`apiHostRequestHeaders` / `streamingHostRequestHeaders`).
+ *
+ * Two header names are **SDK-managed**: the SDK sets them itself and a consumer-supplied value for
+ * them is dropped rather than merged, because overriding `If-None-Match` / `Cache-Control` would
+ * break the ETag-based revalidation the SDK relies on. `User-Agent` is deliberately *not* reserved:
+ * the SDK never sets it on the requests these headers apply to, so blocking it would only break
+ * consumers behind a gateway that requires a specific one.
+ *
+ * Header **values** may carry credentials (a gateway token, a signed cookie). Never log them —
+ * only names are ever safe to log. This is also why unusable values are dropped here instead of
+ * being handed to the HTTP client, whose exception message would quote them back.
+ */
+object GBRequestHeaders {
+
+    /**
+     * Lower-cased names of the headers the SDK manages itself. Consumer-supplied entries for these
+     * are ignored. HTTP header names are case-insensitive, so compare in lower case.
+     */
+    val RESERVED: Set<String> = setOf("if-none-match", "cache-control")
+
+    /**
+     * Characters allowed in a header name beyond letters and digits (RFC 9110 `token`).
+     */
+    private const val NAME_SYMBOLS = "!#$%&'*+-.^_`|~"
+
+    /**
+     * Whether [name] is an SDK-managed header that a consumer must not override.
+     */
+    fun isReserved(name: String): Boolean = name.trim().lowercase() in RESERVED
+
+    /**
+     * Whether [name] is a usable HTTP field-name — a non-empty RFC 9110 `token`. Leading and
+     * trailing whitespace is tolerated (and stripped by [sanitize]); whitespace or a separator
+     * inside the name is not, because no HTTP client can send it.
+     */
+    fun isValidName(name: String): Boolean {
+        val trimmed = name.trim()
+        return trimmed.isNotEmpty() && trimmed.all { char ->
+            char.isAsciiLetterOrDigit() || char in NAME_SYMBOLS
+        }
+    }
+
+    /**
+     * Whether [value] is a usable HTTP field-value — visible ASCII plus space and horizontal tab,
+     * per RFC 9110 `field-value`. Surrounding whitespace is tolerated (and stripped by [sanitize]),
+     * so a token read from a file or env var with a trailing newline still works.
+     *
+     * Anything else — CR, LF, NUL, control or non-ASCII characters — is rejected: HTTP clients
+     * throw on it (which used to surface the value in an error message), and CR/LF inside a value
+     * is the classic header-injection vector.
+     */
+    fun isValidValue(value: String): Boolean =
+        value.trim().all { char -> char == '\t' || char.code in 0x20..0x7E }
+
+    /**
+     * Drops the entries the SDK cannot honour — [RESERVED] names, unusable names and unusable
+     * values — and returns the rest with surrounding whitespace stripped.
+     *
+     * Silent by design: the SDK reports these problems once, up front, when the options are
+     * validated at build time; this is the defence-in-depth pass on the request path, for options
+     * assembled without going through that validation. Dropping here rather than letting the HTTP
+     * client reject the value matters for privacy as much as for robustness — client exceptions
+     * embed the offending value, and that message reaches the SDK's error log.
+     */
+    fun sanitize(headers: Map<String, String>?): Map<String, String> {
+        if (headers.isNullOrEmpty()) return emptyMap()
+        return buildMap {
+            for ((name, value) in headers) {
+                if (isReserved(name) || !isValidName(name) || !isValidValue(value)) continue
+                put(name.trim(), value.trim())
+            }
+        }
+    }
+
+    /**
+     * `Char.isLetterOrDigit()` is Unicode-aware; header names are ASCII-only.
+     */
+    private fun Char.isAsciiLetterOrDigit(): Boolean =
+        this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9'
+}

--- a/Core/src/commonMain/kotlin/com/sdk/growthbook/network/NetworkDispatcher.kt
+++ b/Core/src/commonMain/kotlin/com/sdk/growthbook/network/NetworkDispatcher.kt
@@ -8,6 +8,16 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Network Dispatcher Interface for API Consumption
  * Implement this interface to define specific implementation for Network Calls - to be made by SDK
+ *
+ * The SDK always calls the `headers`-carrying overloads, which pass along the consumer's
+ * `apiHostRequestHeaders` / `streamingHostRequestHeaders`. They default to delegating to the
+ * header-less variants, so an existing Kotlin or Java implementation keeps compiling and working
+ * unchanged — it simply ignores the custom headers. Override them to support authenticated
+ * gateways/proxies. Values may contain credentials: apply them to the request, never log them.
+ *
+ * Not so on Apple targets: Kotlin interfaces are exported to Objective-C with every member
+ * `@required`, so a Swift class conforming to this protocol does not inherit the default bodies and
+ * will not compile until it implements the `headers` overloads too.
  */
 interface NetworkDispatcher {
     fun consumeGETRequest(
@@ -16,10 +26,30 @@ interface NetworkDispatcher {
         onError: (Throwable) -> Unit
     ): Job
 
+    /**
+     * GET with consumer-supplied [headers] applied to the request. SDK-managed headers
+     * ([GBRequestHeaders.RESERVED]) take priority and must not be overridden by [headers].
+     */
+    fun consumeGETRequest(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ): Job = consumeGETRequest(request, onSuccess, onError)
+
     fun consumeSSEConnection(
         url: String,
         sseController: SSEConnectionController? = null
     ): Flow<Resource<String>>
+
+    /**
+     * SSE connection with consumer-supplied [headers] applied to the streaming request.
+     */
+    fun consumeSSEConnection(
+        url: String,
+        headers: Map<String, String>,
+        sseController: SSEConnectionController? = null
+    ): Flow<Resource<String>> = consumeSSEConnection(url, sseController)
 
     fun consumePOSTRequest(
         url: String,
@@ -27,4 +57,15 @@ interface NetworkDispatcher {
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit
     )
+
+    /**
+     * Remote-evaluation POST with consumer-supplied [headers] applied to the request.
+     */
+    fun consumePOSTRequest(
+        url: String,
+        headers: Map<String, String>,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ) = consumePOSTRequest(url, bodyParams, onSuccess, onError)
 }

--- a/Core/src/commonMain/kotlin/com/sdk/growthbook/network/NetworkDispatcherWithNotModified.kt
+++ b/Core/src/commonMain/kotlin/com/sdk/growthbook/network/NetworkDispatcherWithNotModified.kt
@@ -14,4 +14,18 @@ interface NetworkDispatcherWithNotModified : NetworkDispatcher {
         onError: (Throwable) -> Unit,
         onNotModified: () -> Unit
     ): Job
+
+    /**
+     * Same as [consumeGETRequestWithNotModified] with consumer-supplied [headers] applied to the
+     * request. Defaults to the header-less variant, so existing implementations keep working — they
+     * just ignore the custom headers. The SDK-managed `If-None-Match` / `Cache-Control` headers
+     * ([GBRequestHeaders.RESERVED]) always win over [headers].
+     */
+    fun consumeGETRequestWithNotModified(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onNotModified: () -> Unit
+    ): Job = consumeGETRequestWithNotModified(request, onSuccess, onError, onNotModified)
 }

--- a/GrowthBook/build.gradle.kts
+++ b/GrowthBook/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "8.0.0"
+version = "8.1.0"
 
 val generateSdkMeta by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated/sdk-meta/commonMain/kotlin")

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/GBSDKBuilder.kt
@@ -26,12 +26,13 @@ import com.sdk.growthbook.utils.GBCacheRefreshHandler
 import com.sdk.growthbook.utils.GBFeatures
 import com.sdk.growthbook.utils.GBFeaturesChangeHandler
 import com.sdk.growthbook.utils.GBFetchStatsHandler
+import com.sdk.growthbook.utils.GBOptionsValidator
 
 /**
  * SDKBuilder - Root Class for SDK Initializers for GrowthBook SDK
  * APIKey - API Key
  * ApiHost - domain for features fetch
- * StreamingHost - domain for server sent events
+ * StreamingHost - domain for server sent events; falls back to ApiHost when not set
  * UserAttributes - User Attributes
  * Tracking Callback - Track Events for Experiments
  * EncryptionKey - Encryption key if you intend to use data encryption
@@ -92,7 +93,7 @@ abstract class SDKBuilder(
  * SDKBuilder - Initializer for GrowthBook SDK for Apps
  * APIKey - API Key
  * ApiHost - domain for features fetch
- * StreamingHost - domain for server sent events
+ * StreamingHost - domain for server sent events; falls back to ApiHost when not set
  * UserAttributes - User Attributes
  * Tracking Callback - Track Events for Experiments
  * EncryptionKey - Encryption key if you intend to use data encryption
@@ -132,6 +133,8 @@ class GBSDKBuilder(
     private var refreshInterval: Long? = null
     private var staleTtl: Long? = null
     private var serveStaleOnError: Boolean = false
+    private var apiHostRequestHeaders: Map<String, String> = emptyMap()
+    private var streamingHostRequestHeaders: Map<String, String> = emptyMap()
 
     // Dispatcher used to process fetched payloads. Defaults to the platform IO dispatcher in
     // production; tests inject a deterministic dispatcher (e.g. Dispatchers.Unconfined or a
@@ -324,6 +327,55 @@ class GBSDKBuilder(
     }
 
     /**
+     * Extra headers added to every request against the API host — the features `GET` and the
+     * remote-evaluation `POST`. Use this to reach a GrowthBook instance deployed behind an
+     * authenticated gateway or proxy.
+     *
+     * ```kotlin
+     * .setApiHostRequestHeaders(mapOf("Authorization" to "Bearer $gatewayToken"))
+     * ```
+     *
+     * Header values may contain credentials: they are never logged and never surfaced through
+     * diagnostics. Whether they are actually applied depends on the injected
+     * [NetworkDispatcher] — both built-in dispatchers (Ktor and OkHttp) honour them; a custom
+     * dispatcher must override the `headers`-carrying overloads of [NetworkDispatcher] to do so.
+     *
+     * @throws com.sdk.growthbook.utils.GBInvalidOptionsException when a header name is blank, is
+     *   not a valid HTTP token, is one of the SDK-managed names (`If-None-Match`, `Cache-Control`
+     *   — the SDK sets those itself and honouring an override would break ETag-based
+     *   revalidation), or when a value contains characters HTTP forbids (control characters, line
+     *   breaks, non-ASCII). The check runs here so the misconfiguration surfaces at the setter,
+     *   not at the first failed fetch. Violation messages never quote a header value.
+     */
+    fun setApiHostRequestHeaders(headers: Map<String, String>): GBSDKBuilder {
+        GBOptionsValidator.validate(
+            streamingHost = null,
+            apiHostRequestHeaders = headers,
+            streamingHostRequestHeaders = null,
+        )
+        this.apiHostRequestHeaders = headers.toMap()
+        return this
+    }
+
+    /**
+     * Extra headers added to the SSE streaming request (against the streaming host, or the API
+     * host when no streaming host is configured). Same reserved-name and secret-handling rules as
+     * [setApiHostRequestHeaders].
+     *
+     * @throws com.sdk.growthbook.utils.GBInvalidOptionsException when a header name is blank,
+     *   reserved or not a valid HTTP token, or when a value contains characters HTTP forbids.
+     */
+    fun setStreamingHostRequestHeaders(headers: Map<String, String>): GBSDKBuilder {
+        GBOptionsValidator.validate(
+            streamingHost = null,
+            apiHostRequestHeaders = null,
+            streamingHostRequestHeaders = headers,
+        )
+        this.streamingHostRequestHeaders = headers.toMap()
+        return this
+    }
+
+    /**
      * Registers plugins that receive lifecycle callbacks: [GrowthBookPlugin.init],
      * [GrowthBookPlugin.onExperimentViewed], [GrowthBookPlugin.onFeatureEvaluated], and [GrowthBookPlugin.close].
      */
@@ -413,10 +465,14 @@ class GBSDKBuilder(
      * Initialize the Kotlin SDK and provide it when ready
      */
     fun initialize(onResult: (GrowthBookSDK) -> Unit) {
+        // Validated first, before any context/service is built, so a misconfiguration throws
+        // without leaving half-initialized state behind.
+        val gbOptions = createGbOptions()
         val gbContext = createGbContext()
 
         WaitForCallCaseHelper(
             gbContext = gbContext,
+            gbOptions = gbOptions,
             onResult = onResult,
         )
     }
@@ -426,6 +482,9 @@ class GBSDKBuilder(
      * This init method takes less time than method above
      */
     override fun initialize(): GrowthBookSDK {
+        // Validated first, before any context/service is built, so a misconfiguration throws
+        // without leaving half-initialized state behind.
+        val gbOptions = createGbOptions()
         val gbContext = createGbContext()
 
         if (enableLogging && !cachingEnabled) {
@@ -439,8 +498,6 @@ class GBSDKBuilder(
         }
 
         seedInitialState(gbContext)
-
-        val gbOptions = GBOptions(apiHost, streamingHost)
 
         return GrowthBookSDK(
             gbContext,
@@ -456,6 +513,28 @@ class GBSDKBuilder(
             featuresChangeHandler = featuresChangeHandler,
             cachingLayer = customCachingLayer,
             fetchStatsHandler = fetchStatsHandler
+        )
+    }
+
+    /**
+     * Assembles (and validates) the host/header options. The hosts are validated here rather than
+     * in the constructor so an already-compiled consumer passing a malformed value still gets the
+     * same fail-fast error at `initialize()` regardless of which builder overload it uses.
+     * `apiHost` is checked too — it backs every feature fetch and remote-eval POST, so a typo
+     * there degrades into exactly the same opaque fetch failure as a bad `streamingHost`.
+     */
+    private fun createGbOptions(): GBOptions {
+        GBOptionsValidator.validate(
+            streamingHost = streamingHost,
+            apiHostRequestHeaders = apiHostRequestHeaders,
+            streamingHostRequestHeaders = streamingHostRequestHeaders,
+            apiHost = apiHost,
+        )
+        return GBOptions(
+            apiHost = apiHost,
+            streamingHost = streamingHost,
+            apiHostRequestHeaders = apiHostRequestHeaders,
+            streamingHostRequestHeaders = streamingHostRequestHeaders,
         )
     }
 
@@ -480,6 +559,7 @@ class GBSDKBuilder(
 
     private inner class WaitForCallCaseHelper(
         gbContext: GBContext,
+        gbOptions: GBOptions,
         private val onResult: (GrowthBookSDK) -> Unit
     ) {
         var growthBookSDK: GrowthBookSDK? = null
@@ -505,7 +585,6 @@ class GBSDKBuilder(
             }
             seedInitialState(gbContext)
 
-            val gbOptions = GBOptions(apiHost, streamingHost)
             growthBookSDK = GrowthBookSDK(
                 gbContext,
                 gbOptions,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeatureURLBuilder.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeatureURLBuilder.kt
@@ -13,7 +13,13 @@ internal class FeatureURLBuilder(private val gbOptions: GBOptions) {
         featureRefreshStrategy: FeatureRefreshStrategy = FeatureRefreshStrategy.STALE_WHILE_REVALIDATE
     ): String {
         val baseUrl: String = if (featureRefreshStrategy == FeatureRefreshStrategy.SERVER_SENT_EVENTS) {
-            gbOptions.streamingHost ?: DEFAULT_STREAMING_HOST
+            // streamingHost > apiHost > GrowthBook Cloud default, mirroring the TypeScript SDK's
+            // getApiHosts(). Falling straight through to the Cloud CDN (the pre-8.1.0 behaviour)
+            // sent SSE to cdn.growthbook.io for every self-hosted deployment that had not set an
+            // explicit streamingHost, while its features were fetched from apiHost.
+            gbOptions.streamingHost?.takeIf { it.isNotBlank() }
+                ?: gbOptions.apiHost.takeIf { it.isNotBlank() }
+                ?: DEFAULT_STREAMING_HOST
         } else {
             gbOptions.apiHost
         }
@@ -25,14 +31,34 @@ internal class FeatureURLBuilder(private val gbOptions: GBOptions) {
         }
 
         /**
-         * Validate url for setting "/" to result
+         * Normalise the host so exactly one "/" separates it from the endpoint path, whatever
+         * number of trailing slashes the configured host carries (as the TypeScript SDK does).
          */
-        val baseUrlWithFeaturePath = if (baseUrl.endsWith('/'))
-            "$baseUrl$endpointPath"
-        else
-            "$baseUrl/$endpointPath"
+        val baseUrlWithFeaturePath = "${withScheme(baseUrl).trimEnd('/')}/$endpointPath"
 
         return "$baseUrlWithFeaturePath/$apiKey"
+    }
+
+    /**
+     * Prepends `https://` to a scheme-less host, as the Java SDK does. Without this a configured
+     * `cdn.example.com` produces a URL every HTTP client rejects ("Expected URL scheme 'http' or
+     * 'https'"), which surfaces as an opaque fetch failure rather than a bad-config message.
+     *
+     * A blank host is returned unchanged, and deliberately so. Adding a scheme to it would yield
+     * `https:/api/features/<clientKey>`, which HTTP clients do not reject — OkHttp parses it as the
+     * host `api`, which resolves wherever a DNS search domain is configured. An `apiHost` left
+     * empty by a build config would then silently ship the client key to an unintended host instead
+     * of failing. Left blank, the URL stays relative and the client rejects it, as it did before
+     * scheme normalisation existed. [com.sdk.growthbook.utils.GBOptionsValidator] treats a blank
+     * host as "not set" rather than a violation, so this is the only guard.
+     */
+    private fun withScheme(host: String): String {
+        val trimmed = host.trim()
+        return when {
+            trimmed.isEmpty() -> trimmed
+            trimmed.contains(SCHEME_SEPARATOR) -> trimmed
+            else -> "https://$trimmed"
+        }
     }
 
     companion object {
@@ -44,5 +70,7 @@ internal class FeatureURLBuilder(private val gbOptions: GBOptions) {
         private const val REMOTE_FEATURE_PATH = "api/eval"
 
         private const val DEFAULT_STREAMING_HOST = "https://cdn.growthbook.io"
+
+        private const val SCHEME_SEPARATOR = "://"
     }
 }

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/features/FeaturesDataSource.kt
@@ -5,6 +5,7 @@ import com.sdk.growthbook.logger.GB
 import com.sdk.growthbook.model.GBContext
 import com.sdk.growthbook.model.GBOptions
 import com.sdk.growthbook.model.GBValue
+import com.sdk.growthbook.network.GBRequestHeaders
 import com.sdk.growthbook.network.NetworkDispatcher
 import com.sdk.growthbook.network.NetworkDispatcherWithNotModified
 import com.sdk.growthbook.serializable_model.SerializableFeaturesDataModel
@@ -37,6 +38,15 @@ internal class FeaturesDataSource(
 
     private val jsonParser: Json
         get() = Json { prettyPrint = true; isLenient = true; ignoreUnknownKeys = true }
+
+    // Sanitized once, not per request: GBOptions is fixed for the lifetime of the SDK instance.
+    // Sanitizing here as well as validating in GBSDKBuilder is defence in depth: GBOptions can be
+    // assembled inside the SDK (and in tests) without going through the builder's validation.
+    private val apiHostRequestHeaders: Map<String, String> =
+        GBRequestHeaders.sanitize(gbOptions.apiHostRequestHeaders)
+
+    private val streamingHostRequestHeaders: Map<String, String> =
+        GBRequestHeaders.sanitize(gbOptions.streamingHostRequestHeaders)
 
     /**
      * Supportive method for getting url based on feature refresh strategy
@@ -101,6 +111,7 @@ internal class FeaturesDataSource(
         if (dispatcher is NetworkDispatcherWithNotModified) {
             dispatcher.consumeGETRequestWithNotModified(
                 request = getEndpoint(),
+                headers = apiHostRequestHeaders,
                 onSuccess = onSuccess,
                 onError = onError,
                 onNotModified = {
@@ -111,6 +122,7 @@ internal class FeaturesDataSource(
         } else {
             dispatcher.consumeGETRequest(
                 request = getEndpoint(),
+                headers = apiHostRequestHeaders,
                 onSuccess = onSuccess,
                 onError = onError
             )
@@ -123,6 +135,7 @@ internal class FeaturesDataSource(
     fun autoRefreshRaw(): Flow<Resource<FeaturesDataModel>> =
         dispatcher.consumeSSEConnection(
             url = getEndpoint(FeatureRefreshStrategy.SERVER_SENT_EVENTS),
+            headers = streamingHostRequestHeaders,
             sseController = sseController
         ).transform { resource ->
             when (resource) {
@@ -190,6 +203,7 @@ internal class FeaturesDataSource(
          */
         dispatcher.consumePOSTRequest(
             url = getEndpoint(FeatureRefreshStrategy.SERVER_SENT_REMOTE_FEATURE_EVAL),
+            headers = apiHostRequestHeaders,
             bodyParams = payload,
             onSuccess = onSuccess@{ rawContent ->
                 // Same guarded decode as fetchFeatures: a malformed body must reach `failure`,

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBOptions.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/model/GBOptions.kt
@@ -1,12 +1,45 @@
 package com.sdk.growthbook.model
 
 /**
+ * Host and per-host request-header configuration for the feature/streaming endpoints.
+ *
  * SDK-owned: built by [com.sdk.growthbook.GBSDKBuilder], never by consumers. The constructor is
  * internal (and `copy()` with it) so new options can be added without breaking already-compiled
  * consumers — see the API-stability note in CLAUDE.md.
+ *
+ * @param apiHost domain features are fetched from (and remote evaluation is POSTed to).
+ * @param streamingHost dedicated domain for server-sent events. When null or blank, streaming
+ *   falls back to [apiHost] — matching the TypeScript SDK. Set it to use GrowthBook Cloud's
+ *   dedicated streaming domain, or a separate streaming endpoint in a self-hosted deployment.
+ * @param apiHostRequestHeaders extra headers added to every request against [apiHost] — the
+ *   features `GET` and the remote-evaluation `POST`. Use them to authenticate against a gateway or
+ *   proxy that fronts a self-hosted GrowthBook (`mapOf("Authorization" to "Bearer …")`).
+ *   SDK-managed headers ([com.sdk.growthbook.network.GBRequestHeaders.RESERVED]: `If-None-Match`,
+ *   `Cache-Control`) cannot be overridden — supplying one is rejected by
+ *   [com.sdk.growthbook.GBSDKBuilder.setApiHostRequestHeaders] and dropped again on the request
+ *   path, as are names and values no HTTP client can send.
+ * @param streamingHostRequestHeaders extra headers added to the SSE streaming request (against
+ *   [streamingHost], or [apiHost] when no streaming host is set). Same reserved-name and
+ *   secret-handling rules as [apiHostRequestHeaders]; prefer
+ *   [com.sdk.growthbook.GBSDKBuilder.setStreamingHostRequestHeaders], which validates the map up
+ *   front.
  */
 @ConsistentCopyVisibility
 data class GBOptions internal constructor(
     val apiHost: String,
     val streamingHost: String?,
-)
+    val apiHostRequestHeaders: Map<String, String> = emptyMap(),
+    val streamingHostRequestHeaders: Map<String, String> = emptyMap(),
+) {
+
+    /**
+     * Header *values* may carry credentials (a gateway token, a signed cookie), so the generated
+     * `toString()` is replaced with one that lists only the names — a debug dump of these options
+     * must not leak a secret. Names alone are safe to log; see
+     * [com.sdk.growthbook.network.GBRequestHeaders].
+     */
+    override fun toString(): String =
+        "GBOptions(apiHost=$apiHost, streamingHost=$streamingHost, " +
+            "apiHostRequestHeaders=${apiHostRequestHeaders.keys}, " +
+            "streamingHostRequestHeaders=${streamingHostRequestHeaders.keys})"
+}

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBInvalidOptionsException.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBInvalidOptionsException.kt
@@ -1,0 +1,23 @@
+package com.sdk.growthbook.utils
+
+/**
+ * Thrown when the SDK is configured with invalid or contradictory options, so a misconfiguration
+ * is reported up front at build time instead of surfacing later as an opaque fetch failure.
+ *
+ * Every independent problem is collected and reported together in [violations], so a caller fixing
+ * several misconfigured options sees them all at once rather than one per restart.
+ *
+ * Extends [IllegalArgumentException], the exception the rest of [com.sdk.growthbook.GBSDKBuilder]
+ * already throws for bad arguments, so existing `catch (e: IllegalArgumentException)` around
+ * `initialize()` keeps working.
+ *
+ * Never contains header values — only header names — because values may carry credentials.
+ */
+class GBInvalidOptionsException(
+    message: String,
+
+    /**
+     * Human-readable description of each problem found, in the order they were checked.
+     */
+    val violations: List<String>,
+) : IllegalArgumentException(message)

--- a/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBOptionsValidator.kt
+++ b/GrowthBook/src/commonMain/kotlin/com/sdk/growthbook/utils/GBOptionsValidator.kt
@@ -1,0 +1,127 @@
+package com.sdk.growthbook.utils
+
+import com.sdk.growthbook.network.GBRequestHeaders
+
+/**
+ * Validates host/header options once, when the SDK is built, so misconfigurations fail fast with a
+ * clear message rather than turning into an opaque fetch failure at runtime.
+ *
+ * All independent problems are collected and reported together (see [GBInvalidOptionsException]).
+ * Only header *names* ever appear in a message — values may contain secrets.
+ */
+internal object GBOptionsValidator {
+
+    private const val SCHEME_SEPARATOR = "://"
+
+    /**
+     * @throws GBInvalidOptionsException listing every problem found.
+     */
+    fun validate(
+        streamingHost: String?,
+        apiHostRequestHeaders: Map<String, String>?,
+        streamingHostRequestHeaders: Map<String, String>?,
+        apiHost: String? = null,
+    ) {
+        val violations = findViolations(
+            streamingHost,
+            apiHostRequestHeaders,
+            streamingHostRequestHeaders,
+            apiHost,
+        )
+        if (violations.isNotEmpty()) {
+            throw GBInvalidOptionsException(
+                "Invalid GrowthBook options: ${violations.joinToString("; ")}",
+                violations,
+            )
+        }
+    }
+
+    /**
+     * Collects every validation problem without throwing.
+     */
+    fun findViolations(
+        streamingHost: String?,
+        apiHostRequestHeaders: Map<String, String>?,
+        streamingHostRequestHeaders: Map<String, String>?,
+        apiHost: String? = null,
+    ): List<String> = buildList {
+        checkHost("apiHost", apiHost, this)
+        checkHost("streamingHost", streamingHost, this)
+        checkRequestHeaders("apiHostRequestHeaders", apiHostRequestHeaders, this)
+        checkRequestHeaders("streamingHostRequestHeaders", streamingHostRequestHeaders, this)
+    }
+
+    /**
+     * Accepts a host with or without a scheme (a scheme-less `cdn.example.com` is normalised to
+     * https by [com.sdk.growthbook.features.FeatureURLBuilder]); rejects a scheme other than
+     * http/https and anything without a usable host part.
+     *
+     * A blank host means "not set", not "misconfigured": build configs routinely default such a
+     * value to the empty string, and every consumer of it already falls back. Failing the build
+     * over it would break existing apps on a minor upgrade.
+     */
+    private fun checkHost(optionName: String, host: String?, violations: MutableList<String>) {
+        if (host.isNullOrBlank()) return
+
+        val raw = host.trim()
+        val schemeSeparatorIndex = raw.indexOf(SCHEME_SEPARATOR)
+        if (schemeSeparatorIndex >= 0) {
+            val scheme = raw.substring(0, schemeSeparatorIndex).lowercase()
+            if (scheme != "http" && scheme != "https") {
+                violations.add("$optionName must use the http or https scheme: $host")
+                return
+            }
+        }
+
+        val authority = raw
+            .substring(if (schemeSeparatorIndex >= 0) schemeSeparatorIndex + SCHEME_SEPARATOR.length else 0)
+            .takeWhile { it != '/' && it != '?' && it != '#' }
+        // Drop userinfo and port, leaving the host itself.
+        val hostname = authority.substringAfterLast('@').substringBefore(':')
+        if (hostname.isBlank() || hostname.any { it.isWhitespace() }) {
+            violations.add("$optionName is not a valid URL: $host")
+        }
+    }
+
+    /**
+     * Rejects the SDK-managed names in [GBRequestHeaders.RESERVED] (overriding `If-None-Match` or
+     * `Cache-Control` would break ETag-based revalidation) plus names and values no HTTP client can
+     * send. Both are checked here so the consumer hears about it once, at build time, instead of
+     * every request silently losing the header.
+     *
+     * A header **value** is never quoted in a violation message — only its name. Values carry
+     * credentials, and this message ends up in [GBInvalidOptionsException] and, via the SDK's error
+     * path, in the log.
+     */
+    private fun checkRequestHeaders(
+        optionName: String,
+        headers: Map<String, String>?,
+        violations: MutableList<String>,
+    ) {
+        if (headers.isNullOrEmpty()) return
+
+        for ((name, value) in headers) {
+            when {
+                name.isBlank() ->
+                    violations.add("$optionName must not contain a blank header name")
+
+                GBRequestHeaders.isReserved(name) -> violations.add(
+                    "$optionName must not contain the reserved header '${name.trim()}'; " +
+                        "If-None-Match and Cache-Control are managed by the SDK"
+                )
+
+                !GBRequestHeaders.isValidName(name) -> violations.add(
+                    "$optionName contains an invalid header name '${name.trim()}': " +
+                        "header names must be a valid HTTP token"
+                )
+
+                !GBRequestHeaders.isValidValue(value) -> violations.add(
+                    "$optionName contains an invalid value for header '${name.trim()}': " +
+                        "header values must not contain control characters, line breaks or " +
+                        "non-ASCII characters (the value itself is omitted here — it may be a " +
+                        "credential)"
+                )
+            }
+        }
+    }
+}

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/FeatureURLBuilderTest.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/FeatureURLBuilderTest.kt
@@ -36,6 +36,81 @@ class FeatureURLBuilderTest {
         assertEquals("$TEST_API_HOST/sub/api_key", actual)
     }
 
+    @Test
+    fun verifySseUrlFallsBackToApiHostWhenStreamingHostIsNotSet() {
+        val actual = createTestUrlBuilder(TEST_API_HOST)
+            .buildUrl("api_key", FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+
+        assertEquals("$TEST_API_HOST/sub/api_key", actual)
+    }
+
+    @Test
+    fun verifySseUrlFallsBackToApiHostWhenStreamingHostIsBlank() {
+        val urlBuilder = FeatureURLBuilder(GBOptions(TEST_API_HOST, "   "))
+
+        val actual = urlBuilder.buildUrl("api_key", FeatureRefreshStrategy.SERVER_SENT_EVENTS)
+
+        assertEquals("$TEST_API_HOST/sub/api_key", actual)
+    }
+
+    @Test
+    fun verifyStreamingHostIsUsedForSseOnly() {
+        val urlBuilder = FeatureURLBuilder(
+            GBOptions(TEST_API_HOST, TEST_STREAMING_HOST)
+        )
+
+        assertEquals(
+            "$TEST_STREAMING_HOST/sub/api_key",
+            urlBuilder.buildUrl("api_key", FeatureRefreshStrategy.SERVER_SENT_EVENTS),
+        )
+        assertEquals(
+            "$TEST_API_HOST/api/features/api_key",
+            urlBuilder.buildUrl("api_key"),
+        )
+    }
+
+    @Test
+    fun verifySchemeLessHostIsResolvedAgainstHttps() {
+        assertEquals(
+            "https://some.domain/api/features/api_key",
+            createTestUrlBuilder("some.domain").buildUrl("api_key"),
+        )
+        assertEquals(
+            "https://cdn.example.com/sub/api_key",
+            FeatureURLBuilder(GBOptions(TEST_API_HOST, "cdn.example.com"))
+                .buildUrl("api_key", FeatureRefreshStrategy.SERVER_SENT_EVENTS),
+        )
+    }
+
+    @Test
+    fun verifyExplicitHttpSchemeIsPreserved() {
+        assertEquals(
+            "http://localhost:3100/api/features/api_key",
+            createTestUrlBuilder("http://localhost:3100").buildUrl("api_key"),
+        )
+    }
+
+    /**
+     * A blank apiHost must stay scheme-less. `https:/api/features/<key>` is not rejected by HTTP
+     * clients — OkHttp reads `api` as the host — so an apiHost left empty by a build config would
+     * quietly send the client key somewhere real instead of failing.
+     */
+    @Test
+    fun verifyBlankApiHostDoesNotProduceASchemeOnlyUrl() {
+        val actual = createTestUrlBuilder("")
+            .buildUrl("api_key")
+
+        assertEquals("/api/features/api_key", actual)
+    }
+
+    @Test
+    fun verifyRedundantTrailingSlashesAreCollapsed() {
+        val actual = createTestUrlBuilder("$TEST_API_HOST///")
+            .buildUrl("api_key")
+
+        assertEquals("$TEST_API_HOST/api/features/api_key", actual)
+    }
+
     private fun createTestUrlBuilder(apiHost: String) =
         FeatureURLBuilder(
             GBOptions(apiHost, null)
@@ -43,5 +118,6 @@ class FeatureURLBuilderTest {
 
     companion object {
         private const val TEST_API_HOST = "https://some.domain"
+        private const val TEST_STREAMING_HOST = "https://streaming.some.domain"
     }
 }

--- a/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/RequestHeadersTests.kt
+++ b/GrowthBook/src/jvmTest/kotlin/com/sdk/growthbook/tests/RequestHeadersTests.kt
@@ -1,0 +1,387 @@
+package com.sdk.growthbook.tests
+
+import com.sdk.growthbook.GBSDKBuilder
+import com.sdk.growthbook.features.FeaturesDataSource
+import com.sdk.growthbook.model.GBContext
+import com.sdk.growthbook.model.GBOptions
+import com.sdk.growthbook.model.GBString
+import com.sdk.growthbook.network.GBRequestHeaders
+import com.sdk.growthbook.sandbox.CachingJvm
+import com.sdk.growthbook.utils.GBInvalidOptionsException
+import com.sdk.growthbook.utils.GBOptionsValidator
+import com.sdk.growthbook.utils.GBRemoteEvalParams
+import com.sdk.growthbook.utils.Resource
+import com.sdk.growthbook.utils.SSEConnectionController
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers `apiHostRequestHeaders` / `streamingHostRequestHeaders`: that they reach the dispatcher on
+ * every request path, that reserved (SDK-managed) names are rejected up front, and that header
+ * values never leak into an error message.
+ */
+class RequestHeadersTests {
+
+    // initialize() writes the feature cache to disk; keep it out of the developer's home dir.
+    @Rule
+    @JvmField
+    var tempFolder = TemporaryFolder()
+
+    @BeforeTest
+    fun setUp() {
+        CachingJvm.baseDir = tempFolder.newFolder()
+    }
+
+    private val gbContext = GBContext(
+        apiKey = "test-key",
+        enabled = true,
+        attributes = mapOf("id" to GBString("user-1")),
+        forcedVariations = HashMap(),
+        qaMode = false,
+        trackingCallback = { _, _ -> },
+        encryptionKey = null,
+        remoteEval = false,
+    )
+
+    /** Records the headers handed to each request path instead of performing a request. */
+    private class RecordingHeadersClient : MockNetworkClient(MockResponse.successResponse, null) {
+        var getHeaders: Map<String, String>? = null
+        var postHeaders: Map<String, String>? = null
+        var sseHeaders: Map<String, String>? = null
+
+        override fun consumeGETRequestWithNotModified(
+            request: String,
+            headers: Map<String, String>,
+            onSuccess: (String) -> Unit,
+            onError: (Throwable) -> Unit,
+            onNotModified: () -> Unit
+        ): Job {
+            getHeaders = headers
+            return super.consumeGETRequestWithNotModified(
+                request, onSuccess, onError, onNotModified
+            )
+        }
+
+        override fun consumePOSTRequest(
+            url: String,
+            headers: Map<String, String>,
+            bodyParams: Map<String, Any>,
+            onSuccess: (String) -> Unit,
+            onError: (Throwable) -> Unit
+        ) {
+            postHeaders = headers
+            super.consumePOSTRequest(url, bodyParams, onSuccess, onError)
+        }
+
+        override fun consumeSSEConnection(
+            url: String,
+            headers: Map<String, String>,
+            sseController: SSEConnectionController?
+        ): Flow<Resource<String>> {
+            sseHeaders = headers
+            return emptyFlow()
+        }
+    }
+
+    private fun optionsWith(
+        apiHostHeaders: Map<String, String> = emptyMap(),
+        streamingHostHeaders: Map<String, String> = emptyMap(),
+    ) = GBOptions(
+        apiHost = "https://example.com",
+        streamingHost = null,
+        apiHostRequestHeaders = apiHostHeaders,
+        streamingHostRequestHeaders = streamingHostHeaders,
+    )
+
+    @Test
+    fun `apiHostRequestHeaders are passed to the features GET request`() {
+        val client = RecordingHeadersClient()
+        val dataSource = FeaturesDataSource(
+            client, gbContext, optionsWith(apiHostHeaders = mapOf("Authorization" to "Bearer t"))
+        )
+
+        dataSource.fetchFeatures(success = {}, failure = {}, onNotModified = {})
+
+        assertEquals(mapOf("Authorization" to "Bearer t"), client.getHeaders)
+    }
+
+    @Test
+    fun `apiHostRequestHeaders are passed to the remote eval POST request`() {
+        val client = RecordingHeadersClient()
+        val dataSource = FeaturesDataSource(
+            client, gbContext, optionsWith(apiHostHeaders = mapOf("X-Gateway-Key" to "abc"))
+        )
+
+        dataSource.fetchRemoteEval(
+            params = GBRemoteEvalParams(
+                attributes = emptyMap(),
+                forcedFeatures = emptyMap(),
+                forcedVariations = emptyMap(),
+            ),
+            success = {},
+            failure = {},
+        )
+
+        assertEquals(mapOf("X-Gateway-Key" to "abc"), client.postHeaders)
+    }
+
+    @Test
+    fun `streamingHostRequestHeaders are passed to the SSE connection`() {
+        val client = RecordingHeadersClient()
+        val dataSource = FeaturesDataSource(
+            client, gbContext, optionsWith(streamingHostHeaders = mapOf("X-Stream" to "yes"))
+        )
+
+        dataSource.autoRefreshRaw()
+
+        assertEquals(mapOf("X-Stream" to "yes"), client.sseHeaders)
+        // The streaming headers must not bleed onto the API-host requests.
+        assertEquals(null, client.getHeaders)
+    }
+
+    @Test
+    fun `api and streaming headers stay separate`() {
+        val client = RecordingHeadersClient()
+        val dataSource = FeaturesDataSource(
+            client,
+            gbContext,
+            optionsWith(
+                apiHostHeaders = mapOf("X-Api" to "1"),
+                streamingHostHeaders = mapOf("X-Stream" to "2"),
+            )
+        )
+
+        dataSource.fetchFeatures(success = {}, failure = {}, onNotModified = {})
+        dataSource.autoRefreshRaw()
+
+        assertEquals(mapOf("X-Api" to "1"), client.getHeaders)
+        assertEquals(mapOf("X-Stream" to "2"), client.sseHeaders)
+    }
+
+    @Test
+    fun `unusable headers set directly on GBOptions are dropped before reaching the dispatcher`() {
+        val client = RecordingHeadersClient()
+        // Bypasses GBSDKBuilder validation, as a consumer using the public GrowthBookSDK
+        // constructor with a hand-built GBOptions would.
+        val dataSource = FeaturesDataSource(
+            client,
+            gbContext,
+            optionsWith(
+                apiHostHeaders = mapOf(
+                    "If-None-Match" to "\"forged-etag\"",
+                    "cache-control" to "no-store",
+                    "  " to "blank-name",
+                    "X Bad Name" to "v",
+                    "X-Bad-Value" to "abc\ndef",
+                    // Not reserved: the SDK never sets User-Agent on these requests.
+                    "User-Agent" to "acme-mobile/1.0",
+                    " X-Kept " to " kept ",
+                )
+            )
+        )
+
+        dataSource.fetchFeatures(success = {}, failure = {}, onNotModified = {})
+
+        assertEquals(
+            mapOf("User-Agent" to "acme-mobile/1.0", "X-Kept" to "kept"),
+            client.getHeaders,
+        )
+    }
+
+    @Test
+    fun `builder rejects reserved apiHostRequestHeaders`() {
+        for (reserved in listOf("if-none-match", "Cache-Control", "IF-NONE-MATCH")) {
+            val error = assertFailsWith<GBInvalidOptionsException> {
+                newBuilder().setApiHostRequestHeaders(mapOf(reserved to "value"))
+            }
+            assertTrue(
+                error.message!!.contains("apiHostRequestHeaders"),
+                "message should name the offending option: ${error.message}",
+            )
+            assertTrue(error.message!!.contains(reserved))
+        }
+    }
+
+    @Test
+    fun `builder rejects reserved streamingHostRequestHeaders`() {
+        val error = assertFailsWith<GBInvalidOptionsException> {
+            newBuilder().setStreamingHostRequestHeaders(mapOf("Cache-Control" to "no-store"))
+        }
+
+        assertTrue(error.message!!.contains("streamingHostRequestHeaders"))
+        assertEquals(1, error.violations.size)
+    }
+
+    @Test
+    fun `builder rejects a blank header name`() {
+        assertFailsWith<GBInvalidOptionsException> {
+            newBuilder().setApiHostRequestHeaders(mapOf("   " to "value"))
+        }
+    }
+
+    @Test
+    fun `header values never appear in the validation error`() {
+        val secret = "super-secret-gateway-token"
+        val error = assertFailsWith<GBInvalidOptionsException> {
+            newBuilder().setApiHostRequestHeaders(mapOf("Cache-Control" to secret))
+        }
+
+        assertFalse(
+            error.message!!.contains(secret),
+            "header values may be credentials and must never be reported",
+        )
+        assertFalse(error.violations.any { it.contains(secret) })
+    }
+
+    @Test
+    fun `builder rejects a header value HTTP cannot carry`() {
+        // SP and HTAB *are* legal in a field-value ("Bearer token"), so only control
+        // characters, line breaks and non-ASCII are rejected.
+        for (invalid in listOf("abc\ndef", "abc\rdef", "abc\u0000def", "caf\u00e9")) {
+            val error = assertFailsWith<GBInvalidOptionsException>("should reject '$invalid'") {
+                newBuilder().setApiHostRequestHeaders(mapOf("X-Token" to invalid))
+            }
+            assertTrue(error.message!!.contains("X-Token"))
+            assertFalse(
+                error.message!!.contains(invalid.trim()),
+                "the value must never be quoted back: ${error.message}",
+            )
+        }
+    }
+
+    @Test
+    fun `builder rejects a header name that is not an HTTP token`() {
+        for (invalid in listOf("X Token", "X:Token", "X\nToken")) {
+            assertFailsWith<GBInvalidOptionsException>("should reject '$invalid'") {
+                newBuilder().setApiHostRequestHeaders(mapOf(invalid to "value"))
+            }
+        }
+    }
+
+    @Test
+    fun `builder accepts non reserved headers`() {
+        val sdk = newBuilder()
+            .setApiHostRequestHeaders(mapOf("Authorization" to "Bearer token"))
+            .setStreamingHostRequestHeaders(mapOf("X-Stream-Token" to "stream"))
+            .initialize()
+
+        // Reaching here means validation passed and initialize() built an instance.
+        assertTrue(sdk.getGBContext().enabled)
+    }
+
+    /**
+     * A token read from a file or env var routinely arrives with a trailing newline. That is
+     * surrounding whitespace, not an injection attempt, so it is stripped rather than rejected.
+     */
+    @Test
+    fun `a surrounding-whitespace header value is accepted and trimmed`() {
+        newBuilder().setApiHostRequestHeaders(mapOf("Authorization" to "Bearer token\n"))
+
+        assertEquals(
+            mapOf("Authorization" to "Bearer token"),
+            GBRequestHeaders.sanitize(mapOf("Authorization" to "Bearer token\n")),
+        )
+    }
+
+    @Test
+    fun `builder accepts a User-Agent header`() {
+        newBuilder().setApiHostRequestHeaders(mapOf("User-Agent" to "acme-mobile/1.0"))
+    }
+
+    @Test
+    fun `builder rejects an invalid streamingHost`() {
+        for (invalid in listOf("ftp://cdn.example.com", "https://", "https://bad host")) {
+            val error = assertFailsWith<GBInvalidOptionsException>("should reject '$invalid'") {
+                newBuilder(streamingHost = invalid).initialize()
+            }
+            assertTrue(error.message!!.contains("streamingHost"))
+        }
+    }
+
+    @Test
+    fun `builder rejects an invalid apiHost`() {
+        for (invalid in listOf("ftp://cdn.example.com", "https://", "https://bad host")) {
+            val error = assertFailsWith<GBInvalidOptionsException>("should reject '$invalid'") {
+                newBuilder(apiHost = invalid).initialize()
+            }
+            assertTrue(error.message!!.contains("apiHost"))
+        }
+    }
+
+    /**
+     * Build configs routinely default a host to the empty string. Blank means "not set" — every
+     * consumer of it already falls back — so it must not fail the build.
+     */
+    @Test
+    fun `builder treats a blank streamingHost as unset`() {
+        for (blank in listOf("", "   ")) {
+            newBuilder(streamingHost = blank).initialize()
+        }
+    }
+
+    @Test
+    fun `builder accepts a valid streamingHost with or without a scheme`() {
+        for (valid in listOf("https://cdn.example.com", "http://localhost:3100", "cdn.example.com")) {
+            newBuilder(streamingHost = valid).initialize()
+        }
+    }
+
+    @Test
+    fun `all violations are reported together`() {
+        val violations = GBOptionsValidator.findViolations(
+            streamingHost = "ftp://cdn.example.com",
+            apiHostRequestHeaders = mapOf("If-None-Match" to "x"),
+            streamingHostRequestHeaders = mapOf("Cache-Control" to "y"),
+            apiHost = "ftp://api.example.com",
+        )
+
+        assertEquals(4, violations.size)
+    }
+
+    @Test
+    fun `sanitize keeps insertion order and drops reserved names case insensitively`() {
+        val sanitized = GBRequestHeaders.sanitize(
+            linkedMapOf(
+                "A" to "1",
+                "IF-NONE-MATCH" to "2",
+                "B" to "3",
+            )
+        )
+
+        assertEquals(listOf("A", "B"), sanitized.keys.toList())
+    }
+
+    @Test
+    fun `sanitize drops unusable names and values`() {
+        val sanitized = GBRequestHeaders.sanitize(
+            linkedMapOf(
+                "X Bad Name" to "1",
+                "X-Bad-Value" to "a\nb",
+                "X-Good" to "ok",
+            )
+        )
+
+        assertEquals(mapOf("X-Good" to "ok"), sanitized)
+    }
+
+    private fun newBuilder(
+        streamingHost: String? = null,
+        apiHost: String = "https://example.com",
+    ) = GBSDKBuilder(
+        apiKey = "test-key",
+        apiHost = apiHost,
+        streamingHost = streamingHost,
+        networkDispatcher = MockNetworkClient(MockResponse.successResponse, null),
+        attributes = emptyMap(),
+        trackingCallback = { _, _ -> },
+    )
+}

--- a/NetworkDispatcherKtor/build.gradle.kts
+++ b/NetworkDispatcherKtor/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.3.0"
+version = "1.4.0"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherKtor/src/androidUnitTest/kotlin/com/sdk/growthbook/GBNetworkDispatcherKtorHeadersTest.kt
+++ b/NetworkDispatcherKtor/src/androidUnitTest/kotlin/com/sdk/growthbook/GBNetworkDispatcherKtorHeadersTest.kt
@@ -1,0 +1,212 @@
+package com.sdk.growthbook
+
+import com.sdk.growthbook.network.GBNetworkDispatcherKtor
+import com.sdk.growthbook.utils.SSEConnectionController
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val FEATURES_URL = "http://example.com/api/features/my-key"
+private const val EVAL_URL = "http://example.com/api/eval/my-key"
+private const val SSE_URL = "http://example.com/sub/my-key"
+private const val RESPONSE_BODY = """{"features":{}}"""
+
+/**
+ * Verifies `apiHostRequestHeaders` / `streamingHostRequestHeaders` reach the Ktor request, and that
+ * the SDK-managed headers (`If-None-Match`, `Cache-Control`) are never overridden by them.
+ */
+class GBNetworkDispatcherKtorHeadersTest {
+
+    /** Records every request the engine sees, so headers can be asserted after the fact. */
+    private class RecordingEngine(
+        private val etag: String? = null,
+        private val status: HttpStatusCode = HttpStatusCode.OK,
+    ) {
+        /**
+         * Appended from the engine's coroutine and read from the JUnit thread, hence concurrent.
+         * Awaiting [requestReceived] is what gives the read a happens-before edge on the write.
+         */
+        val requests = CopyOnWriteArrayList<HttpRequestData>()
+
+        /** Signals the first request, so a test never has to busy-poll [requests]. */
+        val requestReceived = CountDownLatch(1)
+
+        val engine = MockEngine { request ->
+            requests.add(request)
+            requestReceived.countDown()
+            respond(
+                content = ByteReadChannel(RESPONSE_BODY),
+                status = status,
+                headers = headersOf(
+                    HttpHeaders.ContentType to listOf("application/json"),
+                    *listOfNotNull(etag?.let { HttpHeaders.ETag to listOf(it) }).toTypedArray(),
+                ),
+            )
+        }
+    }
+
+    private fun dispatcher(engine: MockEngine) = GBNetworkDispatcherKtor(
+        HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { isLenient = true; ignoreUnknownKeys = true })
+            }
+        }
+    )
+
+    private fun awaitLatch(latch: CountDownLatch) =
+        assertTrue("request timed out", latch.await(5, TimeUnit.SECONDS))
+
+    @Test
+    fun `custom headers are sent on the features GET request`() {
+        val recorder = RecordingEngine()
+        val latch = CountDownLatch(1)
+
+        dispatcher(recorder.engine).consumeGETRequest(
+            request = FEATURES_URL,
+            headers = mapOf("Authorization" to "Bearer token", "X-Tenant" to "acme"),
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        awaitLatch(latch)
+
+        val headers = recorder.requests.single().headers
+        assertEquals("Bearer token", headers["Authorization"])
+        assertEquals("acme", headers["X-Tenant"])
+        assertEquals("max-age=3600", headers["Cache-Control"])
+    }
+
+    @Test
+    fun `custom headers are sent on the remote eval POST request`() {
+        val recorder = RecordingEngine()
+        val latch = CountDownLatch(1)
+
+        dispatcher(recorder.engine).consumePOSTRequest(
+            url = EVAL_URL,
+            headers = mapOf("Authorization" to "Bearer t"),
+            bodyParams = mapOf("attributes" to emptyMap<String, Any>()),
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        awaitLatch(latch)
+
+        val request = recorder.requests.single()
+        assertEquals("Bearer t", request.headers["Authorization"])
+        assertEquals("application/json", request.headers["Accept"])
+    }
+
+    @Test
+    fun `custom headers cannot override SDK managed headers`() {
+        val recorder = RecordingEngine()
+        val latch = CountDownLatch(1)
+
+        dispatcher(recorder.engine).consumeGETRequest(
+            request = FEATURES_URL,
+            headers = mapOf(
+                "Cache-Control" to "no-store",
+                "If-None-Match" to "\"forged\"",
+                // Not SDK-managed: the SDK sets no User-Agent on this request.
+                "user-agent" to "acme-mobile/1.0",
+                // Dropped by GBRequestHeaders.sanitize — Ktor would otherwise throw
+                // IllegalHeaderValueException, quoting the value back in the message.
+                "X-Bad" to "abc\ndef",
+                "X-Kept" to "kept",
+            ),
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        awaitLatch(latch)
+
+        val headers = recorder.requests.single().headers
+        // Exactly one Cache-Control value, and it is the SDK's.
+        assertEquals(listOf("max-age=3600"), headers.getAll("Cache-Control"))
+        assertNull(headers["If-None-Match"])
+        assertNull(headers["X-Bad"])
+        assertEquals("acme-mobile/1.0", headers["User-Agent"])
+        assertEquals("kept", headers["X-Kept"])
+    }
+
+    @Test
+    fun `ETag revalidation still works alongside custom headers`() {
+        val recorder = RecordingEngine(etag = "\"v1\"")
+        val dispatcher = dispatcher(recorder.engine)
+        val headers = mapOf("Authorization" to "Bearer token")
+
+        repeat(2) {
+            val latch = CountDownLatch(1)
+            dispatcher.consumeGETRequestWithNotModified(
+                request = FEATURES_URL,
+                headers = headers,
+                onSuccess = { latch.countDown() },
+                onError = { latch.countDown() },
+                onNotModified = { latch.countDown() },
+            )
+            awaitLatch(latch)
+        }
+
+        val second = recorder.requests[1].headers
+        assertEquals(listOf("\"v1\""), second.getAll("If-None-Match"))
+        assertEquals("Bearer token", second["Authorization"])
+    }
+
+    @Test
+    fun `streaming headers are applied to the SSE request`() {
+        val recorder = RecordingEngine()
+        val controller = SSEConnectionController()
+        val flow = dispatcher(recorder.engine).consumeSSEConnection(
+            url = SSE_URL,
+            headers = mapOf("Authorization" to "Bearer stream-token"),
+            sseController = controller,
+        )
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            scope.launch { flow.collect { } }
+            // The flow closes immediately unless the controller is ACTIVE.
+            controller.start()
+
+            assertTrue(
+                "SSE request was never made",
+                recorder.requestReceived.await(5, TimeUnit.SECONDS),
+            )
+            assertEquals("Bearer stream-token", recorder.requests.first().headers["Authorization"])
+        } finally {
+            controller.stop()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `header-less overloads keep working`() {
+        val recorder = RecordingEngine()
+        val latch = CountDownLatch(1)
+
+        dispatcher(recorder.engine).consumeGETRequest(
+            request = FEATURES_URL,
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        awaitLatch(latch)
+
+        assertEquals("max-age=3600", recorder.requests.single().headers["Cache-Control"])
+    }
+}

--- a/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
+++ b/NetworkDispatcherKtor/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherKtor.kt
@@ -117,23 +117,39 @@ class GBNetworkDispatcherKtor(
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit,
         onNotModified: () -> Unit
-    ): Job = handleGetRequest(request, onSuccess, onError, onNotModified)
+    ): Job = handleGetRequest(request, emptyMap(), onSuccess, onError, onNotModified)
+
+    override fun consumeGETRequestWithNotModified(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onNotModified: () -> Unit
+    ): Job = handleGetRequest(request, headers, onSuccess, onError, onNotModified)
 
     override fun consumeGETRequest(
         request: String,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit
-    ): Job = handleGetRequest(request, onSuccess, onError)
+    ): Job = handleGetRequest(request, emptyMap(), onSuccess, onError)
+
+    override fun consumeGETRequest(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ): Job = handleGetRequest(request, headers, onSuccess, onError)
 
     private fun handleGetRequest(
         request: String,
+        headers: Map<String, String>,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit,
         onNotModified: (() -> Unit)? = null
     ): Job {
         return CoroutineScope(PlatformDependentIODispatcher).launch {
             try {
-                val result = prepareGetRequest(request).execute()
+                val result = prepareGetRequest(request, headers).execute()
                 try {
                     when (result.status) {
                         HttpStatusCode.OK -> {
@@ -186,6 +202,11 @@ class GBNetworkDispatcherKtor(
      * Supportive method for preparing a GET request, shared by the feature fetch and the SSE
      * connection. [bounded] applies [fetchTimeoutMillis] and must be false for SSE, whose
      * connection is long-lived by design.
+     *
+     * Consumer-supplied [headers] are applied first and stripped of SDK-managed names
+     * ([GBRequestHeaders.RESERVED]), so `If-None-Match` / `Cache-Control` below always win —
+     * `append` adds a second value rather than replacing, which would send two conflicting
+     * cache directives and break ETag revalidation.
      */
     private suspend fun prepareGetRequest(
         url: String,
@@ -196,15 +217,17 @@ class GBNetworkDispatcherKtor(
         client.prepareGet(url) {
             if (bounded) applyFetchTimeout()
             headers {
-                headers.forEach { (key, value) -> append(key, value) }
+                GBRequestHeaders.sanitize(headers)
+                    .forEach { (key, value) -> append(key, value) }
 
                 // Only add cache headers if URL matches featuresPathPattern
                 if (featuresPathPattern.matches(url)) {
-                    // Add If-None-Match header if ETag is present
+                    // set(), not append(): the SDK-managed value must replace any consumer-supplied
+                    // one rather than adding a second, conflicting header value.
                     eTagCache.get(url)?.let {
-                        append("If-None-Match", it)
+                        set("If-None-Match", it)
                     }
-                    append("Cache-Control", "max-age=3600")
+                    set("Cache-Control", "max-age=3600")
                 }
             }
             queryParams.forEach { (key, value) -> addOrReplaceParameter(key, value) }
@@ -219,6 +242,17 @@ class GBNetworkDispatcherKtor(
      */
     override fun consumeSSEConnection(
         url: String,
+        sseController: SSEConnectionController?
+    ) = consumeSSEConnection(url, emptyMap(), sseController)
+
+    /**
+     * Same as [consumeSSEConnection], with consumer-supplied [headers] (typically
+     * `streamingHostRequestHeaders`) applied to the streaming request — and re-applied to every
+     * reconnection attempt.
+     */
+    override fun consumeSSEConnection(
+        url: String,
+        headers: Map<String, String>,
         sseController: SSEConnectionController?
     ) = callbackFlow {
         val scope = this
@@ -277,7 +311,7 @@ class GBNetworkDispatcherKtor(
             connectionJob?.cancel()
             connectionJob = scope.launch(PlatformDependentIODispatcher) {
                 try {
-                    prepareGetRequest(url, bounded = false).execute { response ->
+                    prepareGetRequest(url, bounded = false, headers = headers).execute { response ->
                         val channel: ByteReadChannel = response.body()
                         channel.readSse(
                             onSseEvent = { sseEvent ->
@@ -336,6 +370,18 @@ class GBNetworkDispatcherKtor(
         bodyParams: Map<String, Any>,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit
+    ) = consumePOSTRequest(url, emptyMap(), bodyParams, onSuccess, onError)
+
+    /**
+     * Same as [consumePOSTRequest], with consumer-supplied [headers] (typically
+     * `apiHostRequestHeaders`) applied to the remote-evaluation request.
+     */
+    override fun consumePOSTRequest(
+        url: String,
+        headers: Map<String, String>,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
     ) {
         CoroutineScope(PlatformDependentIODispatcher).launch {
             // Do NOT wrap in `client.use { }`: `client` is the shared, long-lived instance reused
@@ -351,9 +397,15 @@ class GBNetworkDispatcherKtor(
                 }
                 val response = client.post(url) {
                     applyFetchTimeout()
-                    headers {
-                        append("Content-Type", "application/json")
-                        append("Accept", "application/json")
+                    // `this.headers` — the bare name resolves to this function's `headers`
+                    // parameter, which shadows Ktor's HttpMessageBuilder.headers { } builder.
+                    this.headers {
+                        GBRequestHeaders.sanitize(headers)
+                            .forEach { (key, value) -> append(key, value) }
+                        // set(), not append(): the SDK-managed values replace any consumer-supplied
+                        // ones instead of adding a second, conflicting header value.
+                        set("Content-Type", "application/json")
+                        set("Accept", "application/json")
                     }
                     contentType(ContentType.Application.Json)
                     setBody(payload)

--- a/NetworkDispatcherOkHttp/build.gradle.kts
+++ b/NetworkDispatcherOkHttp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.growthbook.sdk"
-version = "1.2.0"
+version = "1.3.0"
 
 kotlin {
     androidTarget {

--- a/NetworkDispatcherOkHttp/src/androidUnitTest/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttpHeadersTest.kt
+++ b/NetworkDispatcherOkHttp/src/androidUnitTest/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttpHeadersTest.kt
@@ -1,0 +1,297 @@
+package com.sdk.growthbook.network
+
+import com.sdk.growthbook.utils.Resource
+import com.sdk.growthbook.utils.SSEConnectionController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+private const val RESPONSE_BODY = """{"features":{}}"""
+
+/**
+ * Verifies `apiHostRequestHeaders` / `streamingHostRequestHeaders` on the wire against an embedded
+ * HTTP server: they are present on the features GET, the remote-eval POST and the SSE request, that
+ * SDK-managed headers (`If-None-Match`, `Cache-Control`) still win, that unusable names and values
+ * are dropped rather than thrown, and that ETag revalidation is unaffected.
+ */
+class GBNetworkDispatcherOkHttpHeadersTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var dispatcher: GBNetworkDispatcherOkHttp
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        dispatcher = GBNetworkDispatcherOkHttp(OkHttpClient())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun featuresUrl() = server.url("/api/features/my-key").toString()
+
+    private fun getSync(url: String, headers: Map<String, String>) {
+        val latch = CountDownLatch(1)
+        dispatcher.consumeGETRequest(
+            request = url,
+            headers = headers,
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        assertTrue("GET timed out", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    private fun getWithNotModifiedSync(url: String, headers: Map<String, String>) {
+        val latch = CountDownLatch(1)
+        dispatcher.consumeGETRequestWithNotModified(
+            request = url,
+            headers = headers,
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+            onNotModified = { latch.countDown() },
+        )
+        assertTrue("GET timed out", latch.await(5, TimeUnit.SECONDS))
+    }
+
+    private fun enqueueOk() {
+        server.enqueue(MockResponse().setBody(RESPONSE_BODY).setResponseCode(200))
+    }
+
+    @Test
+    fun `custom headers are sent on the features GET request`() {
+        enqueueOk()
+
+        getSync(featuresUrl(), mapOf("Authorization" to "Bearer token", "X-Tenant" to "acme"))
+
+        val request: RecordedRequest = server.takeRequest()
+        assertEquals("Bearer token", request.getHeader("Authorization"))
+        assertEquals("acme", request.getHeader("X-Tenant"))
+    }
+
+    @Test
+    fun `custom headers are sent on the remote eval POST request`() {
+        enqueueOk()
+
+        val latch = CountDownLatch(1)
+        dispatcher.consumePOSTRequest(
+            url = server.url("/api/eval/my-key").toString(),
+            headers = mapOf("Authorization" to "Bearer t"),
+            bodyParams = mapOf("attributes" to emptyMap<String, Any>()),
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        assertTrue("POST timed out", latch.await(5, TimeUnit.SECONDS))
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("Bearer t", request.getHeader("Authorization"))
+        assertEquals("application/json", request.getHeader("Accept"))
+    }
+
+    @Test
+    fun `custom headers cannot override SDK managed headers`() {
+        enqueueOk()
+
+        getSync(
+            featuresUrl(),
+            mapOf(
+                "Cache-Control" to "no-store",
+                "If-None-Match" to "\"forged\"",
+                // Not SDK-managed: the SDK sets no User-Agent on this request, so a consumer
+                // behind a gateway that requires one can supply it.
+                "User-Agent" to "acme-mobile/1.0",
+            ),
+        )
+
+        val request = server.takeRequest()
+        assertEquals("max-age=3600", request.getHeader("Cache-Control"))
+        // No ETag has been observed yet, so the SDK sends no If-None-Match — and the forged one was
+        // dropped rather than passed through.
+        assertNull(request.getHeader("If-None-Match"))
+        assertEquals("acme-mobile/1.0", request.getHeader("User-Agent"))
+    }
+
+    @Test
+    fun `ETag revalidation still works alongside custom headers`() {
+        server.enqueue(
+            MockResponse().setBody(RESPONSE_BODY).setResponseCode(200).setHeader("ETag", "\"v1\"")
+        )
+        server.enqueue(MockResponse().setResponseCode(304))
+
+        val headers = mapOf("Authorization" to "Bearer token")
+        getWithNotModifiedSync(featuresUrl(), headers)
+        getWithNotModifiedSync(featuresUrl(), headers)
+
+        server.takeRequest()
+        val second = server.takeRequest()
+        assertEquals("\"v1\"", second.getHeader("If-None-Match"))
+        assertEquals("Bearer token", second.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `header-less overload still sends the SDK cache directive`() {
+        enqueueOk()
+
+        val latch = CountDownLatch(1)
+        dispatcher.consumeGETRequest(
+            request = featuresUrl(),
+            onSuccess = { latch.countDown() },
+            onError = { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS))
+
+        assertEquals("max-age=3600", server.takeRequest().getHeader("Cache-Control"))
+    }
+
+    @Test
+    fun `streaming headers are applied to the SSE request`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody("event: features\ndata: $RESPONSE_BODY\n\n")
+        )
+
+        val controller = SSEConnectionController()
+        val flow = dispatcher.consumeSSEConnection(
+            url = server.url("/sub/my-key").toString(),
+            headers = mapOf("Authorization" to "Bearer stream-token"),
+            sseController = controller,
+        )
+
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            scope.launch { flow.collect { } }
+            // The flow closes immediately unless the controller is ACTIVE.
+            controller.start()
+
+            val request = requireNotNull(server.takeRequest(5, TimeUnit.SECONDS)) {
+                "SSE request was never made"
+            }
+            assertEquals("Bearer stream-token", request.getHeader("Authorization"))
+            assertEquals("text/event-stream", request.getHeader("Accept"))
+            assertEquals("no-cache", request.getHeader("Cache-Control"))
+        } finally {
+            controller.stop()
+            scope.cancel()
+        }
+    }
+
+    /**
+     * A value OkHttp would reject is dropped by `GBRequestHeaders.sanitize` before it reaches the
+     * builder, so the request still goes out — just without that header. Dropping rather than
+     * throwing also keeps the value out of OkHttp's exception message, which the SDK logs.
+     */
+    @Test
+    fun `an illegal custom header value is dropped instead of failing the request`() {
+        enqueueOk()
+
+        getSync(
+            featuresUrl(),
+            mapOf("X-Token" to "abc\ndef", "X-Kept" to "kept"),
+        )
+
+        val request = server.takeRequest()
+        assertNull(request.getHeader("X-Token"))
+        assertEquals("kept", request.getHeader("X-Kept"))
+    }
+
+    @Test
+    fun `a header value with a trailing newline is trimmed rather than dropped`() {
+        enqueueOk()
+
+        getSync(featuresUrl(), mapOf("Authorization" to "Bearer token\n"))
+
+        assertEquals("Bearer token", server.takeRequest().getHeader("Authorization"))
+    }
+
+    /**
+     * `Request.Builder` still throws on a URL it cannot parse, and that happens while the request
+     * is being assembled — before the call is enqueued. It must surface through `onError` rather
+     * than escaping the dispatcher's CoroutineScope, where nothing would ever complete the caller
+     * and the default uncaught handler would take down the app.
+     */
+    @Test
+    fun `a scheme-less url is reported through onError`() {
+        val error = AtomicReference<Throwable?>(null)
+        val latch = CountDownLatch(1)
+
+        dispatcher.consumeGETRequest(
+            request = "cdn.example.com/api/features/my-key",
+            headers = emptyMap(),
+            onSuccess = { latch.countDown() },
+            onError = {
+                error.set(it)
+                latch.countDown()
+            },
+        )
+
+        assertTrue("onError was never invoked", latch.await(5, TimeUnit.SECONDS))
+        assertTrue(
+            "expected IllegalArgumentException, got ${error.get()}",
+            error.get() is IllegalArgumentException
+        )
+        assertEquals("no request should have been made", 0, server.requestCount)
+    }
+
+    @Test
+    fun `a scheme-less url on the not-modified overload is reported through onError`() {
+        val error = AtomicReference<Throwable?>(null)
+        val latch = CountDownLatch(1)
+
+        dispatcher.consumeGETRequestWithNotModified(
+            request = "cdn.example.com/api/features/my-key",
+            headers = emptyMap(),
+            onSuccess = { latch.countDown() },
+            onError = {
+                error.set(it)
+                latch.countDown()
+            },
+            onNotModified = { latch.countDown() },
+        )
+
+        assertTrue("onError was never invoked", latch.await(5, TimeUnit.SECONDS))
+        assertTrue(error.get() is IllegalArgumentException)
+    }
+
+    /**
+     * The SSE request is built inside the flow, so the same failure arrives as [Resource.Error]
+     * instead of propagating synchronously out of `consumeSSEConnection` — which would escape
+     * `FeaturesViewModel.autoRefreshFeatures()` and the public `autoRefreshFeatures()` API.
+     */
+    @Test
+    fun `an unbuildable SSE request surfaces as Resource Error`() {
+        val controller = SSEConnectionController()
+        val flow = dispatcher.consumeSSEConnection(
+            url = "cdn.example.com/sub/my-key",
+            headers = emptyMap(),
+            sseController = controller,
+        )
+
+        val result = runBlocking { withTimeout(5_000) { flow.first() } }
+
+        assertTrue("expected Resource.Error, got $result", result is Resource.Error)
+        assertEquals(0, server.requestCount)
+    }
+}

--- a/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
+++ b/NetworkDispatcherOkHttp/src/commonMain/kotlin/com/sdk/growthbook/network/GBNetworkDispatcherOkHttp.kt
@@ -95,19 +95,46 @@ class GBNetworkDispatcherOkHttp(
         onError: (Throwable) -> Unit,
         onNotModified: (() -> Unit)
     ): Job =
-        handleGetRequest(request, onSuccess, onError, onNotModified)
+        handleGetRequest(request, emptyMap(), onSuccess, onError, onNotModified)
+
+    override fun consumeGETRequestWithNotModified(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+        onNotModified: () -> Unit
+    ): Job = handleGetRequest(request, headers, onSuccess, onError, onNotModified)
 
     override fun consumeGETRequest(
         request: String,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit
-    ): Job = handleGetRequest(request, onSuccess, onError)
+    ): Job = handleGetRequest(request, emptyMap(), onSuccess, onError)
+
+    override fun consumeGETRequest(
+        request: String,
+        headers: Map<String, String>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ): Job = handleGetRequest(request, headers, onSuccess, onError)
 
     /**
      * Method that make POST request to server for remote feature evaluation
      */
     override fun consumePOSTRequest(
         url: String,
+        bodyParams: Map<String, Any>,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit
+    ) = consumePOSTRequest(url, emptyMap(), bodyParams, onSuccess, onError)
+
+    /**
+     * Same as [consumePOSTRequest], with consumer-supplied [headers] (typically
+     * `apiHostRequestHeaders`) applied to the remote-evaluation request.
+     */
+    override fun consumePOSTRequest(
+        url: String,
+        headers: Map<String, String>,
         bodyParams: Map<String, Any>,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit
@@ -120,8 +147,11 @@ class GBNetworkDispatcherOkHttp(
 
                 val postRequest = Request.Builder()
                     .url(url)
-                    .addHeader("Content-Type", "application/json")
-                    .addHeader("Accept", "application/json")
+                    .applyCustomHeaders(headers)
+                    // header(), not addHeader(): the SDK-managed values replace any
+                    // consumer-supplied ones instead of adding a second header value.
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
                     .post(requestBody)
                     .build()
 
@@ -157,24 +187,39 @@ class GBNetworkDispatcherOkHttp(
 
     private fun handleGetRequest(
         request: String,
+        headers: Map<String, String>,
         onSuccess: (String) -> Unit,
         onError: (Throwable) -> Unit,
         onNotModified: (() -> Unit)? = null
     ): Job {
         return CoroutineScope(PlatformDependentIODispatcher).launch {
-            val getRequest = Request.Builder()
-                .url(request)
-                .addHeader("Cache-Control", "max-age=3600")
-                .apply {
-                    // Only add If-None-Match header if URL matches featuresPathPattern
-                    if (featuresPathPattern.matches(request)) {
-                        // Add If-None-Match header if ETag is present
-                        eTagCache.get(request)?.let {
-                            header("If-None-Match", it)
+            val getRequest = try {
+                Request.Builder()
+                    .url(request)
+                    .applyCustomHeaders(headers)
+                    // header(), not addHeader(): the SDK-managed cache directive replaces any
+                    // consumer-supplied one instead of adding a second, conflicting value.
+                    .header("Cache-Control", "max-age=3600")
+                    .apply {
+                        // Only add If-None-Match header if URL matches featuresPathPattern
+                        if (featuresPathPattern.matches(request)) {
+                            // Add If-None-Match header if ETag is present
+                            eTagCache.get(request)?.let {
+                                header("If-None-Match", it)
+                            }
                         }
                     }
-                }
-                .build()
+                    .build()
+            } catch (t: Throwable) {
+                // Building the request can throw before the call is ever enqueued — a malformed
+                // header value, or a `request` without a scheme, makes Request.Builder raise
+                // IllegalArgumentException. Inside launch, not around it: `launch` returns before
+                // the body runs, so a `try` around the call would never see this. Deliberately not
+                // logged — the message embeds the offending header value, which may be a credential.
+                onError(t)
+                return@launch
+            }
+
             fetchClient.newCall(getRequest).enqueue(object : Callback {
                 override fun onFailure(call: Call, e: IOException) {
                     onError(e)
@@ -232,6 +277,17 @@ class GBNetworkDispatcherOkHttp(
     override fun consumeSSEConnection(
         url: String,
         sseController: SSEConnectionController?
+    ): Flow<Resource<String>> = consumeSSEConnection(url, emptyMap(), sseController)
+
+    /**
+     * Same as [consumeSSEConnection], with consumer-supplied [headers] (typically
+     * `streamingHostRequestHeaders`) applied to the streaming request. The request is built once
+     * and reused, so the headers are re-sent on every reconnection attempt.
+     */
+    override fun consumeSSEConnection(
+        url: String,
+        headers: Map<String, String>,
+        sseController: SSEConnectionController?
     ): Flow<Resource<String>> {
         val sseHttpClient = OkHttpClient.Builder()
             .retryOnConnectionFailure(true)
@@ -241,15 +297,30 @@ class GBNetworkDispatcherOkHttp(
             .pingInterval(30, TimeUnit.SECONDS)
             .build()
 
-        val request = Request.Builder()
-            .url(url)
-            .header("Accept", "text/event-stream")
-            .header("Cache-Control", "no-cache")
-            .header("Connection", "keep-alive")
-            .build()
-
         return callbackFlow {
             var eventSource: EventSource? = null
+
+            // Built inside the flow, not around it: a malformed header value or a scheme-less
+            // `url` makes Request.Builder raise IllegalArgumentException, and outside the flow
+            // that throw would propagate synchronously out of the public
+            // GrowthBookSDK.autoRefreshFeatures() instead of being reported as Resource.Error
+            // like every other SSE failure.
+            val request = try {
+                Request.Builder()
+                    .url(url)
+                    .applyCustomHeaders(headers)
+                    .header("Accept", "text/event-stream")
+                    .header("Cache-Control", "no-cache")
+                    .header("Connection", "keep-alive")
+                    .build()
+            } catch (t: Throwable) {
+                // Not logged — the message embeds the offending header value.
+                trySend(Resource.Error(t as? Exception ?: Exception(t)))
+                close()
+                awaitClose { }
+                return@callbackFlow
+            }
+
             val retryManager = SSERetryManager(maxRetries, initialRetryDelayMs, maxRetryDelayMs)
             val controller = sseController ?: SSEConnectionController()
 
@@ -413,5 +484,16 @@ class GBNetworkDispatcherOkHttp(
 
     fun setLoggingEnabled(enabled: Boolean) {
         enableLogging = enabled
+    }
+
+    /**
+     * Applies consumer-supplied headers to a request, dropping the SDK-managed names
+     * ([GBRequestHeaders.RESERVED]). Called before the SDK sets its own headers, so those always
+     * take priority. Header values may contain credentials and are never logged.
+     */
+    private fun Request.Builder.applyCustomHeaders(
+        headers: Map<String, String>
+    ): Request.Builder = apply {
+        GBRequestHeaders.sanitize(headers).forEach { (name, value) -> header(name, value) }
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ repositories {
 
 dependencies {
     // Add GrowthBook module:
-    implementation 'io.growthbook.sdk:GrowthBook:7.9.0'
+    implementation 'io.growthbook.sdk:GrowthBook:8.1.0'
 
     // Add Network Dispatcher you prefer:
     // 1) NetworkDispatcherKtor — supports Android, iOS, JVM, JS, Wasm
-    implementation 'io.growthbook.sdk:NetworkDispatcherKtor:1.2.0'
+    implementation 'io.growthbook.sdk:NetworkDispatcherKtor:1.4.0'
     // 2) NetworkDispatcherOkHttp — supports Android and JVM only
-    implementation 'io.growthbook.sdk:NetworkDispatcherOkHttp:1.1.1'
+    implementation 'io.growthbook.sdk:NetworkDispatcherOkHttp:1.3.0'
 }
 ```
 
@@ -85,6 +85,8 @@ If you are accessing features the first time there will be no features right aft
     .setInitialFeatures(<GBFeatures>) // Seed bundled fallback features (see below)
     .setInitialPayload(<String>) // Seed a bundled raw API payload (see below)
     .setCacheMaxAge(<Long>) // Cache freshness window in ms (see below)
+    .setApiHostRequestHeaders(<Map<String, String>>) // Custom headers for API requests (see below)
+    .setStreamingHostRequestHeaders(<Map<String, String>>) // Custom headers for SSE (see below)
 .initialize()
 ```
 
@@ -238,6 +240,87 @@ The poller is a coroutine (not a dedicated thread) on the SDK's background scope
 `close()` stops the poller too (along with SSE and the background scope), so disposing the SDK instance is enough — you do not need to call `stopPolling()` first.
 
 > **Mobile note:** the SDK cannot observe app lifecycle, so tie `startPolling()` / `stopPolling()` to your foreground/background transitions to avoid keeping the radio awake in the background. On mobile prefer SSE or the pull-on-access cache window (`setCacheMaxAge` / `setStaleTtl`); background polling is intended mainly for JVM/backend usage.
+
+#### Custom request headers & a dedicated streaming host
+
+For a self-hosted GrowthBook behind an authenticated gateway/proxy — or GrowthBook Cloud's
+dedicated streaming domain — you can attach custom headers to the SDK's HTTP requests and point
+streaming at a different host than the API.
+
+```kotlin
+var sdkInstance: GrowthBookSDK = GBSDKBuilder(
+    apiKey = <API_KEY>,
+    apiHost = "https://gb-gateway.internal.example.com",
+    // Optional. When omitted, streaming uses apiHost.
+    streamingHost = "https://gb-stream.internal.example.com",
+    attributes = hashMapOf(),
+    trackingCallback = { _, _ -> },
+    networkDispatcher = GBNetworkDispatcherKtor(),
+)
+    // Sent on every API-host request: the features GET and the remote-evaluation POST.
+    .setApiHostRequestHeaders(
+        mapOf(
+            "Authorization" to "Bearer $gatewayToken",
+            "X-Tenant-Id" to tenantId,
+        )
+    )
+    // Sent on the SSE streaming request (re-sent on every reconnection attempt).
+    .setStreamingHostRequestHeaders(mapOf("Authorization" to "Bearer $streamToken"))
+    .initialize()
+```
+
+| Option | Applies to |
+| --- | --- |
+| `apiHostRequestHeaders` | features `GET` (`/api/features/<key>`), remote-eval `POST` (`/api/eval/<key>`) |
+| `streamingHost` | SSE endpoint (`/sub/<key>`); falls back to `apiHost` when unset |
+| `streamingHostRequestHeaders` | SSE request |
+
+The two header sets are independent and never merged, matching the TypeScript SDK. Note the
+consequence when `streamingHost` is unset: the SSE request goes to `apiHost` but still carries only
+`streamingHostRequestHeaders`. Behind a gateway that authenticates both endpoints, set both — a
+config with only `setApiHostRequestHeaders` yields a working features fetch and an SSE stream that
+is rejected on every reconnection attempt.
+
+**Reserved headers.** `If-None-Match` and `Cache-Control` are managed by the SDK — they drive
+ETag-based cache revalidation. Supplying one is rejected at startup with
+`GBInvalidOptionsException`, which lists every problem it found in `violations`:
+
+```kotlin
+try {
+    builder.setApiHostRequestHeaders(mapOf("Cache-Control" to "no-store"))
+} catch (e: GBInvalidOptionsException) {
+    // "Invalid GrowthBook options: apiHostRequestHeaders must not contain the reserved header
+    //  'Cache-Control'; If-None-Match and Cache-Control are managed by the SDK"
+    e.violations.forEach(::println)
+}
+```
+
+`User-Agent` is *not* reserved — the SDK does not set it on these requests, so you can supply one
+required by your gateway.
+
+Header names must be valid HTTP tokens and values must not contain control characters, line breaks
+or non-ASCII characters; both are rejected the same way. Surrounding whitespace is stripped, so a
+token read from a file or environment variable with a trailing newline still works. An invalid
+`apiHost` or `streamingHost` (a non-`http(s)` scheme, or no usable host) fails the same way at
+`initialize()`; a host without a scheme is resolved against `https`.
+
+> **Security:** header values may be credentials. The SDK never logs them, never puts them in an
+> error message (only header *names* appear) and never exposes them through diagnostics. Read them
+> from your secrets manager / environment rather than hardcoding them.
+
+> **Custom dispatchers:** both built-in dispatchers (Ktor ≥ 1.4.0 and OkHttp ≥ 1.3.0) apply these
+> headers — on an earlier dispatcher the SDK falls through to the header-less code path and your
+> headers are silently dropped, so bump both together. A custom `NetworkDispatcher` ignores them
+> until it overrides the `headers`-carrying overloads of `consumeGETRequest`,
+> `consumeGETRequestWithNotModified`, `consumeSSEConnection` and `consumePOSTRequest` — they have
+> default bodies that delegate to the header-less variants, so existing implementations keep
+> compiling. Use `GBRequestHeaders.sanitize()` from `:Core` to strip reserved names, and apply the
+> SDK's own headers *after* the custom ones so they win.
+>
+> **Implementing `NetworkDispatcher` in Swift:** Kotlin interfaces are exported to Objective-C with
+> every member `@required`, so a Swift conformance does *not* inherit these default bodies and will
+> not compile against `:Core` 1.7.0 until it implements the four new overloads. Kotlin and Java
+> implementations are unaffected.
 
 ## Usage
 


### PR DESCRIPTION
Ports the TypeScript SDK's `apiHostRequestHeaders` / `streamingHostRequestHeaders`, so the SDK works behind an authenticated gateway or proxy fronting a self-hosted GrowthBook.

```kotlin
builder
    .setApiHostRequestHeaders(mapOf("Authorization" to "Bearer $gatewayToken"))
    .setStreamingHostRequestHeaders(mapOf("Authorization" to "Bearer $gatewayToken"))
```

`:Core` gains `GBRequestHeaders` and `headers`-carrying `NetworkDispatcher` overloads (default bodies, so existing dispatchers keep compiling); `:GrowthBook` gains the two builder setters and `GBOptionsValidator`, which fails fast at `initialize()` with every problem collected in `GBInvalidOptionsException.violations`; both built-in dispatchers apply the headers.

Release the dispatchers together with `:Core` 1.7.0 — an older dispatcher silently drops the headers, which surfaces only as an unexplained 401.

## Breaking

1. **`initialize()` throws on a malformed `apiHost` / `streamingHost`** instead of degrading into an opaque fetch failure. A *blank* host still means "not set" and is not a violation.
2. **SSE falls back to `apiHost` when no `streamingHost` is set**, matching the TS SDK's `getApiHosts()`; it previously went to `cdn.growthbook.io` even for self-hosted deployments. Set `streamingHost = "https://cdn.growthbook.io"` to keep the old behaviour.
3. **Swift implementors of `NetworkDispatcher`** must add the four new overloads — Kotlin exports interface members to Objective-C as `@required`, so Swift does not inherit the default bodies. Kotlin/Java implementations, including already-compiled ones, are unaffected.

## Security

Header values may be credentials: they are never logged, never quoted in an error message (only names), and excluded from `GBOptions.toString()`. Values HTTP cannot carry — including CR/LF, the header-injection vector — are rejected up front and dropped again on the request path, rather than handed to the HTTP client whose exception would quote them back into the log. `If-None-Match` and `Cache-Control` are reserved; `User-Agent` deliberately is not.

Also fixed: a request-assembly failure in `GBNetworkDispatcherOkHttp` escaped its `CoroutineScope`, so a malformed URL never fired `onError` and crashed the app on Android.